### PR TITLE
Implemented positional choice conflict checking

### DIFF
--- a/docs/_src/conf.py
+++ b/docs/_src/conf.py
@@ -13,9 +13,9 @@ sys.path.append(docs_dir.joinpath('_ext').as_posix())
 from cli_command_parser.__version__ import __author__, __version__, __description__, __title__
 
 project = __description__
-release = __version__
+version = release = __version__
 author = __author__
-copyright = '{}, {}'.format(datetime.now().strftime('%Y'), author)
+copyright = '{}, {}'.format(datetime.now().strftime('%Y'), author)  # noqa
 
 extensions = [
     'field_list_refs',

--- a/docs/_src/configuration.rst
+++ b/docs/_src/configuration.rst
@@ -65,6 +65,11 @@ Parsing Options
 :option_name_mode: How the default long form that is added for Option/Flag/Counter/etc. Parameters should handle
   underscores/dashes.  See :class:`.OptionNameMode` for more details.  Defaults to using underscores to match the
   attribute name.  May be overridden on a per-Parameter basis with :ref:`parameters:Options:name_mode`.
+:reject_ambiguous_pos_combos: Whether ambiguous combinations of positional choices should result in an
+  :class:`.AmbiguousParseTree` error.  Defaults to True.  Some combinations of positional parameter choices may pass
+  this check, but still be problematic during parsing.  If a false positive is detected, this can be set to ``False``
+  to disable the check (please report it in the `issue tracker <https://github.com/dskrypa/cli_command_parser/issues>`__
+  so it can be fixed!).
 
 
 Usage & Help Text Options

--- a/lib/cli_command_parser/__init__.py
+++ b/lib/cli_command_parser/__init__.py
@@ -4,7 +4,7 @@ Command Parser
 :author: Doug Skrypa
 """
 
-from .config import CommandConfig, ShowDefaults, OptionNameMode
+from .config import CommandConfig, ShowDefaults, OptionNameMode, SubcommandAliasHelpMode
 from .commands import Command, main
 from .context import Context, get_current_context, ctx, get_parsed, get_context, get_raw_arg
 from .exceptions import (

--- a/lib/cli_command_parser/__init__.py
+++ b/lib/cli_command_parser/__init__.py
@@ -21,6 +21,7 @@ from .exceptions import (
     ParamConflict,
     ParamsMissing,
     NoActiveContext,
+    AmbiguousParseTree,
 )
 from .error_handling import ErrorHandler, error_handler, no_exit_handler
 from .formatting.commands import get_formatter

--- a/lib/cli_command_parser/__main__.py
+++ b/lib/cli_command_parser/__main__.py
@@ -1,4 +1,4 @@
 # pylint: disable=W0401,W0611
 from . import *  # noqa
 from .core import *  # noqa
-from .parse_tree import ParseTree
+from .parse_tree import PosNode

--- a/lib/cli_command_parser/__main__.py
+++ b/lib/cli_command_parser/__main__.py
@@ -1,2 +1,4 @@
 # pylint: disable=W0401,W0611
 from . import *  # noqa
+from .core import *  # noqa
+from .parse_tree import ParseTree

--- a/lib/cli_command_parser/command_parameters.py
+++ b/lib/cli_command_parser/command_parameters.py
@@ -27,7 +27,7 @@ if TYPE_CHECKING:
     from .config import CommandConfig
     from .context import Context
     from .formatting.commands import CommandHelpFormatter
-    from .typing import CommandType
+    from .typing import CommandCls
 
 __all__ = ['CommandParameters']
 
@@ -36,9 +36,9 @@ ActionFlags = List[ActionFlag]
 
 
 class CommandParameters:
-    command: CommandType                                 #: The Command associated with this CommandParameters object
+    command: CommandCls                                  #: The Command associated with this CommandParameters object
     formatter: CommandHelpFormatter                      #: The formatter used for this Command's help text
-    command_parent: Optional[CommandType] = None         #: The parent Command, if any
+    command_parent: Optional[CommandCls] = None          #: The parent Command, if any
     parent: Optional[CommandParameters] = None           #: The parent Command's CommandParameters
     action: Optional[Action] = None                      #: An Action Parameter, if specified
     _pass_thru: Optional[PassThru] = None                #: A PassThru Parameter, if specified
@@ -51,7 +51,7 @@ class CommandParameters:
     positionals: List[BasePositional]                    #: List of positional Parameters
     option_map: OptionMap                                #: Mapping of {--opt / -opt: Parameter}
 
-    def __init__(self, command: CommandType, command_parent: Optional[CommandType], config: CommandConfig):
+    def __init__(self, command: CommandCls, command_parent: Optional[CommandCls], config: CommandConfig):
         self.command = command
         if command_parent is not None:
             self.command_parent = command_parent

--- a/lib/cli_command_parser/command_parameters.py
+++ b/lib/cli_command_parser/command_parameters.py
@@ -19,7 +19,7 @@ except ImportError:
     from .compat import cached_property
 
 from .actions import help_action
-from .exceptions import CommandDefinitionError, ParameterDefinitionError
+from .exceptions import CommandDefinitionError, ParameterDefinitionError, ParamsMissing
 from .parameters.base import ParamBase, Parameter, BaseOption, BasePositional
 from .parameters import SubCommand, PassThru, ActionFlag, ParamGroup, Action, Option
 
@@ -373,6 +373,18 @@ class CommandParameters:
         return None
 
     # endregion
+
+    def validate_groups(self):
+        exc = None
+        for group in self.groups:
+            try:
+                group.validate()
+            except ParamsMissing as e:  # Let ParamConflict propagate before ParamsMissing
+                if exc is None:
+                    exc = e
+
+        if exc is not None:
+            raise exc
 
     def try_env_params(self, ctx: Context) -> Iterator[Option]:
         for param in self.options:

--- a/lib/cli_command_parser/config.py
+++ b/lib/cli_command_parser/config.py
@@ -256,6 +256,9 @@ class CommandConfig:
     #: How the default long form that is added for Option/Flag/Counter/etc. Parameters should handle underscores/dashes
     option_name_mode: OptionNameMode = ConfigItem(OptionNameMode.UNDERSCORE, OptionNameMode)
 
+    #: Whether ambiguous combinations of positional choices should result in an :class:`.AmbiguousParseTree` error
+    reject_ambiguous_pos_combos: Bool = ConfigItem(True, bool)
+
     # endregion
 
     # region Usage & Help Text Options

--- a/lib/cli_command_parser/exceptions.py
+++ b/lib/cli_command_parser/exceptions.py
@@ -73,14 +73,19 @@ class ParameterDefinitionError(CommandParserException):
 class AmbiguousParseTree(CommandDefinitionError):
     """Raised when a combination of parameters would result in ambiguous paths to take when parsing arguments"""
 
-    def __init__(self, node: PosNode, word: Word, target: Target):
+    def __init__(self, node: PosNode, target: Target, word: Word = None):
         self.node = node
-        self.word = word
         self.target = target
+        self.word = word
 
     def __str__(self) -> str:
-        node_path = ' '.join(self.node.path)
-        return f'Conflicting targets for parse path={node_path!r}: {self.node.target!r}, {self.target!r}'
+        node, word = self.node, self.word
+        if not word or word == node.word:
+            return f'Conflicting targets for parse path={node.path_repr()}: {node.target!r}, {self.target!r}'
+        return (
+            f'Conflicting choices after parse path={node.parent.path_repr()}:'
+            f' {node.word}=>{node.target!r}, {word}=>{self.target!r}'
+        )
 
 
 # endregion

--- a/lib/cli_command_parser/exceptions.py
+++ b/lib/cli_command_parser/exceptions.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import sys
 from typing import TYPE_CHECKING, Any, Optional, Collection
 
+from .utils import _parse_tree_target_repr
+
 if TYPE_CHECKING:
     from .parameters import Parameter
     from .typing import ParamOrGroup
@@ -80,12 +82,10 @@ class AmbiguousParseTree(CommandDefinitionError):
 
     def __str__(self) -> str:
         node, word = self.node, self.word
+        nt, st = _parse_tree_target_repr(node.target), _parse_tree_target_repr(self.target)
         if not word or word == node.word:
-            return f'Conflicting targets for parse path={node.path_repr()}: {node.target!r}, {self.target!r}'
-        return (
-            f'Conflicting choices after parse path={node.parent.path_repr()}:'
-            f' {node.word}=>{node.target!r}, {word}=>{self.target!r}'
-        )
+            return f'Conflicting targets for parse path={node.path_repr()}: {nt}, {st}'
+        return f'Conflicting choices after parse path={node.parent.path_repr()}: {node.word}=>{nt}, {word}=>{st}'
 
 
 # endregion

--- a/lib/cli_command_parser/exceptions.py
+++ b/lib/cli_command_parser/exceptions.py
@@ -30,7 +30,6 @@ __all__ = [
     'ParamConflict',
     'ParamsMissing',
     'NoActiveContext',
-    'NoEnvVar',
 ]
 
 
@@ -192,10 +191,6 @@ class UnsupportedAction(CommandParserException):
 
 class Backtrack(CommandParserException):
     """Raised when backtracking took place"""
-
-
-class NoEnvVar(CommandParserException):
-    """Indicates that no environment variable was available for a given Parameter."""
 
 
 # endregion

--- a/lib/cli_command_parser/exceptions.py
+++ b/lib/cli_command_parser/exceptions.py
@@ -8,7 +8,7 @@ Exceptions for Command Parser
 from __future__ import annotations
 
 import sys
-from typing import TYPE_CHECKING, Any, Collection
+from typing import TYPE_CHECKING, Any, Optional, Collection
 
 if TYPE_CHECKING:
     from .parameters import Parameter
@@ -102,7 +102,7 @@ class ParamUsageError(UsageError):
 
     message: str = None
 
-    def __init__(self, param: ParamOrGroup, message: str = None):
+    def __init__(self, param: Optional[ParamOrGroup], message: str = None):
         self.param = param
         self.usage_str = param.format_usage(full=True, delim=' / ') if param else ''
         if message:
@@ -162,7 +162,7 @@ class BadArgument(ParamUsageError):
 class InvalidChoice(BadArgument):
     """Error raised when a value that does not match one of the pre-defined choices was provided for a Parameter"""
 
-    def __init__(self, param: Parameter, invalid: Any, choices: Collection[Any]):
+    def __init__(self, param: Optional[Parameter], invalid: Any, choices: Collection[Any]):
         if isinstance(invalid, Collection) and not isinstance(invalid, str):
             bad_str = 'choices: {}'.format(', '.join(map(repr, invalid)))
         else:

--- a/lib/cli_command_parser/exceptions.py
+++ b/lib/cli_command_parser/exceptions.py
@@ -13,11 +13,13 @@ from typing import TYPE_CHECKING, Any, Collection
 if TYPE_CHECKING:
     from .parameters import Parameter
     from .typing import ParamOrGroup
+    from .parse_tree import PosNode, Word, Target
 
 __all__ = [
     'CommandParserException',
     'CommandDefinitionError',
     'ParameterDefinitionError',
+    'AmbiguousParseTree',
     'UsageError',
     'ParamUsageError',
     'BadArgument',
@@ -67,6 +69,19 @@ class CommandDefinitionError(CommandParserException):
 
 class ParameterDefinitionError(CommandParserException):
     """An error caused by providing invalid options for a Parameter"""
+
+
+class AmbiguousParseTree(CommandDefinitionError):
+    """Raised when a combination of parameters would result in ambiguous paths to take when parsing arguments"""
+
+    def __init__(self, node: PosNode, word: Word, target: Target):
+        self.node = node
+        self.word = word
+        self.target = target
+
+    def __str__(self) -> str:
+        node_path = ' '.join(self.node.path)
+        return f'Conflicting targets for parse path={node_path!r}: {self.node.target!r}, {self.target!r}'
 
 
 # endregion

--- a/lib/cli_command_parser/nargs.py
+++ b/lib/cli_command_parser/nargs.py
@@ -6,9 +6,9 @@ Helpers for handling ``nargs=...`` for Parameters.
 
 from __future__ import annotations
 
-from typing import Union, Optional, Sequence, Tuple, Set
+from typing import Union, Optional, Sequence, Collection, Tuple, Set, FrozenSet
 
-NargsValue = Union[str, int, Tuple[int, Optional[int]], Sequence[int], Set[int], range]
+NargsValue = Union[str, int, Tuple[int, Optional[int]], Sequence[int], Set[int], FrozenSet[int], range]
 
 NARGS_STR_RANGES = {'?': (0, 1), '*': (0, None), '+': (1, None)}
 SET_ERROR_FMT = 'Invalid nargs={!r} set - expected non-empty set where all values are integers >= 0'
@@ -25,6 +25,12 @@ class Nargs:
     """
 
     __slots__ = ('_orig', 'range', 'min', 'max', 'allowed', 'variable')
+    _orig: NargsValue
+    range: Optional[range]
+    min: Optional[int]
+    max: Optional[int]
+    allowed: Collection[int]
+    variable: bool
 
     def __init__(self, nargs: NargsValue):  # pylint: disable=R0912
         self._orig = nargs

--- a/lib/cli_command_parser/parameters/choice_map.py
+++ b/lib/cli_command_parser/parameters/choice_map.py
@@ -16,7 +16,7 @@ from ..exceptions import ParameterDefinitionError, BadArgument, MissingArgument,
 from ..formatting.utils import format_help_entry
 from ..nargs import Nargs
 from ..typing import Bool, CommandCls
-from ..utils import _NotSet, camel_to_snake_case
+from ..utils import _NotSet, camel_to_snake_case, short_repr
 from .base import BasePositional, parameter_action
 
 __all__ = ['SubCommand', 'Action', 'Choice', 'ChoiceMap']
@@ -42,7 +42,7 @@ class Choice(Generic[T]):
         self.local = local
 
     def __repr__(self) -> str:
-        help_str = f', help={self.help!r}' if self.help else ''
+        help_str = f', help={short_repr(self.help)}' if self.help else ''
         target_str = f', target={self.target}' if self.choice != self.target else ''
         return f'{self.__class__.__name__}({self.choice!r}{target_str}{help_str})'
 

--- a/lib/cli_command_parser/parameters/groups.py
+++ b/lib/cli_command_parser/parameters/groups.py
@@ -204,6 +204,14 @@ class ParamGroup(ParamBase):
         return parent.mutually_exclusive
 
     def validate(self):
+        """
+        Validate mutual dependency / exclusivity of members and that required members have been provided when they are
+        expected to be (based on mutual dependence/exclusivity and nesting).
+
+        This method is called during parsing, after initially parsing arguments, before evaluating whether a subcommand
+        choice was provided.  Groups are validated in order, starting from the inner-most groups and working outward so
+        that nested groups are validated before any group that they are a member of.
+        """
         provided, missing = self._categorize_params()
         ctx.record_action(self, len(provided))
         self._check_conflicts(provided, missing)

--- a/lib/cli_command_parser/parse_tree.py
+++ b/lib/cli_command_parser/parse_tree.py
@@ -1,0 +1,273 @@
+"""
+:author: Doug Skrypa
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Union, Optional, Collection, Generic, TypeVar, Iterable, Callable, overload, Dict, Set
+
+# from .core import get_params
+from .exceptions import AmbiguousParseTree
+
+if TYPE_CHECKING:
+    from types import MethodType
+    from .nargs import Nargs
+    from .parameters.base import BasePositional
+    from .parameters.choice_map import Choice
+    from .typing import OptStr, CommandCls
+
+__all__ = ['ParseTree']
+
+T = TypeVar('T')
+
+
+class cached_slot_property(Generic[T]):
+    __slots__ = ('func', 'name', '__doc__')
+
+    def __init__(self, func: Callable[[MethodType], T]):
+        self.func = func
+        self.name = None
+        self.__doc__ = func.__doc__
+
+    def __set_name__(self, owner, name: str):
+        self.name = f'_{name}'
+        if self.name not in owner.__slots__:
+            raise TypeError(f'Missing attr {name!r} in {owner.__name__}.__slots__')
+
+    @overload
+    def __get__(self, instance: None, owner) -> cached_slot_property:
+        ...
+
+    @overload
+    def __get__(self, instance, owner) -> T:
+        ...
+
+    def __get__(self, instance, owner):
+        if instance is None:
+            return self
+        try:
+            return getattr(instance, self.name)
+        except AttributeError:
+            pass
+        value = self.func(instance)
+        setattr(instance, self.name, value)
+        return value
+
+    def __set__(self, instance, value: T):
+        setattr(instance, self.name, value)
+
+
+class AnyWord:
+    __slots__ = ('nargs', 'n', 'remaining')
+
+    nargs: Nargs
+    n: int
+    remaining: Union[int, float]
+
+    def __init__(self, nargs: Nargs, remaining: Union[int, float, None] = None, n: int = 1):
+        self.nargs = nargs
+        self.n = n
+        if remaining is None:
+            self.remaining = float('inf') if nargs.max is None else nargs.max - 1  # -1 since one would be consumed
+        else:
+            self.remaining = remaining
+
+    def __str__(self) -> str:
+        # return '[[AnyWord]]'
+        return '*'
+
+    def __repr__(self) -> str:
+        return f'AnyWord({self.nargs!r}, remaining={self.remaining}, n={self.n})'
+
+    def __add__(self, other: int) -> AnyWord:
+        remaining = self.remaining - other
+        if remaining < 0:
+            raise ValueError(f'Unable to add {other} to {self!r} - remaining={remaining} is invalid')
+        return AnyWord(self.nargs, remaining, self.n + other)
+
+
+Word = Union[str, AnyWord, None]
+Target = Union['BasePositional', 'CommandCls', None]
+
+
+class PosNode:
+    __slots__ = ('parent', 'word', 'links', '_any_link', 'target', '_root', '_path')
+
+    parent: Optional[PosNode]
+    word: Word
+    links: Dict[OptStr, PosNode]
+    _any_link: Optional[PosNode]
+    target: Target
+
+    def __init__(self, word: Word, target: Target = None, parent: Optional[PosNode] = None):
+        self.parent = parent
+        self.word = word
+        self.links = {}
+        # self.any_link = None
+        self.target = target
+
+    def __repr__(self) -> str:
+        root = self.parent is None
+        return f'<PosNode[{self.word!r}, links: {len(self.links)}, root: {root}, target={self.target!r}]>'
+
+    def __getitem__(self, word: str) -> PosNode:
+        try:
+            return self.links[word]
+        except KeyError:
+            pass
+        any_link = self.any_link
+        if any_link:
+            return any_link
+        raise KeyError(word)
+
+    @cached_slot_property
+    def any_link(self) -> Optional[PosNode]:
+        try:
+            next_word = self.word + 1
+        except (TypeError, ValueError):  # TypeError for None or str, ValueError for no remaining
+            return None
+        return PosNode(next_word, self.target, self)
+        # word = self.word
+        # try:
+        #     remaining = word.remaining
+        # except AttributeError:  # it was a string or None, not AnyWord
+        #     return None
+        # if not remaining:
+        #     return None
+        # return PosNode(AnyWord(word.nargs, remaining - 1, word.n + 1), self.target, self)
+
+    @cached_slot_property
+    def root(self) -> PosNode:
+        parent = self.parent
+        return parent.root if parent else self
+
+    # @cached_slot_property
+    # def path(self) -> tuple[str, ...]:
+    #     parts = []
+    #     node = self
+    #     while node:
+    #         parts.append(node.word)
+    #         node = node.parent
+    #     return tuple(parts[:-1][::-1])
+
+    @cached_slot_property
+    def path(self) -> tuple[str, ...]:
+        word = self.word
+        if not word:
+            return ()
+        word = str(word)
+        try:
+            return (*self.parent.path, word)  # noqa
+        except AttributeError:
+            return (word,)  # noqa
+
+    @property
+    def is_terminal(self) -> bool:
+        word = self.word
+        try:
+            return word.n in word.nargs
+        except AttributeError:
+            return bool(self.target)
+
+    def _update(self, word: Word, target: Target) -> PosNode:
+        if word:
+            any_link, own_word = self.any_link, self.word
+            if any_link and self.is_terminal:
+                raise AmbiguousParseTree(self, word, target)
+            elif isinstance(word, AnyWord):
+                if any_link or self.links:
+                    raise AmbiguousParseTree(self, word, target)
+                else:
+                    self.any_link = node = PosNode(word, target, self)  # noqa
+                    return node
+            else:
+                try:
+                    node = self.links[word]
+                except KeyError:
+                    self.links[word] = node = PosNode(word, target, self)
+                    return node
+                else:
+                    return node._update(None, target)
+        # Below this point, word is None
+        elif not target:
+            return self
+        elif self.target:
+            raise AmbiguousParseTree(self, word, target)
+        else:
+            self.target = target
+            return self
+
+    def update(self, word: Word, target: Target) -> PosNode:
+        try:
+            *parts, last = word.split()
+        except AttributeError:  # The choice is None or Any
+            return self._update(word, target)
+        else:
+            node = self
+            for part in parts:
+                node = node.update(part, None)
+            return node._update(last, target)
+
+    def print_tree(self, indent: int = 0):
+        prefix = ' ' * indent
+        print(f'{prefix}- <PosNode[{self.word!r}, links: {len(self.links)}, target={self.target!r}]>')
+        indent += 2
+        for node in self.links.values():
+            node.print_tree(indent)
+
+        try:
+            self.any_link.print_tree(indent)
+        except AttributeError:  # any_link is None
+            pass
+
+
+class ParseTree:
+    def __init__(self, command: CommandCls):
+        self.command = command
+        self.root = PosNode(None)
+        self._build([self.root], command.__class__.params(command).positionals)
+
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__}({self.command!r})[root={self.root!r}]>'
+
+    def _build(self, nodes: Iterable[PosNode], params: Iterable[BasePositional]) -> Set[PosNode]:
+        for param in params:
+            nodes = self._process_param(nodes, param)
+
+        return nodes
+
+    def _process_param(self, nodes: Iterable[PosNode], param: BasePositional) -> Set[PosNode]:
+        # At each step, the number of branches grows
+        try:
+            choices: Dict[OptStr, Choice] = param.choices  # noqa
+        except AttributeError:  # It was not a ChoiceMap param
+            pass
+        else:
+            get_params = self.command.__class__.params
+
+            new_nodes = set()
+            for choice in choices.values():
+                target = choice.target
+                try:
+                    params = get_params(target)
+                except TypeError:
+                    new_nodes.update(node.update(choice.choice, target) for node in nodes)
+                else:
+                    choice_nodes = {node.update(choice.choice, target) for node in nodes}
+                    new_nodes.update(self._build(choice_nodes, params.positionals))
+
+            return new_nodes
+
+        try:
+            choices: Collection[str] = param.type.choices  # noqa
+        except AttributeError:  # It was not a _ChoicesBase input type
+            pass
+        else:
+            return {node.update(choice, param) for choice in choices for node in nodes}
+
+        # At this point, the param will take any word
+        word = AnyWord(param.nargs)
+        return {node.update(word, param) for node in nodes}
+
+    def print_tree(self):
+        self.root.print_tree()

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -14,8 +14,7 @@ from typing import TYPE_CHECKING, Optional, Union, Any, Deque, List
 from .context import ActionPhase, Context, ParseState
 from .exceptions import UsageError, ParamUsageError, NoSuchOption, MissingArgument, ParamsMissing
 from .exceptions import CommandDefinitionError, Backtrack, UnsupportedAction
-
-# from .parse_tree import ParseTree
+from .parse_tree import ParseTree
 from .parameters.base import BasicActionMixin, Parameter, BasePositional, BaseOption
 
 if TYPE_CHECKING:
@@ -37,7 +36,7 @@ class CommandParser:
         self.ctx = ctx
         self.params = ctx.params
         self.positionals = ctx.params.positionals.copy()
-        # self.tree = ParseTree(ctx.command)
+        self.tree = ParseTree(ctx.command)
 
     @classmethod
     def parse_args(cls, ctx: Context) -> Optional[CommandType]:
@@ -124,6 +123,8 @@ class CommandParser:
         self._parse_env_vars(ctx)
 
     def _parse_env_vars(self, ctx: Context):
+        # TODO: It would be helpful to store arg provenance for error messages, especially for a conflict between
+        #  mutually exclusive params when they were provided via env
         for param in self.params.try_env_params(ctx):
             for env_var in param.env_vars():
                 try:

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -28,15 +28,19 @@ __all__ = ['CommandParser']
 class CommandParser:
     """Stateful parser used for a single pass of argument parsing"""
 
-    arg_deque: Optional[Deque[str]] = None
-    deferred: Optional[List[str]] = None
-    _last: Optional[Parameter] = None
+    __slots__ = ('_last', 'arg_deque', 'ctx', 'deferred', 'node', 'params', 'positionals')
+
+    arg_deque: Optional[Deque[str]]
+    deferred: Optional[List[str]]
+    _last: Optional[Parameter]
 
     def __init__(self, ctx: Context):
+        self._last = None
         self.ctx = ctx
         self.params = ctx.params
         self.positionals = ctx.params.positionals.copy()
-        self.tree = PosNode.build_tree(ctx.command)
+        if ctx.config.reject_ambiguous_pos_combos:
+            PosNode.build_tree(ctx.command)
 
     @classmethod
     def parse_args(cls, ctx: Context) -> Optional[CommandType]:

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -63,7 +63,7 @@ class CommandParser:
             raise CommandDefinitionError(f'{ctx.command}.{sub_cmd_param.name} = {sub_cmd_param} has no sub Commands')
 
         cls(ctx)._parse_args(ctx)
-        cls._validate_groups(params)
+        params.validate_groups()
 
         if sub_cmd_param:
             next_cmd = sub_cmd_param.target()  # type: CommandType
@@ -95,19 +95,6 @@ class CommandParser:
     @classmethod
     def _missing(cls, params: CommandParameters, ctx: Context) -> List[Parameter]:
         return [p for p in params.required_check_params() if ctx.num_provided(p) == 0]
-
-    @classmethod
-    def _validate_groups(cls, params: CommandParameters):
-        exc = None
-        for group in params.groups:
-            try:
-                group.validate()
-            except ParamsMissing as e:  # Let ParamConflict propagate before ParamsMissing
-                if exc is None:
-                    exc = e
-
-        if exc is not None:
-            raise exc
 
     def _parse_args(self, ctx: Context):
         self.arg_deque = arg_deque = self.handle_pass_thru(ctx)

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -14,7 +14,7 @@ from typing import TYPE_CHECKING, Optional, Union, Any, Deque, List
 from .context import ActionPhase, Context, ParseState
 from .exceptions import UsageError, ParamUsageError, NoSuchOption, MissingArgument, ParamsMissing
 from .exceptions import CommandDefinitionError, Backtrack, UnsupportedAction
-from .parse_tree import ParseTree
+from .parse_tree import PosNode
 from .parameters.base import BasicActionMixin, Parameter, BasePositional, BaseOption
 
 if TYPE_CHECKING:
@@ -36,7 +36,7 @@ class CommandParser:
         self.ctx = ctx
         self.params = ctx.params
         self.positionals = ctx.params.positionals.copy()
-        self.tree = ParseTree(ctx.command)
+        self.tree = PosNode.build_tree(ctx.command)
 
     @classmethod
     def parse_args(cls, ctx: Context) -> Optional[CommandType]:

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -13,6 +13,8 @@ from typing import TYPE_CHECKING, Optional, Union, Any, Deque, List
 from .context import ActionPhase, Context, ParseState
 from .exceptions import UsageError, ParamUsageError, NoSuchOption, MissingArgument, ParamsMissing
 from .exceptions import CommandDefinitionError, Backtrack, UnsupportedAction, NoEnvVar
+
+# from .parse_tree import ParseTree
 from .parameters.base import BasicActionMixin, Parameter, BasePositional, BaseOption
 
 if TYPE_CHECKING:
@@ -54,6 +56,7 @@ class CommandParser:
 
     @classmethod
     def __parse_args(cls, ctx: Context) -> Optional[CommandType]:
+        # tree = ParseTree(ctx.command)
         params = ctx.params
         sub_cmd_param = params.sub_command
         if sub_cmd_param and not sub_cmd_param.choices:

--- a/lib/cli_command_parser/testing.py
+++ b/lib/cli_command_parser/testing.py
@@ -13,6 +13,7 @@ from difflib import unified_diff
 from io import StringIO, BytesIO
 from typing import TYPE_CHECKING, Any, Iterable, Type, Union, Callable, IO, Dict, List, Tuple
 from unittest import TestCase
+from unittest.mock import Mock, seal
 
 from .actions import help_action
 from .commands import Command
@@ -29,6 +30,7 @@ __all__ = [
     'get_rst_text',
     'get_help_text',
     'get_usage_text',
+    'sealed_mock',
 ]
 
 Argv = List[str]
@@ -265,3 +267,10 @@ def get_rst_text(cmd: Union[Type[Command], Command]) -> str:
     cmd.ctx._terminal_width = 199
     with cmd.ctx:
         return get_params(cmd).formatter.format_rst()
+
+
+def sealed_mock(*args, **kwargs):
+    kwargs.setdefault('return_value', None)
+    mock = Mock(*args, **kwargs)
+    seal(mock)
+    return mock

--- a/lib/cli_command_parser/utils.py
+++ b/lib/cli_command_parser/utils.py
@@ -11,7 +11,7 @@ from enum import Flag
 from inspect import isclass
 from shutil import get_terminal_size
 from time import monotonic
-from typing import Union, Optional, TypeVar, get_type_hints, List
+from typing import Any, Callable, Union, Optional, TypeVar, get_type_hints, List
 
 try:
     from typing import get_origin, get_args as _get_args  # pylint: disable=C0412
@@ -29,9 +29,22 @@ FlagEnum = TypeVar('FlagEnum', bound='FixedFlag')
 _NotSet = object()
 
 
+# region Text Processing / Formatting
+
+
 def camel_to_snake_case(text: str, delim: str = '_') -> str:
     return ''.join(f'{delim}{c}' if i and c.isupper() else c for i, c in enumerate(text)).lower()
 
+
+def short_repr(obj: Any, max_len: int = 100, sep: str = '...', func: Callable[[Any], str] = repr) -> str:
+    obj_repr = func(obj)
+    if len(obj_repr) > max_len:
+        part_len = (max_len - len(sep)) // 2
+        return '{}{}{}'.format(obj_repr[:part_len], sep, obj_repr[-part_len:])
+    return obj_repr
+
+
+# endregion
 
 # region Annotation Inspection
 

--- a/lib/cli_command_parser/utils.py
+++ b/lib/cli_command_parser/utils.py
@@ -44,6 +44,13 @@ def short_repr(obj: Any, max_len: int = 100, sep: str = '...', func: Callable[[A
     return obj_repr
 
 
+def _parse_tree_target_repr(target) -> str:
+    try:
+        return target.__name__
+    except AttributeError:
+        return repr(target)
+
+
 # endregion
 
 # region Annotation Inspection

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, PropertyMock
 
 from cli_command_parser import Command, Action, Positional, action_flag, ParameterDefinitionError
 from cli_command_parser.exceptions import CommandDefinitionError, MissingArgument, InvalidChoice
-from cli_command_parser.testing import RedirectStreams
+from cli_command_parser.testing import RedirectStreams, sealed_mock
 
 # TODO: Test multi-word actions; multi-word actions combined with subcommands (with multiple words)
 # TODO: Test space/-/_ switch for multi-word?
@@ -35,7 +35,7 @@ class ActionTest(TestCase):
         self.assertEqual(call_count, 1)
 
     def test_action_called_mock(self):
-        mock = Mock(__name__='bar')
+        mock = sealed_mock(__name__='bar')
 
         class Foo(Command):
             action = Action()
@@ -50,7 +50,7 @@ class ActionTest(TestCase):
     def test_action_wrong_missing_choices(self):
         class Foo(Command):
             action = Action()
-            action(Mock(__name__='bar'))
+            action(sealed_mock(__name__='bar'))
 
         with self.assertRaises(InvalidChoice):
             Foo.parse(['baz']).main()
@@ -80,13 +80,13 @@ class ActionTest(TestCase):
 
                 class Foo(Command):
                     action = Action()
-                    action(name)(Mock(__name__='bar'))
+                    action(name)(sealed_mock(__name__='bar'))
 
     def test_positional_allowed_after_action(self):
         class Foo(Command):
             action = Action(help='The action to take')
             text = Positional(nargs='+')
-            action(Mock(__name__='foo'))
+            action(sealed_mock(__name__='foo'))
 
         foo = Foo.parse(['foo', 'bar'])
         self.assertTrue(foo.ctx.get_parsed()['action'])
@@ -97,7 +97,7 @@ class ActionTest(TestCase):
 
             class Foo(Command):
                 action = Action()
-                action('foo', choice='foo')(Mock(__name__='foo'))
+                action('foo', choice='foo')(sealed_mock(__name__='foo'))
 
     def test_stacked_action_flag_action_as_action(self):
         BuildDocs, build_mock, clean_mock = make_build_docs_command()
@@ -155,21 +155,21 @@ class ActionTest(TestCase):
     def test_default_default_help_text(self):
         class Foo(Command):
             action = Action()
-            action(default=True)(Mock(__name__='main', __doc__=None))
+            action(default=True)(sealed_mock(__name__='main', __doc__=None))
 
         self.assertEqual('Default action if no other action is specified', Foo.action.choices[None].help)
 
     def test_default_doc_help_text(self):
         class Foo(Command):
             action = Action()
-            action(default=True)(Mock(__name__='main', __doc__='test'))
+            action(default=True)(sealed_mock(__name__='main', __doc__='test'))
 
         self.assertEqual('test', Foo.action.choices[None].help)
 
     def test_doc_help_text(self):
         class Foo(Command):
             action = Action()
-            action(Mock(__name__='main', __doc__='test'))
+            action(sealed_mock(__name__='main', __doc__='test'))
 
         self.assertEqual('test', Foo.action.choices['main'].help)
 
@@ -198,7 +198,7 @@ class ActionTest(TestCase):
 
 
 def make_build_docs_command(explicit_build: bool = False):
-    build_mock, clean_mock = Mock(__name__='sphinx_build'), Mock()
+    build_mock, clean_mock = sealed_mock(__name__='sphinx_build'), sealed_mock()
 
     class BuildDocs(Command, description='Build documentation using Sphinx'):
         action = Action()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -7,6 +7,7 @@ from cli_command_parser import Command, CommandConfig, Context
 from cli_command_parser.core import CommandMeta, get_config, get_parent, get_params, _choice_items
 from cli_command_parser.exceptions import CommandDefinitionError, ParamConflict
 from cli_command_parser.parameters import Action, ActionFlag
+from cli_command_parser.testing import sealed_mock
 
 _get_config = CommandMeta.config
 
@@ -143,7 +144,7 @@ class TestCommandMeta(TestCase):
 
 class TestCommands(TestCase):
     def test_true_on_action_handled(self):
-        mock = Mock(__name__='foo')
+        mock = sealed_mock(__name__='foo')
 
         class Foo(Command):
             action = Action()
@@ -179,7 +180,7 @@ class TestCommands(TestCase):
             self.assertFalse(mock.called)
 
     def test_parse_and_run(self):
-        mock = Mock(__name__='bar')
+        mock = sealed_mock(__name__='bar')
 
         class Foo(Command):
             action = Action()
@@ -245,7 +246,7 @@ class TestCommands(TestCase):
 
     def test_action_after_action_flags_exc(self):
         act_flag_mock = Mock()
-        action_mock = Mock(__name__='b')
+        action_mock = sealed_mock(__name__='b')
 
         class Foo(Command, action_after_action_flags=False, error_handler=None):
             a = ActionFlag('-a')(act_flag_mock)
@@ -260,7 +261,7 @@ class TestCommands(TestCase):
 
     def test_action_after_action_flags_ok(self):
         act_flag_mock = Mock()
-        action_mock = Mock(__name__='b')
+        action_mock = sealed_mock(__name__='b')
 
         class Foo(Command):
             a = ActionFlag('-a')(act_flag_mock)

--- a/tests/test_documentation/test_help_text.py
+++ b/tests/test_documentation/test_help_text.py
@@ -19,6 +19,7 @@ from cli_command_parser.inputs import Date, Day
 from cli_command_parser.parameters.choice_map import ChoiceMap, SubCommand, Action, Choice
 from cli_command_parser.parameters import Positional, Counter, ParamGroup, Option, Flag, PassThru, action_flag, TriFlag
 from cli_command_parser.testing import ParserTest, RedirectStreams, get_rst_text, get_help_text, get_usage_text
+from cli_command_parser.testing import sealed_mock
 
 if TYPE_CHECKING:
     from cli_command_parser.typing import CommandCls
@@ -31,7 +32,7 @@ class MetadataTest(ParserTest):
     def test_prog(self):
         class Foo(Command, error_handler=no_exit_handler, prog='foo.py', add_help=True):
             action = Action()
-            action(Mock(__name__='bar'))
+            action(sealed_mock(__name__='bar'))
 
         stdout, stderr = _get_output(Foo, ['-h'])
         self.assertTrue(stdout.startswith('usage: foo.py {bar}'), f'Unexpected stdout: {stdout}')
@@ -44,7 +45,7 @@ class MetadataTest(ParserTest):
     def test_explicit_usage(self):
         class Foo(Command, error_handler=no_exit_handler, usage='this is a test'):
             action = Action()
-            action(Mock(__name__='bar'))
+            action(sealed_mock(__name__='bar'))
 
         stdout, stderr = _get_output(Foo, ['-h'])
         self.assertTrue(stdout.startswith('this is a test'), f'Unexpected stdout: {stdout}')
@@ -53,7 +54,7 @@ class MetadataTest(ParserTest):
     def test_description(self):
         class Foo(Command, error_handler=no_exit_handler, prog='foo.py', description=TEST_DESCRIPTION):
             action = Action()
-            action(Mock(__name__='bar'))
+            action(sealed_mock(__name__='bar'))
 
         stdout, stderr = _get_output(Foo, ['-h'])
         self.assertTrue(stdout.startswith('usage: foo.py {bar}'), f'Unexpected stdout: {stdout}')
@@ -62,7 +63,7 @@ class MetadataTest(ParserTest):
     def test_epilog(self):
         class Foo(Command, error_handler=no_exit_handler, prog='foo.py', epilog=TEST_EPILOG):
             action = Action()
-            action(Mock(__name__='bar'))
+            action(sealed_mock(__name__='bar'))
 
         stdout, stderr = _get_output(Foo, ['-h'])
         self.assertTrue(stdout.startswith('usage: foo.py {bar}'), f'Unexpected stdout: {stdout}')

--- a/tests/test_parameters/test_action_flags.py
+++ b/tests/test_parameters/test_action_flags.py
@@ -2,7 +2,7 @@
 
 from itertools import count
 from unittest import main
-from unittest.mock import Mock
+from unittest.mock import Mock, seal
 
 from cli_command_parser import Command, Action, no_exit_handler, ActionFlag, ParamGroup
 from cli_command_parser.actions import help_action
@@ -15,6 +15,7 @@ from cli_command_parser.testing import ParserTest, RedirectStreams
 class ActionFlagTest(ParserTest):
     def test_help_action(self):
         mock = Mock(__name__='bar')
+        seal(mock)
 
         class Foo(Command, error_handler=no_exit_handler):
             action = Action()
@@ -24,7 +25,7 @@ class ActionFlagTest(ParserTest):
             Foo.parse(['bar', '-h'])()
 
         self.assertTrue(streams.stdout.startswith('usage: '))
-        self.assertEqual(mock.call_count, 0)
+        mock.assert_not_called()
 
     def test_af_func_missing(self):
         class Foo(Command):

--- a/tests/test_parameters/test_choice_maps.py
+++ b/tests/test_parameters/test_choice_maps.py
@@ -16,13 +16,22 @@ class ChoiceMapTest(ParserTest):
 
             class Foo(Command):
                 action = Action()
-                action('foo')(Mock())
-                action('foo')(Mock())
+
+                @action
+                def foo(self):
+                    pass
+
+                @action('foo')
+                def _foo(self):
+                    pass
 
     def test_bad_choice_append_rejected(self):
         class Foo(Command):
             action = Action()
-            action('foo bar')(Mock())
+
+            @action('foo bar')
+            def foo(self):
+                pass
 
         with Context():
             Foo.action.take_action('foo')
@@ -47,7 +56,10 @@ class ChoiceMapTest(ParserTest):
     def test_choice_map_too_many(self):
         class Foo(Command):
             action = Action()
-            action('foo')(Mock())
+
+            @action
+            def foo(self):
+                pass
 
         with Context():
             Foo.action.take_action('foo')
@@ -57,7 +69,10 @@ class ChoiceMapTest(ParserTest):
     def test_no_choices_result_forced(self):
         class Foo(Command):
             action = Action()
-            action('foo')(Mock())
+
+            @action
+            def foo(self):
+                pass
 
         with self.assertRaises(CommandDefinitionError):
             foo = Foo.parse([])
@@ -67,7 +82,10 @@ class ChoiceMapTest(ParserTest):
     def test_unexpected_nargs(self):
         class Foo(Command):
             action = Action()
-            action('foo bar')(Mock())
+
+            @action('foo bar')
+            def foo(self):
+                pass
 
         with Context():
             Foo.action.take_action('foo')
@@ -77,8 +95,14 @@ class ChoiceMapTest(ParserTest):
     def test_unexpected_choice(self):
         class Foo(Command):
             action = Action()
-            action('foo bar')(Mock())
-            action('foo baz')(Mock())
+
+            @action('foo bar')
+            def foo(self):
+                pass
+
+            @action('foo baz')
+            def bar(self):
+                pass
 
         with Context():
             Foo.action.take_action('foo bar')
@@ -104,7 +128,10 @@ class ChoiceMapTest(ParserTest):
     def test_custom_action_choice(self):
         class Foo(Command):
             action = Action()
-            action(choice='foo')(Mock(__name__='bar'))
+
+            @action('foo')
+            def bar(self):
+                pass
 
         self.assertIn('foo', Foo.action.choices)
 

--- a/tests/test_parameters/test_misc.py
+++ b/tests/test_parameters/test_misc.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Optional, Collection, Sequence, Iterable, Union
 from unittest import main, skipIf
-from unittest.mock import Mock
 
 from cli_command_parser import Command
 from cli_command_parser.context import Context
@@ -32,7 +31,7 @@ from cli_command_parser.parameters.base import parameter_action, Parameter, Base
 from cli_command_parser.parameters.choice_map import ChoiceMap, SubCommand, Action
 from cli_command_parser.parameters import PassThru, Positional, ParamGroup, ActionFlag, Counter, Flag, Option
 from cli_command_parser.parser import CommandParser
-from cli_command_parser.testing import ParserTest
+from cli_command_parser.testing import ParserTest, sealed_mock
 
 
 class PassThruTest(ParserTest):
@@ -161,7 +160,7 @@ class MiscParameterTest(ParserTest):
 
     def test_unexpected_prep_value_error(self):
         class Foo(Command):
-            bar = Positional(type=Mock(side_effect=OSError))
+            bar = Positional(type=sealed_mock(side_effect=OSError))
 
         self.assert_parse_fails(Foo, ['a'], BadArgument, 'unable to cast value=.* to type=')
 

--- a/tests/test_parse_tree.py
+++ b/tests/test_parse_tree.py
@@ -2,12 +2,145 @@
 
 from unittest import main, skip
 
-from cli_command_parser import Command, Positional, SubCommand
-from cli_command_parser.exceptions import AmbiguousParseTree
-from cli_command_parser.testing import ParserTest
+from cli_command_parser import Command, Positional, SubCommand, AmbiguousParseTree
+from cli_command_parser.core import get_config
+from cli_command_parser.nargs import Nargs
+from cli_command_parser.parse_tree import PosNode, AnyWord
+from cli_command_parser.testing import ParserTest, RedirectStreams
 
 
-@skip('Implementation is incomplete and not working yet')
+class TestPosNode(ParserTest):
+    def test_get_link_params(self):
+        class Foo(Command):
+            foo = Positional()
+            bar = Positional()
+
+        node = PosNode.build_tree(Foo)
+        self.assertEqual({Foo.foo}, node.link_params())
+        self.assertEqual({Foo.foo, Foo.bar}, node.link_params(True))
+
+    def test_nargs_min_max_unbound(self):
+        class Foo(Command):
+            foo = Positional(nargs=2)
+            bar = Positional(nargs='+')
+
+        node = PosNode.build_tree(Foo)
+        self.assertEqual(3, node.nargs_min())
+        self.assertEqual(float('inf'), node.nargs_max())
+
+    def test_nargs_min_max_bound(self):
+        class Foo(Command):
+            foo = Positional(choices=('a', 'b'))
+            bar = Positional()
+
+        node = PosNode.build_tree(Foo)
+        self.assertEqual(2, node.nargs_min())
+        self.assertEqual(2, node.nargs_max())
+
+    def test_repr(self):
+        class Foo(Command):
+            sub_cmd = SubCommand()
+
+        class Bar(Foo):
+            baz = Positional()
+
+        self.assertNotIn('param=target=', repr(PosNode.build_tree(Foo)['bar']))
+        self.assertIn('param=target=', repr(PosNode.build_tree(Bar)['a']))
+
+    def test_equality(self):
+        class Foo(Command):
+            bar = Positional()
+
+        class Bar(Foo):
+            baz = Positional()
+
+        foo = PosNode.build_tree(Foo)
+        bar = PosNode.build_tree(Bar)
+        self.assertNotEqual(foo, bar)
+        self.assertEqual(foo, foo)
+
+    def test_bool(self):
+        class Foo(Command):
+            bar = Positional(choices=('a', 'b'))
+
+        node = PosNode.build_tree(Foo)
+        self.assertTrue(node)
+        self.assertFalse(node['a'])
+
+    def test_contains(self):
+        class Foo(Command):
+            bar = Positional(choices=('a', 'b'))
+            baz = Positional(nargs='+')
+
+        root = PosNode.build_tree(Foo)
+        self.assertIn('a', root)
+        self.assertNotIn('c', root)
+        node = root['a']
+        self.assertNotIn('a', node)
+        self.assertIn(node.any_word, node)
+        self.assertNotIn(node.any_word + 1, node)
+
+    def test_invalid_any_word(self):
+        class Foo(Command):
+            bar = Positional(nargs='+')
+
+        root = PosNode.build_tree(Foo)
+        with self.assertRaisesRegex(KeyError, r'=>.*? cannot replace') as ctx:
+            root['a'][AnyWord(Nargs(1))] = root
+        self.assertEqual(1, str(ctx.exception).count('=>'))
+        with self.assertRaisesRegex(KeyError, r'=>.*? cannot replace') as ctx:
+            root[AnyWord(Nargs(1))] = root
+        self.assertEqual(2, str(ctx.exception).count('=>'))
+
+    def test_delete_key(self):
+        class Foo(Command):
+            bar = Positional(choices=('a', 'b'))
+            baz = Positional(nargs='+')
+
+        root = PosNode.build_tree(Foo)
+        self.assertIn('a', root)
+        del root['a']
+        self.assertNotIn('a', root)
+
+        node = root['b']
+        with self.assertRaises(KeyError):
+            del node['a']
+        with self.assertRaises(KeyError):
+            del node[AnyWord(Nargs(1))]
+
+        word = node.any_word
+        self.assertIn(word, node)
+        del node[word]
+        self.assertNotIn(word, node)
+        with self.assertRaises(KeyError):
+            del node[word]
+
+    def test_print_tree(self):
+        class Foo(Command):
+            bar = Positional(choices=('a', 'b'))
+            baz = Positional(nargs='+')
+
+        with RedirectStreams() as streams:
+            PosNode.build_tree(Foo).print_tree()
+
+        expected = """
+- <PosNode[None, links: 2, target=<class 'tests.test_parse_tree.TestPosNode.test_print_tree.<locals>.Foo'>]>
+  - <PosNode['a', links: 1, target=Positional('bar', action='store', type=<Choices[case_sensitive=True, choices=('a','b')]>, required=True)]>
+    - <PosNode[AnyWord(Nargs('+'), remaining=inf, n=1), links: 1, target=Positional('baz', action='append', required=True)]>
+  - <PosNode['b', links: 1, target=Positional('bar', action='store', type=<Choices[case_sensitive=True, choices=('a','b')]>, required=True)]>
+    - <PosNode[AnyWord(Nargs('+'), remaining=inf, n=1), links: 1, target=Positional('baz', action='append', required=True)]>
+        """.strip()
+        self.assert_strings_equal(expected, streams.stdout.strip())
+
+    def test_intentional_bad_addition(self):
+        class Foo(Command):
+            bar = Positional(nargs='+')
+
+        node = PosNode.build_tree(Foo)
+        with self.assertRaises(AmbiguousParseTree):
+            node._update_any(AnyWord(Nargs('+')), Foo.bar, None)
+
+
 class ParseTreeTestOk(ParserTest):
     def test_sub_cmd_choices_overlap_ok(self):
         class Show(Command):
@@ -24,6 +157,7 @@ class ParseTreeTestOk(ParserTest):
             with self.subTest(argv=argv, exp_cls=exp_cls):
                 self.assertIsInstance(Show.parse(argv), exp_cls)
 
+    @skip('Implementation is incomplete and not working yet')
     def test_sub_cmd_choices_with_inner_pos_overlap_ok(self):
         class Show(Command):
             sub_cmd = SubCommand()
@@ -39,6 +173,7 @@ class ParseTreeTestOk(ParserTest):
             with self.subTest(argv=argv, exp_cls=exp_cls):
                 self.assertIsInstance(Show.parse(argv), exp_cls)
 
+    @skip('Implementation is incomplete and not working yet')
     def test_nested_sub_cmd_choices_overlap_ok(self):
         class Show(Command):
             sub_cmd = SubCommand()
@@ -65,6 +200,7 @@ class ParseTreeTestOk(ParserTest):
             with self.subTest(argv=argv, exp_cls=exp_cls):
                 self.assertIsInstance(Show.parse(argv), exp_cls)
 
+    @skip('Implementation is incomplete and not working yet')
     def test_nested_pos_choices_partial_overlap_ok(self):
         class Base(Command):
             sub_cmd = SubCommand()
@@ -96,6 +232,9 @@ class ParseTreeTestBad(ParserTest):
 
         with self.assertRaisesRegex(AmbiguousParseTree, 'Conflicting targets'):
             Show.parse([])
+
+        get_config(Show).reject_ambiguous_pos_combos = False
+        self.assertEqual('baz', Show.parse(['foo', 'baz']).type)
 
     def test_overlap_choice_open_bad(self):
         class Show(Command):

--- a/tests/test_parse_tree.py
+++ b/tests/test_parse_tree.py
@@ -83,7 +83,6 @@ class ParseTreeTestOk(ParserTest):
         self.assert_parse_results_cases(Base, success_cases)
 
 
-@skip('Implementation is incomplete and not working yet')
 class ParseTreeTestBad(ParserTest):
     def test_overlap_choice_conflict_bad(self):
         class Show(Command):
@@ -95,7 +94,7 @@ class ParseTreeTestBad(ParserTest):
         class ShowFooBar(Show, choice='foo bar'):
             pass
 
-        with self.assertRaises(AmbiguousParseTree):
+        with self.assertRaisesRegex(AmbiguousParseTree, 'Conflicting targets'):
             Show.parse([])
 
     def test_overlap_choice_open_bad(self):
@@ -108,7 +107,7 @@ class ParseTreeTestBad(ParserTest):
         class ShowFooBar(Show, choice='foo bar'):
             pass
 
-        with self.assertRaises(AmbiguousParseTree):
+        with self.assertRaisesRegex(AmbiguousParseTree, 'Conflicting choices'):
             Show.parse([])
 
     def test_overlap_deep_choice_conflict_bad(self):

--- a/tests/test_parse_tree.py
+++ b/tests/test_parse_tree.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python
+
+from unittest import main, skip
+
+from cli_command_parser import Command, Positional, SubCommand
+from cli_command_parser.exceptions import AmbiguousParseTree
+from cli_command_parser.testing import ParserTest
+
+
+@skip('Implementation is incomplete and not working yet')
+class ParseTreeTestOk(ParserTest):
+    def test_sub_cmd_choices_overlap_ok(self):
+        class Show(Command):
+            sub_cmd = SubCommand()
+
+        class ShowFoo(Show, choice='foo'):
+            pass
+
+        class ShowFooBar(Show, choice='foo bar'):
+            pass
+
+        cases = [(['foo'], ShowFoo), (['foo', 'bar'], ShowFooBar), (['foo bar'], ShowFooBar)]
+        for argv, exp_cls in cases:
+            with self.subTest(argv=argv, exp_cls=exp_cls):
+                self.assertIsInstance(Show.parse(argv), exp_cls)
+
+    def test_sub_cmd_choices_with_inner_pos_overlap_ok(self):
+        class Show(Command):
+            sub_cmd = SubCommand()
+
+        class ShowFoo(Show, choice='foo'):
+            type = Positional(choices=('a', 'b', 'c'))
+
+        class ShowFooBar(Show, choice='foo bar'):
+            pass
+
+        cases = [(['foo'], ShowFoo), (['foo', 'bar'], ShowFooBar), (['foo bar'], ShowFooBar)]
+        for argv, exp_cls in cases:
+            with self.subTest(argv=argv, exp_cls=exp_cls):
+                self.assertIsInstance(Show.parse(argv), exp_cls)
+
+    def test_nested_sub_cmd_choices_overlap_ok(self):
+        class Show(Command):
+            sub_cmd = SubCommand()
+
+        class ShowFoo(Show, choice='foo'):
+            type = SubCommand()
+
+        class ShowFooBar(ShowFoo, choice='bar'):
+            pass
+
+        class ShowFooBarBaz(Show, choice='foo bar baz'):
+            pass
+
+        cases = [
+            (['foo'], ShowFoo),
+            (['foo', 'bar'], ShowFooBar),
+            (['foo bar'], ShowFooBar),
+            (['foo', 'bar', 'baz'], ShowFooBarBaz),
+            (['foo bar', 'baz'], ShowFooBarBaz),
+            (['foo', 'bar baz'], ShowFooBarBaz),
+            (['foo bar baz'], ShowFooBarBaz),
+        ]
+        for argv, exp_cls in cases:
+            with self.subTest(argv=argv, exp_cls=exp_cls):
+                self.assertIsInstance(Show.parse(argv), exp_cls)
+
+    def test_nested_pos_choices_partial_overlap_ok(self):
+        class Base(Command):
+            sub_cmd = SubCommand()
+
+        class Show(Base):
+            type = Positional(choices=('foo', 'bar'))
+
+        class ShowFooBaz(Base, choice='show foo baz'):
+            pass
+
+        success_cases = [
+            (['show', 'foo'], {'sub_cmd': 'show', 'type': 'foo'}),
+            (['show', 'bar'], {'sub_cmd': 'show', 'type': 'bar'}),
+            (['show', 'foo', 'baz'], {'sub_cmd': 'show foo baz'}),
+        ]
+        self.assert_parse_results_cases(Base, success_cases)
+
+
+@skip('Implementation is incomplete and not working yet')
+class ParseTreeTestBad(ParserTest):
+    def test_overlap_choice_conflict_bad(self):
+        class Show(Command):
+            sub_cmd = SubCommand()
+
+        class ShowFoo(Show, choice='foo'):
+            type = Positional(choices=('bar', 'baz'))
+
+        class ShowFooBar(Show, choice='foo bar'):
+            pass
+
+        with self.assertRaises(AmbiguousParseTree):
+            Show.parse([])
+
+    def test_overlap_choice_open_bad(self):
+        class Show(Command):
+            sub_cmd = SubCommand()
+
+        class ShowFoo(Show, choice='foo'):
+            type = Positional()
+
+        class ShowFooBar(Show, choice='foo bar'):
+            pass
+
+        with self.assertRaises(AmbiguousParseTree):
+            Show.parse([])
+
+    def test_overlap_deep_choice_conflict_bad(self):
+        class Show(Command):
+            sub_cmd = SubCommand()
+
+        class ShowA(Show, choice='a'):
+            sub_cmd = SubCommand()
+
+        class ShowAB(ShowA, choice='b'):
+            letter = Positional(choices=('c', 'd'))
+
+        class ShowABC(Show, choice='a b c'):
+            pass
+
+        with self.assertRaises(AmbiguousParseTree):
+            Show.parse([])
+
+    def test_overlap_deep_choice_open_bad(self):
+        class Show(Command):
+            sub_cmd = SubCommand()
+
+        class ShowA(Show, choice='a'):
+            sub_cmd = SubCommand()
+
+        class ShowAB(ShowA, choice='b'):
+            letter = Positional()
+
+        class ShowABC(Show, choice='a b c'):
+            pass
+
+        with self.assertRaises(AmbiguousParseTree):
+            Show.parse([])
+
+    def test_overlap_deep_choice_open_unbound_bad(self):
+        class Show(Command):
+            sub_cmd = SubCommand()
+
+        class ShowA(Show, choice='a'):
+            letters = Positional(nargs='+')
+
+        class ShowABC(Show, choice='a b c'):
+            pass
+
+        with self.assertRaises(AmbiguousParseTree):
+            Show.parse([])
+
+    def test_overlap_deep_choice_open_bound_bad(self):
+        class Show(Command):
+            sub_cmd = SubCommand()
+
+        class ShowA(Show, choice='a'):
+            letters = Positional(nargs=2)
+
+        class ShowABC(Show, choice='a b c'):
+            pass
+
+        with self.assertRaises(AmbiguousParseTree):
+            Show.parse([])
+
+    def test_nested_pos_choice_conflict_bad(self):
+        class Base(Command):
+            sub_cmd = SubCommand()
+
+        class Show(Base):
+            type = Positional(choices=('foo', 'foo bar'))
+
+        class ShowFooBar(Base, choice='show foo bar'):
+            pass
+
+        with self.assertRaises(AmbiguousParseTree):
+            Base.parse([])
+
+
+if __name__ == '__main__':
+    # import logging
+    # logging.basicConfig(level=logging.DEBUG, format='%(message)s')
+    try:
+        main(verbosity=2, exit=False)
+    except KeyboardInterrupt:
+        print()

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -181,6 +181,6 @@ if __name__ == '__main__':
     # import logging
     # logging.basicConfig(level=logging.DEBUG, format='%(message)s')
     try:
-        main(warnings='ignore', verbosity=2, exit=False)
+        main(verbosity=2, exit=False)
     except KeyboardInterrupt:
         print()

--- a/tests/test_parsing/test_sub_commands.py
+++ b/tests/test_parsing/test_sub_commands.py
@@ -8,24 +8,6 @@ from cli_command_parser.testing import ParserTest
 
 class SubCmdParsingTest(ParserTest):
     @skip('Cross-param positional conflict detection needs to be implemented')  # TODO #8
-    def test_ambiguous_positional_vs_subcommand_single(self):
-        class Base(Command):
-            sub_cmd = SubCommand()
-
-        class Show(Base):
-            type = Positional(choices=('foo', 'bar'))
-
-        class ShowFooBaz(Base, choice='show foo baz'):
-            pass
-
-        success_cases = [
-            (['show', 'foo'], {'sub_cmd': 'show', 'type': 'foo'}),
-            (['show', 'bar'], {'sub_cmd': 'show', 'type': 'bar'}),
-            (['show', 'foo', 'baz'], {'sub_cmd': 'show foo baz'}),
-        ]
-        self.assert_parse_results_cases(Base, success_cases)
-
-    @skip('Cross-param positional conflict detection needs to be implemented')  # TODO #8
     def test_ambiguous_positional_vs_subcommand_multiple(self):
         class Base(Command):
             sub_cmd = SubCommand()

--- a/tests/test_sub_commands.py
+++ b/tests/test_sub_commands.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from abc import ABC
-from unittest import main, skip
+from unittest import main
 from unittest.mock import Mock
 
 from cli_command_parser import Command, SubCommand, Counter, Option, Positional, Flag
@@ -173,8 +173,8 @@ class SubCommandTest(ParserTest):
         class D(B):
             y = Positional()
 
-        self.assertEqual('1', A.parse_and_run(['b', 'c', '1']).x)
-        self.assertEqual('2', A.parse_and_run(['b', 'd', '2']).y)
+        self.assertEqual('1', A.parse(['b', 'c', '1']).x)
+        self.assertEqual('2', A.parse(['b', 'd', '2']).y)
 
     def test_choices(self):
         class Foo(Command):
@@ -224,48 +224,6 @@ class SubCommandTest(ParserTest):
             ]
             self.assert_parse_results_cases(Base, success_cases)
             self.assert_parse_fails(Base, ['mid'])
-
-    @skip('Cross-param positional conflict detection needs to be implemented')  # TODO #8
-    def test_cross_param_positional_conflict_partial_1(self):
-        with self.assertRaises(CommandDefinitionError):
-
-            class Base(Command):
-                sub_cmd = SubCommand()
-
-            class Show(Base):
-                type = Positional(choices=('foo', 'bar'))
-
-            class ShowBaz(Base, choice='show baz'):
-                pass
-
-            class ShowFooBars(Base, choice='show foo bars'):
-                pass
-
-    @skip('Cross-param positional conflict detection needs to be implemented')  # TODO #8
-    def test_cross_param_positional_conflict_partial_2(self):
-        with self.assertRaises(CommandDefinitionError):
-
-            class Base(Command):
-                sub_cmd = SubCommand()
-
-            class Show(Base):
-                type = Positional(choices=('foo', 'bar'))
-
-            class ShowFooBaz(Base, choice='show foo baz'):
-                pass
-
-    @skip('Cross-param positional conflict detection needs to be implemented')  # TODO #8
-    def test_cross_param_positional_conflict_exact(self):
-        with self.assertRaises(CommandDefinitionError):
-
-            class Base(Command):
-                sub_cmd = SubCommand()
-
-            class Show(Base):
-                type = Positional(choices=('foo', 'foo bar'))
-
-            class ShowFooBar(Base, choice='show foo bar'):
-                pass
 
 
 if __name__ == '__main__':

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3,7 +3,7 @@
 from unittest import TestCase, main
 from unittest.mock import Mock, patch
 
-from cli_command_parser.utils import camel_to_snake_case, get_args, Terminal
+from cli_command_parser.utils import camel_to_snake_case, get_args, Terminal, short_repr
 from cli_command_parser.formatting.utils import _description_start_line, _norm_column, _single_line_strs
 
 
@@ -38,6 +38,17 @@ class UtilsTest(TestCase):
         self.assertListEqual(['a', 'b'], _single_line_strs(['a\nb']))
         self.assertListEqual(['a', 'b'], _single_line_strs(['a', 'b']))
         self.assertListEqual(['a', 'b', 'c'], _single_line_strs(['a', 'b\nc']))
+
+    def test_short_repr(self):
+        for case in (20, 97, 98):
+            with self.subTest(len=case):
+                text = 'x' * case
+                self.assertEqual(repr(text), short_repr(text))
+
+        expected = repr('x' * 47 + '...' + 'x' * 47)
+        for case in (99, 200):
+            with self.subTest(len=case):
+                self.assertEqual(expected, short_repr('x' * case))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR addresses issue #8 

Implemented a way to validate that nested combinations of positional Parameter choices across multiple Subcommands / Parameters do not overlap in such a way that they would cause significant ambiguity as to what the correct handling should be when parsing.  Some combinations may pass this validation and still cause issues when parsing, but such cases are relatively rare and workarounds exist to avoid the ambiguity.

An attempt was made to update the `CommandParser` class to also use the new `PosNode` tree during parsing for Positional params, but relatively deep and invasive changes are necessary to do so.