### PR TITLE
Added argparse conversion script

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -31,7 +31,7 @@ jobs:
         run: |
           python -m pip install --upgrade pip setuptools wheel
           python -m pip install flake8 pytest pytest-cov
-          pip install -e .[wcwidth]
+          pip install -e .[wcwidth,conversion]
       - name: Lint with flake8
         run: |
           # stop the build if there are Python syntax errors or undefined names

--- a/bin/argparse_to_command.py
+++ b/bin/argparse_to_command.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from cli_command_parser import Command, Counter, Positional, Flag, ParamGroup, SubCommand, main
+from cli_command_parser.compat import cached_property
+from cli_command_parser.inputs import Path as IPath
+
+log = logging.getLogger(__name__)
+
+arg_parser = 'argparse.ArgumentParser'
+cli_cp_cmd = 'cli-command-parser Command'
+
+
+class ParserConverter(Command, description=f'Tool to convert an {arg_parser} into a {cli_cp_cmd}'):
+    action = SubCommand()
+    input: Path
+    # fmt: off
+    smart_for = Flag(
+        '--no-smart-for', '-S', default=True, help='Disable "smart" for loop handling, which attempts to dedupe common subparser params'
+    )
+    # fmt: on
+    with ParamGroup('Common'):
+        verbose = Counter('-v', help='Increase logging verbosity (can specify multiple times)')
+        dry_run = Flag('-D', help='Print the actions that would be taken instead of taking them')
+
+    def _init_command_(self):
+        log_fmt = '%(asctime)s %(levelname)s %(name)s %(lineno)d %(message)s' if self.verbose > 1 else '%(message)s'
+        logging.basicConfig(level=logging.DEBUG if self.verbose else logging.INFO, format=log_fmt)
+
+    @cached_property
+    def script(self):
+        from cli_command_parser.conversion import Script
+
+        script = Script(self.input.read_text(), self.smart_for, path=self.input)
+        log.debug(f'Found script={script!r}')
+        return script
+
+
+class Convert(ParserConverter):
+    input: Path = Positional(type=IPath(type='file', exists=True), help=f'A file containing an {arg_parser}')
+
+    def main(self):
+        from cli_command_parser.conversion import convert_script
+
+        print(convert_script(self.script))
+
+
+class Pprint(ParserConverter):
+    input: Path = Positional(type=IPath(type='file', exists=True), help=f'A file containing an {arg_parser}')
+
+    def main(self):
+        for parser in self.script.parsers:
+            parser.pprint()
+
+
+if __name__ == '__main__':
+    main()

--- a/lib/cli_command_parser/conversion/__init__.py
+++ b/lib/cli_command_parser/conversion/__init__.py
@@ -1,0 +1,3 @@
+from .argparse_ast import Script, AstCallable, ArgCollection, AstArgumentParser, SubParser, AddVisitedChild, visit_func
+from .argparse_ast import ArgGroup, MutuallyExclusiveGroup
+from .command_builder import Converter, convert_script

--- a/lib/cli_command_parser/conversion/__main__.py
+++ b/lib/cli_command_parser/conversion/__main__.py
@@ -1,0 +1,2 @@
+# pylint: disable=W0401,W0611
+from . import *  # noqa

--- a/lib/cli_command_parser/conversion/argparse_ast.py
+++ b/lib/cli_command_parser/conversion/argparse_ast.py
@@ -1,0 +1,361 @@
+from __future__ import annotations
+
+import ast
+import logging
+import sys
+from argparse import ArgumentParser
+from ast import Assign, Call, withitem
+from functools import partial
+from inspect import Signature, BoundArguments
+from pathlib import Path
+from typing import TYPE_CHECKING, Union, Optional, Callable, Collection, TypeVar, Generic, Type, Iterator
+from typing import List, Tuple, Dict, Set
+
+from cli_command_parser.compat import cached_property
+from .argparse_utils import ArgumentParser as _ArgumentParser, SubParsersAction as _SubParsersAction
+from .utils import get_name_repr
+
+if TYPE_CHECKING:
+    from cli_command_parser.typing import PathLike
+    from .visitor import TrackedRefMap, TrackedRef
+
+__all__ = ['ParserArg', 'ArgGroup', 'MutuallyExclusiveGroup', 'AstArgumentParser', 'SubParser', 'Script']
+log = logging.getLogger(__name__)
+
+InitNode = Union[Call, Assign, withitem]
+OptCall = Optional[Call]
+ParserCls = Type['AstArgumentParser']
+ParserObj = TypeVar('ParserObj', bound='AstArgumentParser')
+RepresentedCallable = TypeVar('RepresentedCallable', bound=Callable)
+AC = TypeVar('AC', bound='AstCallable')
+D = TypeVar('D')
+_NotSet = object()
+
+
+class Script:
+    _parser_classes = {}
+    path: Optional[Path]
+
+    def __init__(self, src_text: str, smart_loop_handling: bool = True, path: PathLike = None):
+        self.smart_loop_handling = smart_loop_handling
+        self._parsers = []
+        self.path = Path(path) if path else None
+        self.src_text = src_text
+        parse_args = (self.src_text, self.path.as_posix()) if self.path else (self.src_text,)
+        self.root_node = ast.parse(*parse_args)
+
+    def __repr__(self) -> str:
+        parsers = len(self.parsers)
+        return f'<{self.__class__.__name__}[{parsers=} @ {self.path.as_posix()}]>'
+
+    @property
+    def mod_cls_to_ast_cls_map(self) -> dict[str, dict[str, ParserCls]]:
+        return self._parser_classes
+
+    @classmethod
+    def _register_parser(cls, real_cls: Type[ArgumentParser], ast_cls: ParserCls):
+        module, name = real_cls.__module__, real_cls.__name__
+        # Identify package-level exports that may have been defined for a custom ArgumentParser subclass
+        modules = [module]
+        while (parent := module.rsplit('.', 1)[0]) != module:
+            if name in vars(sys.modules[parent]):
+                modules.append(parent)
+            module = parent
+
+        for module in modules:
+            log.debug(f'Registering {module}.{name} -> {ast_cls}')
+            cls._parser_classes.setdefault(module, {})[name] = ast_cls
+
+    @classmethod
+    def register_parser(cls, ast_cls: ParserCls):
+        cls._register_parser(ast_cls.represents, ast_cls)
+        return ast_cls
+
+    def add_parser(self, ast_cls: ParserCls, node: InitNode, call: OptCall, tracked_refs: TrackedRefMap) -> ParserObj:
+        parser = ast_cls(node, self, tracked_refs, call)
+        self._parsers.append(parser)
+        return parser
+
+    @cached_property
+    def parsers(self) -> list[ParserObj]:
+        from .visitor import ScriptVisitor, TrackedRef  # noqa: F811
+
+        track_refs = (TrackedRef('argparse.REMAINDER'), TrackedRef('argparse.SUPPRESS'))
+        visitor = ScriptVisitor(self.smart_loop_handling, track_refs=track_refs)
+        for module, name_cls_map in self.mod_cls_to_ast_cls_map.items():
+            for name, ast_cls in name_cls_map.items():
+                visitor.track_callable(module, name, partial(self.add_parser, ast_cls))
+
+        visitor.visit(self.root_node)
+        return self._parsers
+
+
+# region Decorators & Descriptors
+
+
+class visit_func:
+    """A method that can be called by an AST visitor."""
+
+    __slots__ = ('func',)
+
+    def __init__(self, func):
+        self.func = func
+
+    def __set_name__(self, owner: Type[AstCallable], name: str):
+        owner._add_visit_func(name)
+        setattr(owner, name, self.func)  # There's no need to keep the descriptor - replace self with func
+
+    def __get__(self, instance, owner):
+        # This will never actually be called, but it makes PyCharm happy
+        return self if instance is None else partial(self.func, instance)
+
+
+class AddVisitedChild(Generic[AC]):
+    """Simplifies the definition of an add_child method that can be called by an AST visitor, where possible."""
+
+    __slots__ = ('child_cls', 'list_attr')
+
+    def __init__(self, child_cls: Type[AC], attr: str):
+        self.child_cls = child_cls
+        self.list_attr = attr
+
+    def __set_name__(self, owner: Type[ArgCollection], name: str):
+        owner._add_visit_func(name)
+
+    def __get__(self, instance: ArgCollection, owner) -> Callable[[InitNode, Call, TrackedRefMap], AC]:
+        if instance is None:
+            return self  # noqa
+        return partial(instance._add_child, self.child_cls, getattr(instance, self.list_attr))  # noqa
+
+
+# endregion
+
+
+class AstCallable:
+    represents: RepresentedCallable
+    visit_funcs = set()
+    _sig: Signature | None = None
+
+    @classmethod
+    def _add_visit_func(cls, name: str):
+        try:
+            parent_visit_funcs = cls.__base__.visit_funcs  # noqa
+        except AttributeError:
+            pass
+        else:  # Note: __init_subclass__ is called after __set_name__ is called for members
+            if parent_visit_funcs is cls.visit_funcs:
+                cls.visit_funcs = cls.visit_funcs.copy()
+        cls.visit_funcs.add(name)
+
+    def __init_subclass__(cls, represents: RepresentedCallable = None, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if represents:
+            cls.represents = represents
+            cls._sig = None
+
+    def __init__(self, node: InitNode, parent: AstCallable | Script, tracked_refs: TrackedRefMap, call: Call = None):
+        self.init_node = node
+        if not call:
+            call = node.value if isinstance(node, Assign) else node  # type: Call
+        self.call_node = call
+        self.call_args = call.args
+        self.call_kwargs = call.keywords
+        self._tracked_refs = tracked_refs
+        self.parent = parent
+        self.names = set()
+
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__}[{self.init_call_repr()}]>'
+
+    def get_tracked_refs(self, module: str, name: str, default: D = _NotSet) -> Union[Set[str], D]:
+        for tracked_ref, refs in self._tracked_refs.items():
+            if tracked_ref.module == module and tracked_ref.name == name:
+                return refs
+        if default is not _NotSet:
+            return default
+        raise KeyError(f'No tracked ref found for {module}.{name}')
+
+    # region Initialization Call
+
+    @classmethod
+    def _signature(cls) -> Signature:
+        if not cls._sig:
+            cls._sig = Signature.from_callable(cls.represents)
+        return cls._sig
+
+    @property
+    def signature(self) -> Signature:
+        return self._signature()
+
+    @cached_property
+    def init_func_name(self) -> str:
+        """The name or alias of the function/callable that was used to initialize this object"""
+        return get_name_repr(self.call_node.func)
+
+    @cached_property
+    def _init_func_bound(self) -> BoundArguments:
+        args = self.call_args if isinstance(self.represents, type) else ('self', *self.call_args)
+        return self.signature.bind(*args, **{kw.arg: kw.value for kw in self.call_kwargs})
+
+    @cached_property
+    def init_func_args(self) -> list[str]:
+        try:
+            args = self._init_func_bound.args[1:]
+        except (TypeError, AttributeError):  # No represents func
+            args = self.call_args
+        return [ast.unparse(arg) for arg in args]
+
+    def _init_func_kwargs(self) -> dict[str, str]:
+        try:
+            kwargs = self._init_func_bound.arguments
+        except (TypeError, AttributeError):  # No represents func
+            kwargs = {kw.arg: kw.value for kw in self.call_kwargs}
+        else:
+            kwargs = kwargs.copy()
+            kwargs.pop('self', None)
+            if isinstance(kwargs.get('args'), tuple):
+                kwargs.pop('args')
+            if isinstance(kwargs.get('kwargs'), dict):
+                kwargs.update(kwargs.pop('kwargs'))
+        return {key: ast.unparse(val) for key, val in kwargs.items()}
+
+    @cached_property
+    def init_func_kwargs(self) -> dict[str, str]:
+        return self._init_func_kwargs()
+
+    def init_call_repr(self) -> str:
+        arg_str = ', '.join(self.init_func_args)
+        kw_str = ', '.join(f'{k}={v}' for k, v in self.init_func_kwargs.items())
+        if kw_str:
+            arg_str = kw_str if not arg_str else (arg_str + ', ' + kw_str)
+        return f'{self.init_func_name}({arg_str})'
+
+    # endregion
+
+    def pprint(self, indent: int = 0):
+        print(f'{" " * indent} - {self!r}')
+
+
+# region Stdlib Argparse Wrappers
+
+
+class ParserArg(AstCallable, represents=ArgumentParser.add_argument):
+    parent: ArgCollection
+
+
+class ArgCollection(AstCallable):
+    parent: ArgCollection | Script
+    _children = ('args', 'groups')
+    args: List[ParserArg]
+    groups: List[ArgGroup]
+    add_argument = AddVisitedChild(ParserArg, 'args')
+
+    def __init_subclass__(cls, children: Collection[str] = (), **kwargs):
+        super().__init_subclass__(**kwargs)
+        if children:
+            cls._children = (*cls._children, *children)
+
+    def __init__(self, node: InitNode, parent: AstCallable | Script, tracked_refs: TrackedRefMap, call: Call = None):
+        super().__init__(node, parent, tracked_refs, call)
+        self.args = []
+        self.groups = []
+
+    @cached_property
+    def is_stdlib(self) -> bool:
+        parent = self.parent
+        while parent:
+            try:
+                return parent.is_stdlib
+            except AttributeError:
+                parent = parent.parent
+        return True
+
+    def __repr__(self) -> str:
+        stdlib = self.is_stdlib
+        return f'<{self.__class__.__name__}[{stdlib=}]: ``{" = ".join(sorted(self.names))} = {self.init_call_repr()}``>'
+
+    def _add_child(self, cls: Type[AC], container: List[AC], node: InitNode, call: Call, refs: TrackedRefMap) -> AC:
+        child = cls(node, self, refs, call)
+        container.append(child)
+        return child
+
+    @visit_func
+    def add_mutually_exclusive_group(self, node: InitNode, call: Call, tracked_refs: TrackedRefMap):
+        return self._add_child(MutuallyExclusiveGroup, self.groups, node, call, tracked_refs)
+
+    @visit_func
+    def add_argument_group(self, node: InitNode, call: Call, tracked_refs: TrackedRefMap):
+        return self._add_child(ArgGroup, self.groups, node, call, tracked_refs)
+
+    def grouped_children(self) -> Iterator[Tuple[Type[AC], List[AC]]]:
+        yield ParserArg, self.args
+        yield ArgGroup, self.groups
+
+    # region Output Methods
+
+    def pprint(self, indent: int = 0):
+        print(f'{" " * indent} + {self!r}:')
+        indent += 3
+        for attr in self._children:
+            if values := getattr(self, attr):
+                for value in values:
+                    value.pprint(indent)
+
+    # endregion
+
+
+class ArgGroup(ArgCollection, represents=_ArgumentParser.add_argument_group):
+    pass
+
+
+class MutuallyExclusiveGroup(ArgGroup, represents=_ArgumentParser.add_mutually_exclusive_group):
+    pass
+
+
+class SubparsersAction(AstCallable, represents=_ArgumentParser.add_subparsers):
+    parent: ParserObj
+
+    @visit_func
+    def add_parser(self, node: InitNode, call: Call, tracked_refs: TrackedRefMap):
+        sub_parser = self.parent._add_subparser(node, call, tracked_refs)
+        sub_parser.sp_parent = self
+        return sub_parser
+
+
+@Script.register_parser
+class AstArgumentParser(ArgCollection, represents=ArgumentParser, children=('sub_parsers',)):
+    is_stdlib: bool = True
+    sub_parsers: List[SubParser]
+    add_subparsers = AddVisitedChild(SubparsersAction, '_subparsers_actions')
+
+    def __init_subclass__(cls, is_stdlib: bool = False, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.is_stdlib = is_stdlib
+
+    def __init__(self, node: InitNode, parent: AstCallable | Script, tracked_refs: TrackedRefMap, call: Call = None):
+        super().__init__(node, parent, tracked_refs, call)
+        self._subparsers_actions = []
+        # Note: sub_parsers aren't included in grouped_children since they need different handling during conversion
+        self.sub_parsers = []
+
+    def __repr__(self) -> str:
+        stdlib, sub_parsers = self.is_stdlib, len(self.sub_parsers)
+        assign_repr = f'``{" = ".join(sorted(self.names))} = {self.init_call_repr()}``'
+        return f'<{self.__class__.__name__}[{stdlib=}, {sub_parsers=}]: {assign_repr}>'
+
+    def _add_subparser(self, node: InitNode, call: Call, tracked_refs: TrackedRefMap, sub_parser_cls: ParserCls = None):
+        # Using default of None since the class hasn't been defined at the time it would need to be set as default
+        return self._add_child(sub_parser_cls or SubParser, self.sub_parsers, node, call, tracked_refs)
+
+
+class SubParser(AstArgumentParser, represents=_SubParsersAction.add_parser, is_stdlib=True):
+    sp_parent: SubparsersAction = None
+
+    @cached_property
+    def init_func_kwargs(self) -> dict[str, str]:
+        if sp_parent := self.sp_parent:
+            return sp_parent.init_func_kwargs | self._init_func_kwargs()
+        return self._init_func_kwargs()
+
+
+# endregion

--- a/lib/cli_command_parser/conversion/argparse_utils.py
+++ b/lib/cli_command_parser/conversion/argparse_utils.py
@@ -1,0 +1,32 @@
+"""
+Typing helpers to make it easier to use Signature.from_callable for automatic conversion of positional to keyword args.
+"""
+
+from argparse import ArgumentParser as _ArgumentParser, _SubParsersAction  # noqa
+
+__all__ = ['ArgumentParser', 'SubParsersAction']
+
+
+class ArgumentParser(_ArgumentParser):
+    def add_argument_group(
+        self, title=None, description=None, *, prefix_chars=None, argument_default=None, conflict_handler=None
+    ):
+        kwargs = {k: v for k, v in locals().items() if k not in {'self', '__class__'} and v is not None}
+        return super().add_argument_group(**kwargs)
+
+    def add_mutually_exclusive_group(self, *, required=False):
+        return super().add_mutually_exclusive_group(required=required)
+
+    # fmt: off
+    def add_subparsers(
+        self, *, title=None, description=None, prog=None, dest=None, help=None,  # noqa
+        action=None, option_string=None, required=None, metavar=None,
+    ):
+        kwargs = {k: v for k, v in locals().items() if k not in {'self', '__class__'} and v is not None}
+        return super().add_subparsers(**kwargs)
+    # fmt: on
+
+
+class SubParsersAction(_SubParsersAction):
+    def add_parser(self, name, *, aliases=(), description=None, prog=None, help=None):  # noqa
+        return super().add_parser(name, aliases=aliases, description=description, prog=prog, help=help)

--- a/lib/cli_command_parser/conversion/command_builder.py
+++ b/lib/cli_command_parser/conversion/command_builder.py
@@ -360,7 +360,7 @@ class ParamConverter(Converter, converts=ParserArg):
 
         if self.is_positional:
             if action and action not in ('store', 'append'):
-                raise ConversionError(f'{self.ast_obj}: {action=} is not supported for Positional parameters')
+                raise ConversionError(f'{self.ast_obj}: action={action!r} is not supported for Positional parameters')
             return 'Positional', ParamArgs.init_positional(action, **kwargs)
         elif self.is_option:
             kwargs['name_mode'] = self.name_mode
@@ -370,7 +370,7 @@ class ParamConverter(Converter, converts=ParserArg):
                 elif action == 'count':
                     return 'Counter', FlagArgs.init_counter(**kwargs)
                 elif action not in ('store', 'append'):
-                    raise ConversionError(f'{self.ast_obj}: {action=} is not supported for Option parameters')
+                    raise ConversionError(f'{self.ast_obj}: action={action!r} is not supported for Option parameters')
             return 'Option', OptionArgs.init_option(self.ast_obj, action, **kwargs)
 
         raise ConversionError(f'Unable to determine a suitable Parameter type for {self.ast_obj!r}')

--- a/lib/cli_command_parser/conversion/command_builder.py
+++ b/lib/cli_command_parser/conversion/command_builder.py
@@ -1,0 +1,593 @@
+from __future__ import annotations
+
+import keyword
+import logging
+from abc import ABC, abstractmethod
+from ast import literal_eval
+from dataclasses import dataclass, fields
+from itertools import count
+from typing import TYPE_CHECKING, Union, Optional, Iterator, Iterable, Type, TypeVar, Generic, List, Tuple, Dict, Set
+
+from cli_command_parser.compat import cached_property
+from cli_command_parser.nargs import Nargs
+from .argparse_ast import AC, ParserArg, ArgGroup, MutuallyExclusiveGroup, AstArgumentParser, Script
+
+if TYPE_CHECKING:
+    from cli_command_parser.typing import OptStr
+    from .argparse_ast import ArgCollection
+
+__all__ = ['convert_script']
+log = logging.getLogger(__name__)
+
+C = TypeVar('C', bound='Converter')
+
+RESERVED = set(keyword.kwlist) | set(keyword.softkwlist)
+
+
+def convert_script(script: Script) -> str:
+    return ScriptConverter(script).convert()
+
+
+class Converter(ABC):
+    converts: Type[AC] = None
+    _ac_converter_map = {}
+
+    def __init_subclass__(cls, converts: Type[AC] = None, **kwargs):
+        super().__init_subclass__(**kwargs)
+        if converts:
+            cls.converts = converts
+            cls._ac_converter_map[converts] = cls
+
+    def __init__(self, ast_obj: Union[AC, Script], parent: Optional[Converter] = None):
+        self.ast_obj = ast_obj
+        self.parent = parent
+
+    @classmethod
+    def for_ast_callable(cls, ast_obj: Union[AC, Type[AC]]) -> Converter:
+        if not isinstance(ast_obj, type):
+            ast_obj = ast_obj.__class__
+        try:
+            return cls._ac_converter_map[ast_obj]
+        except KeyError:
+            pass
+        for converts_cls, converter_cls in cls._ac_converter_map.items():
+            if issubclass(ast_obj, converts_cls):
+                return converter_cls
+        raise TypeError(f'No Converter is registered for {ast_obj.__class__.__name__} objects')
+
+    @classmethod
+    def init_group(cls: Type[C], parent: CollectionConverter, ast_objs: List[AC]) -> ConverterGroup[C]:
+        return ConverterGroup(parent, [cls(ast_obj, parent) for ast_obj in ast_objs])
+
+    def convert(self, indent: int = 0) -> str:
+        return '\n'.join(self.format_lines(indent))
+
+    @abstractmethod
+    def format_lines(self, indent: int = 0) -> Iterator[str]:
+        raise NotImplementedError
+
+
+class ConverterGroup(Generic[C]):
+    __slots__ = ('parent', 'members')
+
+    def __init__(self, parent: CollectionConverter, members: List[C]):
+        self.parent = parent
+        self.members = members
+
+    def __len__(self) -> int:
+        return len(self.members)
+
+    def __getitem__(self, index: int) -> C:
+        return self.members[index]
+
+    def __iter__(self) -> Iterator[C]:
+        yield from self.members
+
+    def format_all(self, indent: int = 0) -> Iterator[str]:
+        for member in self.members:
+            yield from member.format_lines(indent)
+
+
+class ScriptConverter(Converter, converts=Script):
+    def format_lines(self, indent: int = 0) -> Iterator[str]:
+        # TODO: Filter to what is actually used
+        yield (
+            'from cli_command_parser import'
+            ' Command, SubCommand, ParamGroup, Positional, Option, Flag, Counter, PassThru, main'
+        )
+        for parser in self.ast_obj.parsers:
+            yield from ParserConverter(parser).format_lines()
+
+
+class CollectionConverter(Converter, ABC):
+    ast_obj: ArgCollection
+    parent: CollectionConverter | None
+    _name_mode = None
+
+    @cached_property
+    def name_mode(self) -> str | None:
+        return self._name_mode or (self.parent.name_mode if self.parent else None)
+
+    @cached_property
+    def grouped_children(self) -> List[ConverterGroup[ParamConverter | GroupConverter | Converter]]:
+        return [self.for_ast_callable(cg_cls).init_group(self, cg) for cg_cls, cg in self.ast_obj.grouped_children()]
+
+    def descendant_args(self) -> Iterator[ParamConverter]:
+        for child_group in self.grouped_children:
+            if not child_group.members:
+                continue
+            elif hasattr(child_group[0], 'descendant_args'):
+                for child in child_group:
+                    yield from child.descendant_args()
+            elif isinstance(child_group[0], ParamConverter):
+                yield from child_group
+
+    def format_members(self, prefix: str, indent: int = 4) -> Iterator[str]:
+        for child_group in self.grouped_children:
+            yield from child_group.format_all(indent)
+
+        if not any(cg for cg in self.grouped_children):
+            yield f'{prefix}    pass'
+
+
+class ParserConverter(CollectionConverter, converts=AstArgumentParser):
+    _auto_gen_disclaimer = '# This is an automatically generated name that should probably be updated'
+    ast_obj: AstArgumentParser
+    parent: ParserConverter | None
+
+    def __init__(self, parser: AstArgumentParser, parent: ParserConverter = None, counter: count = None):
+        super().__init__(parser, parent)
+        self.counter = count() if counter is None else counter
+
+    @cached_property
+    def sub_parser_converters(self) -> List[ParserConverter]:
+        return [self.__class__(sub_parser, self, self.counter) for sub_parser in self.ast_obj.sub_parsers]
+
+    def descendant_args(self) -> Iterator[ParamConverter]:
+        yield from super().descendant_args()
+        for sp_converter in self.sub_parser_converters:
+            yield from sp_converter.descendant_args()
+
+    def format_lines(self, indent: int = 0) -> Iterator[str]:
+        suffix = f'  {self._auto_gen_disclaimer}' if self.parent is None else ''
+        yield '\n'
+        yield f'class {self.name}({self._get_args()}):{suffix}'
+        yield from self.format_members('')
+        for sp_converter in self.sub_parser_converters:
+            yield from sp_converter.format_lines()
+
+    def _get_args(self) -> str:
+        # log.debug(f'Processing args for {parser._init_func_bound}')
+        kwargs = self.ast_obj.init_func_kwargs.copy()
+        kwargs['option_name_mode'] = self._name_mode
+        if self.is_sub_parser:
+            if choices := self.choices:
+                if len(choices) > 1:
+                    kwargs['choices'] = f'({", ".join(choices)})'
+                elif not self._custom_name:
+                    kwargs['choice'] = choices[0]
+        elif (add_help := kwargs.get('add_help')) and literal_eval_or_none(add_help) == 'True':
+            kwargs.pop('add_help')
+
+        cmd_args = CommandArgs.from_kwargs(**kwargs)
+        return cmd_args.to_str(self.parent.name if self.parent else 'Command')
+
+    @cached_property
+    def is_sub_parser(self) -> bool:
+        return self.parent is not None
+
+    # region Name / CLI Choices
+
+    @cached_property
+    def name(self) -> str:
+        return self._custom_name or f'Command{next(self.counter)}'
+
+    @cached_property
+    def _custom_name(self) -> str | None:
+        if not self.is_sub_parser or not (name := literal_eval_or_none(self.ast_obj.init_func_kwargs.get('name'))):
+            return None
+        if not name or ' ' in name or '-' in name or not name[0].isalpha():
+            return None
+        return name.title().replace('_', '')
+
+    @cached_property
+    def choices(self) -> List[str]:
+        choices = []
+        if not self.is_sub_parser:
+            return choices
+
+        kwargs = self.ast_obj.init_func_kwargs
+        if name := kwargs.get('name'):
+            choices.append(name)
+        if aliases := kwargs.get('aliases'):
+            choices.extend(aliases)
+        return choices
+
+    # endregion
+
+    # region Member-Related Properties
+
+    @cached_property
+    def name_mode(self) -> str | None:
+        return self._name_mode or (self.parent.name_mode if self.parent else None)
+
+    @cached_property
+    def _name_mode(self) -> str | None:
+        if self.parent and self.parent._name_mode:
+            return None
+        name_modes = {pc._name_mode for pc in self.descendant_args() if pc.is_option and '_' in pc.attr_name}
+        return next(iter(name_modes)) if len(name_modes) == 1 else None
+
+    # endregion
+
+
+class GroupConverter(CollectionConverter, converts=ArgGroup):
+    ast_obj: ArgGroup
+
+    def format_lines(self, indent: int = 4) -> Iterator[str]:
+        prefix = ' ' * indent
+        yield f'\n{prefix}with ParamGroup({self._get_args()}):'
+        yield from self.format_members(prefix, indent + 4)
+
+    def _get_args(self) -> str:
+        # log.debug(f'Processing args for {self.ast_obj._init_func_bound}')
+        description = self.ast_obj.init_func_kwargs.get('description')
+        if title := self.ast_obj.init_func_kwargs.get('title'):
+            title_str = literal_eval(title)
+            if title_str.lower().endswith(' options'):
+                if description:
+                    title = repr(title_str[:-7].rstrip())
+                else:
+                    description, title = title, None
+
+        args = [title] if title else []
+        if description:
+            args.append(f'description={description}')
+        if isinstance(self.ast_obj, MutuallyExclusiveGroup):
+            args.append('mutually_exclusive=True')
+        return ', '.join(args)
+
+
+class ParamConverter(Converter, converts=ParserArg):
+    ast_obj: ParserArg
+    parent: CollectionConverter | None
+    _counter = count()
+
+    def __init__(self, arg: ParserArg, parent: CollectionConverter, num: int):
+        super().__init__(arg, parent)
+        self.num = num
+
+    def __eq__(self, other: ParamConverter) -> bool:
+        return self.ast_obj == other.ast_obj and self.num == other.num
+
+    def __lt__(self, other: ParamConverter) -> bool:
+        if self.is_positional and not other.is_positional:
+            return True
+        if self.is_pass_thru and not other.is_pass_thru:
+            return False
+        return self.num < other.num
+
+    @classmethod
+    def init_group(cls, parent: CollectionConverter, args: List[ParserArg]) -> ParamConverterGroup:
+        return ParamConverterGroup(parent, [cls(arg, parent, i) for i, arg in enumerate(args)])
+
+    def format_lines(self, indent: int = 4) -> Iterator[str]:
+        yield self.format(indent)
+
+    def format(self, indent: int = 4) -> str:
+        param_cls, args_obj = self.get_cls_and_kwargs()
+        arg_str = args_obj.to_str(*self.get_pos_args())
+        return f'{" " * indent}{self.attr_name} = {param_cls}({arg_str})'
+
+    # region Naming
+
+    @cached_property
+    def attr_name(self) -> str:
+        return self._attr_name.replace('-', '_') if self._name_mode else self._attr_name
+
+    @cached_property
+    def name_mode(self) -> str | None:
+        return None if self.parent.name_mode else self._name_mode
+
+    @cached_property
+    def _name_mode(self) -> str | None:
+        if not self.use_auto_long_opt_str:
+            return None
+        return "'-'" if '-' in self._attr_name else None
+
+    @cached_property
+    def _attr_name(self) -> str:
+        return next(name for name in self._attr_name_candidates() if name not in RESERVED)
+
+    def _attr_name_candidates(self) -> Iterator[str]:
+        long, short, plain = self._grouped_opt_strs
+        if self.is_positional or self.is_pass_thru:
+            yield from plain
+        if self.is_option or self.is_pass_thru:
+            for group in (long, short):
+                for opt in group:
+                    opt = opt.lstrip('-')
+                    if opt:
+                        yield opt
+        while True:
+            yield f'param_{next(self._counter)}'
+
+    # endregion
+
+    # region Arg Processing
+
+    @cached_property
+    def cmd_option_strs(self) -> List[str]:
+        if not self.is_option:
+            return []
+        long, short, plain = self._grouped_opt_strs
+        return short if self.use_auto_long_opt_str else (long + short)
+
+    @cached_property
+    def use_auto_long_opt_str(self) -> bool:
+        if not self.is_option:
+            return False
+        long, short, plain = self._grouped_opt_strs
+        return len(long) == 1 and long[0][2:] == self._attr_name
+
+    def get_pos_args(self) -> Iterable[str]:
+        return (repr(arg) for arg in self.cmd_option_strs)
+
+    def get_cls_and_kwargs(self) -> tuple[str, BaseArgs]:
+        kwargs = self.ast_obj.init_func_kwargs.copy()
+        help_arg = kwargs.get('help')
+        if help_arg and help_arg in self.ast_obj.get_tracked_refs('argparse', 'SUPPRESS', ()):
+            kwargs.update({'hide': 'True', 'help': None})
+
+        if self.is_pass_thru:
+            return 'PassThru', PassThruArgs.from_kwargs(**kwargs)
+
+        action = kwargs.pop('action', None)
+        if action:
+            action = literal_eval(action)
+
+        if self.is_positional:
+            if action and action not in ('store', 'append'):
+                raise ConversionError(f'{self.ast_obj}: {action=} is not supported for Positional parameters')
+            return 'Positional', ParamArgs.init_positional(action, **kwargs)
+        elif self.is_option:
+            kwargs['name_mode'] = self.name_mode
+            if action:
+                if action in ('store_true', 'store_false', 'store_const', 'append_const'):
+                    return 'Flag', FlagArgs.init_flag(action, **kwargs)
+                elif action == 'count':
+                    return 'Counter', FlagArgs.init_counter(**kwargs)
+                elif action not in ('store', 'append'):
+                    raise ConversionError(f'{self.ast_obj}: {action=} is not supported for Option parameters')
+            return 'Option', OptionArgs.init_option(self.ast_obj, action, **kwargs)
+
+        raise ConversionError(f'Unable to determine a suitable Parameter type for {self.ast_obj!r}')
+
+    # endregion
+
+    # region High Level Param Type
+
+    @cached_property
+    def is_pass_thru(self) -> bool:
+        nargs = self.ast_obj.init_func_kwargs.get('nargs')
+        if not nargs:
+            return False
+        return nargs in self.ast_obj.get_tracked_refs('argparse', 'REMAINDER', ())
+
+    @cached_property
+    def is_positional(self) -> bool:
+        long, short, plain = self._grouped_opt_strs
+        return plain and not long and not short
+
+    @cached_property
+    def is_option(self) -> bool:
+        long, short, plain = self._grouped_opt_strs
+        return (long or short) and not plain
+
+    # endregion
+
+    @cached_property
+    def _grouped_opt_strs(self) -> tuple[List[str], List[str], List[str]]:
+        option_strs = (literal_eval(opt) for opt in self.ast_obj.init_func_args)
+        long, short, plain = [], [], []
+        for opt in option_strs:
+            if opt.startswith('--'):
+                long.append(opt)
+            elif opt.startswith('-'):
+                short.append(opt)
+            else:
+                plain.append(opt)
+        return long, short, plain
+
+
+class ParamConverterGroup(ConverterGroup[ParamConverter]):
+    __slots__ = ()
+
+    def __bool__(self) -> bool:
+        return bool(self.members) or bool(getattr(self.parent.ast_obj, 'sub_parsers', None))
+
+    def format_all(self, indent: int = 4) -> Iterator[str]:
+        positionals, others = [], []
+        i_converters = iter(sorted(self.members))
+        for converter in i_converters:
+            if converter.is_positional:
+                positionals.append(converter)
+            else:
+                others.append(converter)
+                others.extend(i_converters)
+
+        for positional in positionals:
+            yield from positional.format_lines(indent)
+
+        sub_parsers = getattr(self.parent.ast_obj, 'sub_parsers', None)
+        if sub_parsers:
+            log.debug(f'Found sub_parsers={sub_parsers}')
+            try:
+                name = literal_eval(sub_parsers[0].init_func_kwargs['dest']).replace('-', '_')
+            except (KeyError, ValueError):
+                name = 'sub_cmd'
+            else:
+                if name in RESERVED:
+                    name = 'sub_cmd'
+            yield f'{" " * indent}{name} = SubCommand()'
+
+        for other in others:
+            yield from other.format_lines(indent)
+
+
+# region Arg Containers
+
+
+@dataclass
+class BaseArgs:
+    help: OptStr = None
+
+    def _to_str(self, args: tuple[str, ...], end_fields: List[str]) -> str:
+        skip = set(end_fields)
+        keys = [f.name for f in fields(self) if f.name not in skip] + end_fields
+        kv_iter = ((key, getattr(self, key)) for key in keys)
+        return ', '.join((*args, *(f'{key}={val}' for key, val in kv_iter if val is not None)))
+
+    def to_str(self, *args: str) -> str:
+        return self._to_str(args, ['help'])
+
+    @classmethod
+    def from_kwargs(cls, **kwargs):
+        keys = set(f.name for f in fields(cls)).intersection(kwargs)
+        filtered = {key: kwargs[key] for key in keys}
+        help_str = filtered.get('help')
+        if help_str:
+            # log.debug(f'Processing {help_str=}')
+            try:
+                help_str = literal_eval(help_str)
+            except ValueError:  # likely an f-string
+                pass
+            else:
+                if help_str.endswith('(default: %(default)s)'):
+                    help_str = help_str[:-22].rstrip()
+                filtered['help'] = repr(help_str) if help_str else None
+
+        return cls(**filtered)
+
+
+@dataclass
+class CommandArgs(BaseArgs):
+    choice: OptStr = None
+    choices: OptStr = None
+    prog: OptStr = None
+    usage: OptStr = None
+    description: OptStr = None
+    epilog: OptStr = None
+    option_name_mode: OptStr = None
+    add_help: OptStr = None
+    docs_url: OptStr = None
+    email: OptStr = None
+
+
+# endregion
+
+
+# region ParserArg Arg Containers
+
+
+@dataclass
+class ParamBaseArgs(BaseArgs):
+    name: OptStr = None
+    default: OptStr = None
+    required: OptStr = None
+    metavar: OptStr = None
+    hide: OptStr = None
+
+    def to_str(self, *args: str) -> str:
+        return self._to_str(args, ['hide', 'help'])
+
+
+@dataclass
+class PassThruArgs(ParamBaseArgs):
+    pass
+
+
+@dataclass
+class ParamArgs(ParamBaseArgs):
+    action: OptStr = None
+    type: OptStr = None
+    nargs: OptStr = None
+    choices: OptStr = None
+
+    @classmethod
+    def init_positional(cls, action: OptStr = None, nargs: OptStr = None, **kwargs):
+        if nargs is not None:
+            nargs_obj = Nargs(literal_eval(nargs))
+        else:
+            nargs_obj = Nargs(1)
+        if (action == 'store' and nargs_obj == 1) or (action == 'append' and nargs_obj != Nargs(1)):
+            action = None
+        return cls.from_kwargs(action=action, nargs=nargs, **kwargs)
+
+
+@dataclass
+class OptionArgs(ParamArgs):
+    name_mode: OptStr = None
+
+    @classmethod
+    def init_option(cls, arg: ParserArg, action: OptStr = None, nargs: OptStr = None, const: OptStr = None, **kwargs):
+        if const:
+            log.warning(f'{arg}: ignoring {const=} - it is only supported for Flag and Counter parameters')
+
+        if action == 'append':
+            if not nargs:
+                log.debug(f"{arg}: using default nargs='+' because {action=} and no nargs value was provided")
+                nargs = "'+'"
+            action = None
+        elif action == 'store':
+            if nargs == '1':
+                nargs = None
+            if not nargs:
+                action = None
+
+        return cls.from_kwargs(action=repr(action) if action else None, nargs=nargs, **kwargs)
+
+
+@dataclass
+class FlagArgs(OptionArgs):
+    const: OptStr = None
+
+    @classmethod
+    def init_flag(cls, action: str, const: OptStr = None, default: OptStr = None, **kwargs):
+        values = {'store_true': ('True', 'False'), 'store_false': ('False', 'True')}
+        try:
+            value, opposite = values[action]
+        except KeyError:
+            if action == 'store_const':
+                action = None
+        else:
+            if default == opposite:
+                default = None
+            action = None
+            const = value if default else None
+
+        kwargs['type'] = kwargs['nargs'] = None
+        if action:
+            action = repr(action)
+        return cls.from_kwargs(action=action, const=const, default=default, **kwargs)
+
+    @classmethod
+    def init_counter(cls, const: OptStr = None, default: OptStr = None, **kwargs):
+        kwargs['type'] = kwargs['nargs'] = kwargs['action'] = None
+        kwargs['const'] = None if const == '1' else const
+        kwargs['default'] = None if default == '0' else default
+        return cls.from_kwargs(**kwargs)
+
+
+# endregion
+
+
+def literal_eval_or_none(expr: str) -> str | None:
+    try:
+        return literal_eval(expr)
+    except ValueError:
+        return None
+
+
+class ConversionError(Exception):
+    pass

--- a/lib/cli_command_parser/conversion/utils.py
+++ b/lib/cli_command_parser/conversion/utils.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from ast import AST, Call, Attribute, Name, expr, unparse
-from typing import Union
+from typing import Union, Iterator
 
-__all__ = ['get_name_repr']
+__all__ = ['get_name_repr', 'iter_parents']
 
 
 def get_name_repr(node: Union[AST, expr]) -> str:
@@ -18,3 +18,12 @@ def get_name_repr(node: Union[AST, expr]) -> str:
         return unparse(node)
     else:
         raise TypeError(f'Only AST nodes are supported - found {node.__class__.__name__}')
+
+
+def iter_parents(module: str) -> Iterator[str]:
+    while True:
+        parent = module.rsplit('.', 1)[0]
+        if parent == module:
+            break
+        yield parent
+        module = parent

--- a/lib/cli_command_parser/conversion/utils.py
+++ b/lib/cli_command_parser/conversion/utils.py
@@ -1,6 +1,23 @@
 from __future__ import annotations
 
-from ast import AST, expr, unparse, Call, Attribute, Name, Dict, List, Set, Tuple
+from ast import AST, expr, Call, Attribute, Name, Dict, List, Set, Tuple
+
+try:
+    from ast import unparse
+except ImportError:  # added in 3.9
+    try:
+        from astunparse import unparse as _unparse
+    except ImportError as e:
+        raise RuntimeError(
+            'Missing required dependency: astunparse (only required in Python 3.8 and below'
+            ' - upgrade to 3.9 or above to avoid this dependency)'
+        )
+    else:
+
+        def unparse(node):
+            return ''.join(_unparse(node).splitlines())
+
+
 from typing import Union, Iterator, List as _List
 
 __all__ = ['get_name_repr', 'iter_module_parents', 'collection_contents']

--- a/lib/cli_command_parser/conversion/utils.py
+++ b/lib/cli_command_parser/conversion/utils.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from ast import AST, Call, Attribute, Name, expr, unparse
-from typing import Union, Iterator
+from ast import AST, expr, unparse, Call, Attribute, Name, Dict, List, Set, Tuple
+from typing import Union, Iterator, List as _List
 
-__all__ = ['get_name_repr', 'iter_parents']
+__all__ = ['get_name_repr', 'iter_module_parents', 'collection_contents']
 
 
 def get_name_repr(node: Union[AST, expr]) -> str:
@@ -20,10 +20,19 @@ def get_name_repr(node: Union[AST, expr]) -> str:
         raise TypeError(f'Only AST nodes are supported - found {node.__class__.__name__}')
 
 
-def iter_parents(module: str) -> Iterator[str]:
+def iter_module_parents(module: str) -> Iterator[str]:
     while True:
         parent = module.rsplit('.', 1)[0]
         if parent == module:
             break
         yield parent
         module = parent
+
+
+def collection_contents(node: AST) -> _List[str]:
+    if isinstance(node, Dict):
+        return [unparse(key) for key in node.keys]  # noqa
+    elif isinstance(node, (List, Set, Tuple)):
+        return [unparse(ele) for ele in node.elts]  # noqa
+    else:
+        raise TypeError(f'Unexpected AST node type={node.__class__.__name__}')

--- a/lib/cli_command_parser/conversion/utils.py
+++ b/lib/cli_command_parser/conversion/utils.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from ast import AST, Call, Attribute, Name, expr, unparse
+from typing import Union
+
+__all__ = ['get_name_repr']
+
+
+def get_name_repr(node: Union[AST, expr]) -> str:
+    if isinstance(node, Call):
+        node = node.func
+
+    if isinstance(node, Name):
+        return node.id
+    elif isinstance(node, Attribute):
+        return f'{get_name_repr(node.value)}.{node.attr}'  # noqa
+    elif isinstance(node, AST):
+        return unparse(node)
+    else:
+        raise TypeError(f'Only AST nodes are supported - found {node.__class__.__name__}')

--- a/lib/cli_command_parser/conversion/visitor.py
+++ b/lib/cli_command_parser/conversion/visitor.py
@@ -1,0 +1,210 @@
+from __future__ import annotations
+
+import logging
+from ast import NodeVisitor, AST, Assign, Call, For, Attribute, Name, Import, ImportFrom, expr
+from collections import ChainMap, defaultdict
+from functools import partial, wraps
+from typing import Iterator, Union, Callable, Collection, Tuple, List, Dict, Set
+
+from .argparse_ast import AstArgumentParser
+from .utils import get_name_repr
+
+__all__ = ['ScriptVisitor', 'TrackedRef']
+log = logging.getLogger(__name__)
+
+TrackedRefMap = Dict['TrackedRef', Set[str]]
+_NoCall = object()
+
+
+def scoped(func):
+    @wraps(func)
+    def _scoped_method(self: ScriptVisitor, *args, **kwargs):
+        self.scopes = self.scopes.new_child()
+        try:
+            func(self, *args, **kwargs)
+        finally:
+            self.scopes = self.scopes.parents
+
+    return _scoped_method
+
+
+class ScopedVisit:
+    __slots__ = ()
+
+    def __get__(self, instance: ScriptVisitor, owner):
+        return self if instance is None else partial(scoped(owner.generic_visit), instance)
+
+
+class ScriptVisitor(NodeVisitor):
+    visit_FunctionDef = visit_AsyncFunctionDef = ScopedVisit()
+    visit_Lambda = ScopedVisit()
+    visit_ClassDef = ScopedVisit()
+    visit_While = ScopedVisit()
+
+    def __init__(self, smart_loop_handling: bool = True, track_refs: Collection[TrackedRef] = ()):
+        self.smart_loop_handling = smart_loop_handling
+        self.scopes = ChainMap()
+        self._tracked_refs = set()
+        self._mod_name_tracked_map = defaultdict(dict)
+        for ref in track_refs:
+            self.track_refs_to(ref)
+
+    def track_callable(self, module: str, name: str, cb: Callable):
+        self._mod_name_tracked_map[module][name] = cb
+
+    def track_refs_to(self, ref: TrackedRef):
+        self._tracked_refs.add(ref)
+        self._mod_name_tracked_map[ref.module][ref.name] = ref
+
+    def get_tracked_refs(self) -> TrackedRefMap:
+        tracked_refs = defaultdict(set)
+        for key, val in self.scopes.items():
+            if val in self._tracked_refs:
+                tracked_refs[val].add(key)
+        tracked_refs.default_factory = None
+        return tracked_refs
+
+    # region Imports
+
+    def visit_Import(self, node: Import):
+        for module_name, as_name in imp_names(node):
+            name_tracked_map = self._mod_name_tracked_map.get(module_name)
+            if name_tracked_map:
+                log.debug(f'Found module import: {module_name} as {as_name}')
+                for name, tracked in name_tracked_map.items():
+                    self.scopes[f'{as_name}.{name}'] = tracked
+
+    def visit_ImportFrom(self, node: ImportFrom):
+        name_tracked_map = self._mod_name_tracked_map.get(node.module)
+        if name_tracked_map:
+            for name, as_name in imp_names(node):
+                tracked = name_tracked_map.get(name)
+                if tracked:
+                    log.debug(f'Found tracked import: {node.module}.{name} as {as_name}')
+                    self.scopes[as_name] = tracked
+
+    # endregion
+
+    # region Scope Changes
+
+    @scoped
+    def visit_For(self, node: For):
+        if isinstance(node.target, Name):
+            try:
+                ele_names = [get_name_repr(ele) for ele in node.iter.elts]  # noqa
+            except (AttributeError, TypeError):
+                ele_names = ()
+
+            if ele_names and self.smart_loop_handling:
+                self._visit_for_smart(node, node.target.id, ele_names)
+            else:
+                self._visit_for_elements(node, node.target.id, ele_names)
+        else:
+            self.generic_visit(node)
+
+    visit_AsyncFor = visit_For
+
+    def _visit_for_smart(self, node: For, loop_var: str, ele_names: List[str]):
+        log.debug(f'Attempting smart for loop visit for {loop_var=} in {ele_names=}')
+        refs = [ref for ref in (self.scopes.get(name) for name in ele_names) if ref]
+        log.debug(f'  > Found {len(refs)=}, {len(ele_names)=}')
+
+        if len(refs) == len(ele_names) and all(isinstance(ref, AstArgumentParser) for ref in refs):
+            parents = set(ref.parent for ref in refs)
+            log.debug(f'  > Found {parents=}')
+            if len(parents) == 1:
+                parent = next(iter(parents))
+                if parent and set(parent.sub_parsers) == set(refs):
+                    self.scopes[loop_var] = parent
+                    self.generic_visit(node)
+                    return
+
+        log.debug('Falling back to generic loop handling')
+        self._visit_for_elements(node, loop_var, ele_names)
+
+    def _visit_for_elements(self, node: For, loop_var: str, ele_names: List[str]):
+        visited_any = False
+        for name in ele_names:
+            ref = self.scopes.get(name)
+            if ref:
+                visited_any = True
+                self.scopes[loop_var] = ref
+                self.generic_visit(node)
+
+        if not visited_any:
+            self.generic_visit(node)
+
+    # endregion
+
+    def resolve_ref(self, name: Union[str, AST, Attribute, Name, expr]):
+        if not isinstance(name, str):
+            name = get_name_repr(name)
+        try:
+            return self.scopes[name]
+        except KeyError:
+            pass
+        try:
+            obj_name, attr = name.rsplit('.', 1)
+        except ValueError:
+            return None
+        try:
+            obj = self.scopes[obj_name]
+        except KeyError:
+            return None
+        try:
+            can_call = attr in obj.visit_funcs
+        except (AttributeError, TypeError):
+            return None
+        return getattr(obj, attr) if can_call else None
+
+    def visit_withitem(self, item):
+        context_expr = item.context_expr
+        func = self.resolve_ref(context_expr)
+        if func:
+            call = context_expr if isinstance(context_expr, Call) else None
+            result = func(item, call, self.get_tracked_refs())
+            as_name = item.optional_vars
+            if as_name:
+                self.scopes[get_name_repr(as_name)] = result
+
+    def visit_Assign(self, node: Assign):
+        value = node.value
+        if isinstance(value, (Attribute, Name)):  # Assigning an alias to a variable
+            ref = self.resolve_ref(value)
+            if ref:
+                for target in node.targets:
+                    self.scopes[get_name_repr(target)] = ref
+        elif isinstance(value, Call):
+            result = self.visit_Call(value)
+            if result is not _NoCall:
+                for target in node.targets:
+                    self.scopes[get_name_repr(target)] = result  # noq
+
+    def visit_Call(self, node: Call):
+        func = self.resolve_ref(node.func)
+        if func:
+            return func(node, node, self.get_tracked_refs())
+        return _NoCall
+
+
+class TrackedRef:
+    __slots__ = ('module', 'name')
+
+    def __init__(self, name: str):
+        self.module, self.name = name.rsplit('.', 1)
+
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__}: {self.module}.{self.name}>'
+
+    def __hash__(self) -> int:
+        return hash(self.__class__) ^ hash(self.module) ^ hash(self.name)
+
+    def __eq__(self, other: TrackedRef) -> bool:
+        return self.name == other.name and self.module == other.module
+
+
+def imp_names(imp: Import | ImportFrom) -> Iterator[Tuple[str, str]]:
+    for alias in imp.names:
+        name = alias.name
+        as_name = alias.asname or name
+        yield name, as_name

--- a/lib/cli_command_parser/conversion/visitor.py
+++ b/lib/cli_command_parser/conversion/visitor.py
@@ -105,13 +105,13 @@ class ScriptVisitor(NodeVisitor):
     visit_AsyncFor = visit_For
 
     def _visit_for_smart(self, node: For, loop_var: str, ele_names: List[str]):
-        log.debug(f'Attempting smart for loop visit for {loop_var=} in {ele_names=}')
+        log.debug(f'Attempting smart for loop visit for loop_var={loop_var!r} in ele_names={ele_names!r}')
         refs = [ref for ref in (self.scopes.get(name) for name in ele_names) if ref]
-        log.debug(f'  > Found {len(refs)=}, {len(ele_names)=}')
+        # log.debug(f'  > Found {len(refs)=}, {len(ele_names)=}')
 
         if len(refs) == len(ele_names) and all(isinstance(ref, AstArgumentParser) for ref in refs):
             parents = set(ref.parent for ref in refs)
-            log.debug(f'  > Found {parents=}')
+            log.debug(f'  > Found parents={parents!r}')
             if len(parents) == 1:
                 parent = next(iter(parents))
                 if parent and set(parent.sub_parsers) == set(refs):

--- a/lib/cli_command_parser/formatting/utils.py
+++ b/lib/cli_command_parser/formatting/utils.py
@@ -136,7 +136,7 @@ def _should_add_default(default: Any, help_text: Optional[str], param_show_defau
     elif param_show_default is not None:
         return param_show_default
     sd = ctx.config.show_defaults
-    if sd._value_ < 2 or (sd & ShowDefaults.MISSING and help_text and 'default:' in help_text):
+    if sd._value_ < 2 or (sd & ShowDefaults.MISSING and help_text and 'default:' in help_text):  # noqa
         return False
     elif sd & ShowDefaults.ANY:
         return True

--- a/setup.cfg
+++ b/setup.cfg
@@ -39,5 +39,7 @@ tests_require = testtools; coverage
 where = lib
 
 [options.extras_require]
-wcwidth = wcwidth
-conversion = astunparse; python_version<"3.9"
+wcwidth =
+    wcwidth
+conversion =
+    astunparse; python_version<"3.9"

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,3 +40,4 @@ where = lib
 
 [options.extras_require]
 wcwidth = wcwidth
+conversion = astunparse;python_version<'3.9'

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,4 +40,4 @@ where = lib
 
 [options.extras_require]
 wcwidth = wcwidth
-conversion = astunparse;python_version<'3.9'
+conversion = astunparse; python_version<"3.9"

--- a/tests/test_conversion/test_convert_argparse.py
+++ b/tests/test_conversion/test_convert_argparse.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+
+# from argparse import ArgumentParser as _ArgumentParser
+from textwrap import dedent
+from unittest import TestCase, main
+
+from cli_command_parser.conversion.argparse_ast import Script, AstArgumentParser
+from cli_command_parser.conversion.argparse_utils import ArgumentParser, SubParsersAction
+from cli_command_parser.conversion.command_builder import convert_script
+from cli_command_parser.conversion.utils import get_name_repr
+from cli_command_parser.conversion.visitor import ScriptVisitor
+from cli_command_parser.testing import ParserTest
+
+DISCLAIMER = '# This is an automatically generated name that should probably be updated'
+IMPORT_LINE = (
+    'from cli_command_parser import Command, SubCommand, ParamGroup, Positional, Option, Flag, Counter, PassThru, main'
+)
+
+
+class ArgparseConversionTest(ParserTest):
+    def test_argparse_typing_helpers(self):
+        parser = ArgumentParser()
+        parser.register('action', 'parsers', SubParsersAction)
+        sp_action = parser.add_subparsers(dest='action', prog='')
+        self.assertIsInstance(sp_action, SubParsersAction)
+        sub_parser = sp_action.add_parser('test')
+        self.assertIsNotNone(sub_parser.add_mutually_exclusive_group())
+        self.assertIsNotNone(sub_parser.add_argument_group('test'))
+
+    def test_get_name_repr_bad_type(self):
+        with self.assertRaises(TypeError):
+            get_name_repr('foo')  # noqa
+
+    def test_renamed_import_and_remainder(self):
+        code = """
+from argparse import ArgumentParser as ArgParser, REMAINDER
+parser = ArgParser()
+parser.add_argument('test', nargs=REMAINDER)
+        """
+        expected = f'{IMPORT_LINE}\n\n\nclass Command0(Command):  {DISCLAIMER}\n    test = PassThru()'
+        self.assertEqual(expected, convert_script(Script(code)))
+
+    def test_sub_parser_args_in_loop(self):
+        code = """
+import argparse
+parser = argparse.ArgumentParser()
+subparsers = parser.add_subparsers(dest='action')
+sp1 = subparsers.add_parser('one', help='Command one')
+sp1.add_argument('--foo-bar', '-f', action='store_true', help='Do foo bar')
+sp2 = subparsers.add_parser('two', description='Command two')
+sp2.add_argument('--baz', '-b', nargs='+', help='What to baz')
+for sp in (sp1, sp2):
+    group = sp.add_argument_group('Common options')
+    group.add_argument('--verbose', '-v', action='count', default=0, help='Increase logging verbosity')
+    group.add_argument('--dry-run', '-D', action='store_true', help='Perform a dry run with no side effects')
+        """
+        expected_base = (
+            f"{IMPORT_LINE}\n\n\nclass Command0(Command, option_name_mode='-'):  {DISCLAIMER}\n"
+            '    action = SubCommand()'
+        )
+        common = (
+            "\n    with ParamGroup(description='Common options'):\n"
+            "        verbose = Counter('-v', help='Increase logging verbosity')\n"
+            "        dry_run = Flag('-D', help='Perform a dry run with no side effects')"
+        )
+        expected_smart = f"""{expected_base}\n{common}
+\n
+class One(Command0, help='Command one'):
+    foo_bar = Flag('-f', help='Do foo bar')
+\n
+class Two(Command0, description='Command two'):
+    baz = Option('-b', nargs='+', help='What to baz')
+        """.rstrip()
+        expected_split = f"""{expected_base}
+\n
+class One(Command0, help='Command one'):
+    foo_bar = Flag('-f', help='Do foo bar')
+{common}
+\n
+class Two(Command0, description='Command two'):
+    baz = Option('-b', nargs='+', help='What to baz')
+{common}
+        """.rstrip()
+        with self.subTest(smart_loop_handling=True):
+            self.assert_strings_equal(expected_smart, convert_script(Script(code)))
+        with self.subTest(smart_loop_handling=False):
+            self.assert_strings_equal(expected_split, convert_script(Script(code, False)))
+
+
+if __name__ == '__main__':
+    try:
+        main(verbosity=2, exit=False)
+    except KeyboardInterrupt:
+        print()

--- a/tests/test_conversion/test_convert_argparse.py
+++ b/tests/test_conversion/test_convert_argparse.py
@@ -1,16 +1,26 @@
 #!/usr/bin/env python
 
-# from argparse import ArgumentParser as _ArgumentParser
-from textwrap import dedent
-from unittest import TestCase, main
+from __future__ import annotations
 
-from cli_command_parser.conversion.argparse_ast import Script, AstArgumentParser
+import ast
+from typing import TYPE_CHECKING
+from unittest import main
+from unittest.mock import Mock, patch
+
+from cli_command_parser.compat import cached_property
+from cli_command_parser.conversion.argparse_ast import Script, AstArgumentParser, AstCallable
+from cli_command_parser.conversion.argparse_ast import AddVisitedChild, visit_func
 from cli_command_parser.conversion.argparse_utils import ArgumentParser, SubParsersAction
 from cli_command_parser.conversion.command_builder import convert_script
 from cli_command_parser.conversion.utils import get_name_repr
-from cli_command_parser.conversion.visitor import ScriptVisitor
-from cli_command_parser.testing import ParserTest
+from cli_command_parser.conversion.visitor import TrackedRefMap
+from cli_command_parser.testing import ParserTest, RedirectStreams
 
+if TYPE_CHECKING:
+    from cli_command_parser.conversion.argparse_ast import InitNode
+
+
+PACKAGE = 'cli_command_parser.conversion'
 DISCLAIMER = '# This is an automatically generated name that should probably be updated'
 IMPORT_LINE = (
     'from cli_command_parser import Command, SubCommand, ParamGroup, Positional, Option, Flag, Counter, PassThru, main'
@@ -18,6 +28,8 @@ IMPORT_LINE = (
 
 
 class ArgparseConversionTest(ParserTest):
+    # region Low value tests for coverage
+
     def test_argparse_typing_helpers(self):
         parser = ArgumentParser()
         parser.register('action', 'parsers', SubParsersAction)
@@ -27,9 +39,80 @@ class ArgparseConversionTest(ParserTest):
         self.assertIsNotNone(sub_parser.add_mutually_exclusive_group())
         self.assertIsNotNone(sub_parser.add_argument_group('test'))
 
+    def test_script_reprs(self):
+        self.assertEqual('<Script[parsers=0]>', repr(Script('foo()')))
+
+    def test_group_and_arg_reprs(self):
+        code = "import argparse\np = argparse.ArgumentParser()\ng = p.add_argument_group()\ng.add_argument('--foo')\n"
+        parser = Script(code).parsers[0]
+        group = parser.groups[0]
+        self.assertIn('p.add_argument_group()', repr(group))
+        self.assertIn("g.add_argument('--foo')", repr(group.args[0]))
+
+    def test_descriptors(self):
+        mock = Mock()
+
+        class Foo:
+            foo = AddVisitedChild(Mock, 'abc')
+
+            @classmethod
+            def _add_visit_func(cls, name):
+                return False
+
+            @visit_func
+            def bar(self):
+                return 123
+
+        Foo.baz = visit_func(mock)
+        self.assertEqual(123, Foo().bar())
+        self.assertIsInstance(Foo().baz(), Mock)  # noqa
+        mock.assert_called()
+        self.assertIsInstance(Foo.foo, AddVisitedChild)
+
+    def test_add_visit_func_attr_error(self):
+        original = AstCallable.visit_funcs.copy()
+        self.assertTrue(AstCallable._add_visit_func('foo_bar'))
+        self.assertNotEqual(original, AstCallable.visit_funcs)
+        self.assertIn('foo_bar', AstCallable.visit_funcs)
+        AstCallable.visit_funcs = original
+
+    def test_ast_callable_misc(self):
+        ac = AstCallable(Mock(args=123, keywords=456), Mock(), {})
+        self.assertEqual(123, ac.call_args)
+        self.assertIsNone(ac.get_tracked_refs('foo', 'bar', None))
+        with self.assertRaises(KeyError):
+            self.assertIsNone(ac.get_tracked_refs('foo', 'bar'))
+
+    # endregion
+
+    # region get_name_repr
+
     def test_get_name_repr_bad_type(self):
         with self.assertRaises(TypeError):
             get_name_repr('foo')  # noqa
+
+    def test_get_name_repr_call(self):
+        node = ast.parse('foo()').body[0]
+        self.assertEqual('foo', get_name_repr(node.value))  # noqa # Tests the isinstance(node, Call) line
+        self.assertEqual('foo()', get_name_repr(node))      # noqa # Tests the isinstance(node, AST) line
+
+    # endregion
+
+    def test_ast_callable_no_represents(self):
+        ac = AstCallable(ast.parse('foo(123, bar=456)').body[0].value, Mock(), {})  # noqa
+        self.assertEqual(['123'], ac.init_func_args)
+        self.assertEqual({'bar': '456'}, ac.init_func_kwargs)
+
+    def test_pprint(self):
+        code = "import argparse\np = argparse.ArgumentParser()\ng = p.add_argument_group()\ng.add_argument('--foo')\n"
+        expected = """
+ + <AstArgumentParser[sub_parsers=0]: ``argparse.ArgumentParser()``>:
+    + <ArgGroup: ``p.add_argument_group()``>:
+       - <ParserArg[g.add_argument('--foo')]>
+        """.strip()
+        with RedirectStreams() as streams:
+            Script(code).parsers[0].pprint()
+        self.assert_strings_equal(expected, streams.stdout.strip())
 
     def test_renamed_import_and_remainder(self):
         code = """
@@ -54,40 +137,141 @@ for sp in (sp1, sp2):
     group.add_argument('--verbose', '-v', action='count', default=0, help='Increase logging verbosity')
     group.add_argument('--dry-run', '-D', action='store_true', help='Perform a dry run with no side effects')
         """
+
         expected_base = (
             f"{IMPORT_LINE}\n\n\nclass Command0(Command, option_name_mode='-'):  {DISCLAIMER}\n"
             '    action = SubCommand()'
         )
-        common = (
-            "\n    with ParamGroup(description='Common options'):\n"
-            "        verbose = Counter('-v', help='Increase logging verbosity')\n"
-            "        dry_run = Flag('-D', help='Perform a dry run with no side effects')"
-        )
-        expected_smart = f"""{expected_base}\n{common}
-\n
-class One(Command0, help='Command one'):
-    foo_bar = Flag('-f', help='Do foo bar')
-\n
-class Two(Command0, description='Command two'):
-    baz = Option('-b', nargs='+', help='What to baz')
+        common = """
+    with ParamGroup(description='Common options'):
+        verbose = Counter('-v', help='Increase logging verbosity')
+        dry_run = Flag('-D', help='Perform a dry run with no side effects')
         """.rstrip()
-        expected_split = f"""{expected_base}
-\n
+
+        expected_smart = f"""{expected_base}\n{common}\n\n
 class One(Command0, help='Command one'):
-    foo_bar = Flag('-f', help='Do foo bar')
-{common}
-\n
+    foo_bar = Flag('-f', help='Do foo bar')\n\n
 class Two(Command0, description='Command two'):
     baz = Option('-b', nargs='+', help='What to baz')
-{common}
         """.rstrip()
         with self.subTest(smart_loop_handling=True):
             self.assert_strings_equal(expected_smart, convert_script(Script(code)))
+
+        expected_split = f"""{expected_base}\n\n
+class One(Command0, help='Command one'):
+    foo_bar = Flag('-f', help='Do foo bar')
+{common}\n\n
+class Two(Command0, description='Command two'):
+    baz = Option('-b', nargs='+', help='What to baz')
+{common}
+        """.rstrip()
         with self.subTest(smart_loop_handling=False):
             self.assert_strings_equal(expected_split, convert_script(Script(code, False)))
 
+    def test_sub_parser_args_mismatch_in_loop(self):
+        code = """
+import argparse as ap
+parser = ap.ArgumentParser()
+add_arg = parser.add_argument
+add_arg('foo')
+subparsers = parser.add_subparsers(dest='action')
+sp1 = subparsers.add_parser('one', help='Command one')
+sp1.add_argument('--foo-bar', '-f', action='store_true', help='Do foo bar')
+sp2 = subparsers.add_parser('two', description='Command two')
+sp2.add_argument('--baz', '-b', nargs='+', help='What to baz')
+for sp in [sp1]:
+    group = sp.add_mutually_exclusive_group()
+    group.add_argument('--verbose', '-v', action='count', default=0, help='Increase logging verbosity')
+    group.add_argument('--dry_run', '-D', action='store_true', help='Perform a dry run with no side effects')
+        """
+        expected = f"""{IMPORT_LINE}\n\n
+class Command0(Command):  {DISCLAIMER}
+    foo = Positional()
+    action = SubCommand()
+\n
+class One(Command0, help='Command one'):
+    foo_bar = Flag('-f', name_mode='-', help='Do foo bar')\n
+    with ParamGroup(mutually_exclusive=True):
+        verbose = Counter('-v', help='Increase logging verbosity')
+        dry_run = Flag('-D', help='Perform a dry run with no side effects')
+\n
+class Two(Command0, description='Command two'):
+    baz = Option('-b', nargs='+', help='What to baz')
+        """.rstrip()
+        self.assert_strings_equal(expected, convert_script(Script(code)))
+
+
+class ArgparseConversionCustomSubclassTest(ParserTest):
+    @classmethod
+    def _prepare_test_classes(cls):
+        class ArgParser(ArgumentParser):
+            @property
+            def subparsers(self):
+                try:
+                    return {sp.dest: sp for sp in self._subparsers._group_actions}
+                except AttributeError:
+                    return {}
+
+            def add_subparser(self, dest, name, help_desc=None, *, help=None, description=None, **kwargs):  # noqa
+                try:
+                    sp_group = self.subparsers[dest]
+                except KeyError:
+                    sp_group = self.add_subparsers(dest=dest, title='subcommands')
+                return sp_group.add_parser(name, help=help or help_desc, description=description or help_desc, **kwargs)
+
+        class AstArgParser(AstArgumentParser, represents=ArgParser):
+            @visit_func
+            def add_subparser(self, node: InitNode, call: ast.Call, tracked_refs: TrackedRefMap):
+                return self._add_subparser(node, call, tracked_refs, SubParserShortcut)
+
+        class SubParserShortcut(AstArgParser, represents=ArgParser.add_subparser):
+            @cached_property
+            def init_func_kwargs(self) -> dict[str, str]:
+                kwargs = self._init_func_kwargs()
+                help_desc = kwargs.get('help_desc')
+                if help_desc and kwargs.setdefault('help', help_desc) != help_desc:
+                    kwargs.setdefault('description', help_desc)
+                return kwargs
+
+        return ArgParser, AstArgParser, SubParserShortcut
+
+    def test_custom_parser_subclass(self):
+        ArgParser, AstArgParser, SubParserShortcut = self._prepare_test_classes()
+
+        class Module:
+            def __init__(self, data):
+                self.__dict__.update(data)
+
+        modules = {'foo': Module({'ArgParser': ArgParser}), 'foo.bar': Module({'ArgParser': ArgParser})}
+        with patch(f'{PACKAGE}.argparse_ast.sys.modules', modules):
+            Script._register_parser('foo.bar.baz', 'ArgParser', AstArgParser)
+
+        code = """
+from argparse import SUPPRESS as hide
+from foo.bar import ArgParser
+parser = ArgParser(description='Parse args')
+with parser.add_subparser('action', 'one') as sp1:
+    sp1.add_argument('--foo', help=hide)
+sp2 = parser.add_subparser('action', 'two')
+        """
+        expected = f"""{IMPORT_LINE}\n\n
+class Command0(Command, description='Parse args'):  {DISCLAIMER}
+    action = SubCommand()
+\n
+class One(Command0):
+    foo = Option(hide=True)
+\n
+class Two(Command0):
+    pass
+        """.rstrip()
+        self.assert_strings_equal(expected, convert_script(Script(code)))
+        for module in ('foo', 'foo.bar', 'foo.bar.baz'):
+            del Script._parser_classes[module]
+
 
 if __name__ == '__main__':
+    # import logging
+    # logging.basicConfig(level=logging.DEBUG, format='%(asctime)s %(levelname)s %(name)s %(lineno)d %(message)s')
     try:
         main(verbosity=2, exit=False)
     except KeyboardInterrupt:


### PR DESCRIPTION
Some additional unit tests are still needed, and a proper entry_point still needs to be added, but the feature is 95%+ ready.

It is able to automatically identify any argparse ArgumentParser instances defined in a given file, and then generate code to define a roughly equivalent Command based on it.  It will not work with very complex ways of defining the args/groups/subparsers, but it can handle custom subclasses with custom methods for adding subparsers, etc, if a handler is registered for the subclass.

Since it uses the AST instead of importing the target file, it can copy references to variables instead of their contents.

For users running Python <3.9, an additional optional dependency on `astunparse` is required to use the conversion feature.