### PR TITLE
Minor RstWriter.document_module bug fix + documentation updates

### DIFF
--- a/docs/_src/configuration.rst
+++ b/docs/_src/configuration.rst
@@ -17,6 +17,7 @@ keyword arguments when defining a Command subclass.  All of these options are op
 :choices: SubCommand values to map to this command.  Similar to ``choice``, but accepts multiple values.  A mapping
   of ``{choice: help text}`` may be provided to customize the help text displayed for each choice.
 :prog: The name of the program (default: ``sys.argv[0]``)
+:doc_name: The name of the program / title to use in documentation
 :usage: Usage message to be printed with help text or when incorrect arguments are provided (default:
   auto-generated)
 :description: Description of what the program does.  If the Command contains a class-level docstring, then that

--- a/lib/cli_command_parser/documentation.py
+++ b/lib/cli_command_parser/documentation.py
@@ -150,6 +150,19 @@ def _is_command(obj) -> bool:
 
 
 class RstWriter:
+    """
+    A helper class for generating RST documentation for a Python package and/or scripts containing Commands.
+
+    :param output_dir: Directory in which RST files should be written.
+    :param dry_run: If True, log the actions that would be taken instead of taking them.
+    :param encoding: The text encoding to use for output.
+    :param newline: The newline character to use for output.
+    :param ext: The file extension / suffix (including the leading ``.``) to use for output.
+    :param module_template: The format string to use when generating RST for Python modules.
+    :param skip_modules: A collection of module names (using ``package.module`` notation) that should be skipped
+      when documenting a Python package via :meth:`.document_package`.
+    """
+
     def __init__(
         self,
         output_dir: PathLike,
@@ -178,6 +191,24 @@ class RstWriter:
         top_only: Bool = True,
         **kwargs,
     ) -> str:
+        """
+        Generate an RST file to document a Python script containing one or more Command classes.
+
+        :param path: Path for a file containing one or more Command classes.
+        :param subdir: If specified, write RST output for this script in this subdirectory, relative to the specified
+          :paramref:`output_dir<RstWriter.output_dir>`.
+        :param name: Replacement name to use as the stem of the RST file name and as the title of the page.  To replace
+          the RST file name, but preserve default behavior for the page title, use ``fix_name=False`` with this param.
+          The default page title is based on the name of the file that contains the Command, but can be overridden by
+          providing a :ref:`configuration:Command Metadata:doc_name` value when defining the Command.
+        :param replacements: A mapping of simple string replacements to apply to the generated RST content before
+          saving it.  For each key=value pair, ``rst_str = rst_str.replace(key, value)`` will be performed.
+        :param top_only: If True (the default), then only top-level commands in the given file will be documented,
+          otherwise all commands will be documented.  When True, subcommands of the discovered top-level commands will
+          still be documented.
+        :param kwargs: Additional keyword arguments to pass to :func:`render_script_rst`
+        :return: The stem of the file name that was used when saving the RST content for the given script.
+        """
         if name:
             kwargs['fix_name_func'] = lambda n: name
             rst_name = Path(name).stem
@@ -210,8 +241,15 @@ class RstWriter:
             self.write_index(name, index_header or name.title(), names, subdir, caption, index_subdir)
 
     def document_module(self, module: str, subdir: str = None):
+        """
+        Generate an RST file to document a Python module.
+
+        :param module: The name of the module that should be documented, using ``package.module`` notation.
+        :param subdir: If specified, write RST output for the specified module in this subdirectory, relative to the
+          specified :paramref:`output_dir<RstWriter.output_dir>`.
+        """
         name = module.split('.')[-1].title()
-        rendered = MODULE_TEMPLATE.format(header=rst_header(f'{name} Module', 2), module=module)
+        rendered = self.module_template.format(header=rst_header(f'{name} Module', 2), module=module)
         self.write_rst(module, rendered, subdir)
 
     def document_package(

--- a/lib/cli_command_parser/formatting/params.py
+++ b/lib/cli_command_parser/formatting/params.py
@@ -7,7 +7,7 @@ Parameter usage / help text formatters
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Union, Type, Callable, Iterator, Iterable, Tuple, Dict
+from typing import TYPE_CHECKING, Type, Callable, Iterator, Iterable, Tuple, Dict
 
 try:
     from functools import cached_property
@@ -404,6 +404,7 @@ class PassThruHelpFormatter(ParamHelpFormatter, param_cls=PassThru):
 
 class GroupHelpFormatter(ParamHelpFormatter, param_cls=ParamGroup):  # noqa  # pylint: disable=W0223
     required_formatter_map: BoolFormatterMap = {True: '{{{}}}'.format, False: '[{}]'.format}
+    # TODO: #18 Group order changes between invocations - should be sorted as declared or alphanumerically (config?)
 
     def _get_choice_delim(self) -> str:
         param: ParamGroup = self.param

--- a/tests/test_documentation/test_user_docs.py
+++ b/tests/test_documentation/test_user_docs.py
@@ -55,11 +55,12 @@ def get_func_params(func: Callable, skip: Collection[str] = None) -> Set[str]:
 
 class UserDocsTest(TestCase):
     def test_command_kwargs_up_to_date(self):
-        doc_params = get_doc_params('configuration.rst', 'Command Metadata', 'Configuration Options')
-        doc_ignore = {'description', 'prog', 'epilog', 'usage'}
-        doc_params = set(doc_params).difference(doc_ignore)
+        doc_params = set(get_doc_params('configuration.rst', 'Command Metadata', 'Configuration Options'))
+
+        meta_kwargs = {'prog', 'usage', 'description', 'epilog', 'doc_name'}
         cmd_params = get_func_params(CommandMeta.__new__, ('mcs', 'name', 'bases', 'namespace', 'kwargs'))
-        self.assertSetEqual(doc_params, cmd_params)
+
+        self.assertSetEqual(doc_params, cmd_params | meta_kwargs)
 
     def test_config_options_up_to_date(self):
         doc_params = get_doc_params('configuration.rst', 'Configuration Options')


### PR DESCRIPTION
- Fixed `RstWriter.document_module` to use `self.module_template` instead of the global `MODULE_TEMPLATE`
- Expanded `RstWriter` docstrings to provide more info about `document_script` params
- Added an entry for `doc_name` in the configuration documentation