### PR TITLE
Changed the default `option_name_mode` from underscore to dash

### DIFF
--- a/docs/_src/advanced.rst
+++ b/docs/_src/advanced.rst
@@ -224,7 +224,7 @@ Example snippet::
 The help text (note that ``clean`` appears in both the ``Actions`` section and the optional args section)::
 
     $ build_docs.py -h
-    usage: build_docs.py {clean,backup} [--verbose [VERBOSE]] [--dry_run] [--clean] [--update] [--open] [--help]
+    usage: build_docs.py {clean,backup} [--verbose [VERBOSE]] [--dry-run] [--clean] [--update] [--open] [--help]
 
     Build documentation using Sphinx
 
@@ -237,11 +237,11 @@ The help text (note that ``clean`` appears in both the ``Actions`` section and t
     Optional arguments:
       --verbose [VERBOSE], -v [VERBOSE]
                                   Increase logging verbosity (can specify multiple times) (default: 0)
-      --dry_run, -D               Print the actions that would be taken instead of taking them (default: False)
-      --clean, -c                 Clean the docs directory before building docs (default: False)
-      --update, -u                Update RST files (default: False)
-      --open, -o                  Open the docs in the default web browser after running sphinx-build (default: False)
-      --help, -h                  Show this help message and exit (default: False)
+      --dry-run, -D               Print the actions that would be taken instead of taking them
+      --clean, -c                 Clean the docs directory before building docs
+      --update, -u                Update RST files
+      --open, -o                  Open the docs in the default web browser after running sphinx-build
+      --help, -h                  Show this help message and exit
 
 
 If the script is called with ``build_docs.py clean`` or ``build_docs.py backup``, then only the ``clean`` or ``backup``

--- a/docs/_src/groups.rst
+++ b/docs/_src/groups.rst
@@ -291,13 +291,13 @@ Example output for the mutually dependent group nested inside the mutually exclu
     main
 
     $ grouped_action_flags.py -ab
-    argument conflict - the following arguments cannot be combined: --action_a / -a, --action_b / -b (they are mutually exclusive - only one is allowed)
+    argument conflict - the following arguments cannot be combined: --action-a / -a, --action-b / -b (they are mutually exclusive - only one is allowed)
 
     $ grouped_action_flags.py -abc
-    argument conflict - the following arguments cannot be combined: --action_a / -a, --action_b / -b, {--action_c / -c,--action_d / -d} (they are mutually exclusive - only one is allowed)
+    argument conflict - the following arguments cannot be combined: --action-a / -a, --action-b / -b, {--action-c / -c,--action-d / -d} (they are mutually exclusive - only one is allowed)
 
     $ grouped_action_flags.py -c
-    argument missing - the following argument is required: --action_d / -d (because --action_c/-c was provided)
+    argument missing - the following argument is required: --action-d / -d (because --action-c/-c was provided)
 
     $ grouped_action_flags.py -cd
     c
@@ -308,10 +308,10 @@ Example output for the mutually dependent group nested inside the mutually exclu
 Example output for the mutually exclusive group nested inside the mutually dependent group::
 
     $ grouped_action_flags.py -w
-    arguments missing - the following arguments are required: --action_x / -x, {--action_y / -y,--action_z / -z} (because --action_w/-w was provided)
+    arguments missing - the following arguments are required: --action-x / -x, {--action-y / -y,--action-z / -z} (because --action-w/-w was provided)
 
     $ grouped_action_flags.py -wx
-    argument missing - the following argument is required: {--action_y / -y,--action_z / -z} (because --action_w/-w, --action_x/-x were provided)
+    argument missing - the following argument is required: {--action-y / -y,--action-z / -z} (because --action-w/-w, --action-x/-x were provided)
 
     $ grouped_action_flags.py -wxy
     main
@@ -320,4 +320,4 @@ Example output for the mutually exclusive group nested inside the mutually depen
     y
 
     $ grouped_action_flags.py -wxyz
-    argument conflict - the following arguments cannot be combined: --action_y / -y, --action_z / -z (they are mutually exclusive - only one is allowed)
+    argument conflict - the following arguments cannot be combined: --action-y / -y, --action-z / -z (they are mutually exclusive - only one is allowed)

--- a/docs/_src/groups.rst
+++ b/docs/_src/groups.rst
@@ -50,7 +50,7 @@ Using that example, we can see the common options group in a subcommand's help t
       {foo,bar,baz}               The type of object to show
 
     Optional arguments:
-      --help, -h                  Show this help message and exit (default: False)
+      --help, -h                  Show this help message and exit
       --ids IDS, -i IDS           The IDs of the objects to show
 
     Common options:

--- a/docs/_src/index.rst
+++ b/docs/_src/index.rst
@@ -64,7 +64,7 @@ Example Program
     Optional arguments:
       --name NAME, -n NAME        The person to say hello to (default: 'World')
       --count COUNT, -c COUNT     Number of times to repeat the message (default: 1)
-      --help, -h                  Show this help message and exit (default: False)
+      --help, -h                  Show this help message and exit
 
 
 Installing CLI Command Parser

--- a/docs/_src/intro.rst
+++ b/docs/_src/intro.rst
@@ -95,7 +95,7 @@ Using the Hello World example again, we can see the automatically generated help
 
     Optional arguments:
       --name NAME, -n NAME        The person to say hello to (default: 'World')
-      --help, -h                  Show this help message and exit (default: False)
+      --help, -h                  Show this help message and exit
 
 
 The ``--help`` / ``-h`` option is automatically added to the command, and usage / help text is automatically generated

--- a/docs/_src/parameters.rst
+++ b/docs/_src/parameters.rst
@@ -191,9 +191,9 @@ Example usage::
     usage: simple_flags.py [--foo] [--no-bar] [--help]
 
     Optional arguments:
-      --foo, -f                   (default: False)
+      --foo, -f
       --no-bar, -B                (default: True)
-      --help, -h                  Show this help message and exit (default: False)
+      --help, -h                  Show this help message and exit
 
 
 
@@ -434,7 +434,7 @@ The resulting help text::
       TEXT [TEXT ...]             The text to print
 
     Optional arguments:
-      --help, -h                  Show this help message and exit (default: False)
+      --help, -h                  Show this help message and exit
 
 
 Example usage::
@@ -485,8 +485,8 @@ Example help text::
       HOSTS [HOSTS ...]           The hosts on which the given command should be run
 
     Optional arguments:
-      COMMAND                     The command to run (default: None)
-      --help, -h                  Show this help message and exit (default: False)
+      COMMAND                     The command to run
+      --help, -h                  Show this help message and exit
 
 
 Example usage::

--- a/docs/_src/subcommands.rst
+++ b/docs/_src/subcommands.rst
@@ -74,7 +74,7 @@ We can see from the help text that it is aware of its subcommands::
         bar                       Print bar
 
     Optional arguments:
-      --help, -h                  Show this help message and exit (default: False)
+      --help, -h                  Show this help message and exit
 
 
 Usage examples::
@@ -154,7 +154,7 @@ common ``env`` Option for selecting an environment to connect to::
         find                      Find objects
 
     Optional arguments:
-      --help, -h                  Show this help message and exit (default: False)
+      --help, -h                  Show this help message and exit
 
     Common options:
       --verbose [VERBOSE], -v [VERBOSE]
@@ -251,7 +251,7 @@ Top level ``--help`` text for the above example::
     Optional arguments:
       --verbose [VERBOSE], -v [VERBOSE]
                                   Increase logging verbosity (can specify multiple times) (default: 0)
-      --help, -h                  Show this help message and exit (default: False)
+      --help, -h                  Show this help message and exit
 
 
 Each subcommand has its own command-specific help text as well::
@@ -262,13 +262,13 @@ Each subcommand has its own command-specific help text as well::
     Optional arguments:
       --verbose [VERBOSE], -v [VERBOSE]
                                   Increase logging verbosity (can specify multiple times) (default: 0)
-      --help, -h                  Show this help message and exit (default: False)
+      --help, -h                  Show this help message and exit
 
     $ advanced_subcommand.py baz -h
     usage: advanced_subcommand.py baz [--help]
 
     Optional arguments:
-      --help, -h                  Show this help message and exit (default: False)
+      --help, -h                  Show this help message and exit
 
 
 Note that the ``baz`` subcommand, which does not extend ``Base``, does not include ``verbose`` because it does not

--- a/lib/cli_command_parser/config.py
+++ b/lib/cli_command_parser/config.py
@@ -286,7 +286,7 @@ class CommandConfig:
     allow_backtrack: Bool = ConfigItem(True, bool)
 
     #: How the default long form that is added for Option/Flag/Counter/etc. Parameters should handle underscores/dashes
-    option_name_mode: OptionNameMode = ConfigItem(OptionNameMode.UNDERSCORE, OptionNameMode)
+    option_name_mode: OptionNameMode = ConfigItem(OptionNameMode.DASH, OptionNameMode)
 
     #: Whether ambiguous combinations of positional choices should result in an :class:`.AmbiguousParseTree` error
     reject_ambiguous_pos_combos: Bool = ConfigItem(False, bool)  # EXPERIMENTAL

--- a/lib/cli_command_parser/conversion/command_builder.py
+++ b/lib/cli_command_parser/conversion/command_builder.py
@@ -22,10 +22,7 @@ log = logging.getLogger(__name__)
 
 C = TypeVar('C', bound='Converter')
 
-try:
-    RESERVED = set(keyword.kwlist) | set(keyword.softkwlist)
-except AttributeError:  # < 3.9
-    RESERVED = set(keyword.kwlist)
+RESERVED = set(keyword.kwlist) | set(getattr(keyword, 'softkwlist', ('_', 'case', 'match')))  # soft was added in 3.9
 
 
 def convert_script(script: Script) -> str:
@@ -299,7 +296,7 @@ class ParamConverter(Converter, converts=ParserArg):
 
     @cached_property
     def attr_name(self) -> str:
-        return self._attr_name.replace('-', '_') if self._name_mode else self._attr_name
+        return self._attr_name.replace('-', '_')
 
     @cached_property
     def name_mode(self) -> str | None:
@@ -309,7 +306,7 @@ class ParamConverter(Converter, converts=ParserArg):
     def _name_mode(self) -> str | None:
         if not self.use_auto_long_opt_str:
             return None
-        return "'-'" if '-' in self._attr_name else None
+        return "'_'" if '_' in self._attr_name else None
 
     @cached_property
     def _attr_name(self) -> str:

--- a/lib/cli_command_parser/conversion/visitor.py
+++ b/lib/cli_command_parser/conversion/visitor.py
@@ -111,10 +111,10 @@ class ScriptVisitor(NodeVisitor):
 
         if len(refs) == len(ele_names) and all(isinstance(ref, AstArgumentParser) for ref in refs):
             parents = set(ref.parent for ref in refs)
-            log.debug(f'  > Found parents={parents!r}')
+            log.debug(f'  > Found parents={len(parents)}')
             if len(parents) == 1:
                 parent = next(iter(parents))
-                if parent and set(parent.sub_parsers) == set(refs):
+                if parent and set(getattr(parent, 'sub_parsers', ())) == set(refs):
                     self.scopes[loop_var] = parent
                     self.generic_visit(node)
                     return

--- a/readme.rst
+++ b/readme.rst
@@ -64,7 +64,7 @@ Example Program
     Optional arguments:
       --name NAME, -n NAME        The person to say hello to (default: 'World')
       --count COUNT, -c COUNT     Number of times to repeat the message (default: 1)
-      --help, -h                  Show this help message and exit (default: False)
+      --help, -h                  Show this help message and exit
 
 
 Installing CLI Command Parser

--- a/tests/data/test_examples_documentation/custom_inputs_help.txt
+++ b/tests/data/test_examples_documentation/custom_inputs_help.txt
@@ -1,20 +1,20 @@
-usage: custom_inputs.py [--path PATH] [--in_file IN_FILE] [--out_file OUT_FILE] [--json JSON] [--simple_range {0 <= N <= 49}] [--skip_range {1 <= N <= 29, step=2}] [--float_range {0.0 <= N < 1.0}] [--choice_range {0 <= N <= 19}] [--help]
+usage: custom_inputs.py [--path PATH] [--in-file IN_FILE] [--out-file OUT_FILE] [--json JSON] [--simple-range {0 <= N <= 49}] [--skip-range {1 <= N <= 29, step=2}] [--float-range {0.0 <= N < 1.0}] [--choice-range {0 <= N <= 19}] [--help]
 
 Optional arguments:
   --path PATH, -p PATH        The path to a file
-  --in_file IN_FILE, -f IN_FILE
+  --in-file IN_FILE, -f IN_FILE
                               The path to a file to read
-  --out_file OUT_FILE, -o OUT_FILE
+  --out-file OUT_FILE, -o OUT_FILE
                               The path to a file to write
   --json JSON, -j JSON        The path to a file containing json
   --help, -h                  Show this help message and exit
 
 Mutually exclusive options:
-  --simple_range {0 <= N <= 49}, -r {0 <= N <= 49}
+  --simple-range {0 <= N <= 49}, -r {0 <= N <= 49}
                               Choose a number in the specified range
-  --skip_range {1 <= N <= 29, step=2}, -k {1 <= N <= 29, step=2}
+  --skip-range {1 <= N <= 29, step=2}, -k {1 <= N <= 29, step=2}
                               Choose a number in the specified range
-  --float_range {0.0 <= N < 1.0}, -F {0.0 <= N < 1.0}
+  --float-range {0.0 <= N < 1.0}, -F {0.0 <= N < 1.0}
                               Choose a number in the specified range
-  --choice_range {0 <= N <= 19}, -c {0 <= N <= 19}
+  --choice-range {0 <= N <= 19}, -c {0 <= N <= 19}
                               Choose a number in the specified range

--- a/tests/test_conversion/test_convert_argparse.py
+++ b/tests/test_conversion/test_convert_argparse.py
@@ -15,7 +15,7 @@ from cli_command_parser.conversion.argparse_utils import ArgumentParser, SubPars
 from cli_command_parser.conversion.command_builder import Converter, ParserConverter, ParamConverter, convert_script
 from cli_command_parser.conversion.command_builder import ConversionError
 from cli_command_parser.conversion.utils import get_name_repr, collection_contents
-from cli_command_parser.conversion.visitor import TrackedRefMap
+from cli_command_parser.conversion.visitor import ScriptVisitor, TrackedRefMap, TrackedRef
 from cli_command_parser.testing import ParserTest, RedirectStreams
 
 if TYPE_CHECKING:
@@ -123,11 +123,14 @@ class ArgparseConversionTest(ParserTest):
             Script(code).parsers[0].pprint()
         self.assert_strings_equal(expected, streams.stdout.strip())
 
-    def test_renamed_import_and_remainder(self):
+    def test_renamed_import_and_remainder_in_func(self):
         code = """
+import logging
 from argparse import ArgumentParser as ArgParser, REMAINDER
-parser = ArgParser()
-parser.add_argument('test', nargs=REMAINDER)
+log = logging.getLogger(__name__)
+def main():
+    parser = ArgParser()
+    parser.add_argument('test', nargs=REMAINDER)
         """
         expected = f'{IMPORT_LINE}\n\n\nclass Command0(Command):  {DISCLAIMER}\n    test = PassThru()'
         self.assertEqual(expected, convert_script(Script(code)))
@@ -185,7 +188,7 @@ sp1 = subparsers.add_parser('one', help='Command one')
 sp1.add_argument('--foo-bar', '-f', action='store_true', help='Do foo bar')
 sp2 = subparsers.add_parser('two', description='Command two')
 sp2.add_argument('--baz', '-b', nargs='+', help='What to baz')
-for sp in [sp1]:
+for sp in [sp1, sp123456789]:
     group = sp.add_mutually_exclusive_group()
     group.add_argument('--verbose', '-v', action='count', default=0, help='Increase logging verbosity')
     group.add_argument('--dry_run', '-D', action='store_true', help='Perform a dry run with no side effects')
@@ -319,6 +322,57 @@ class One(Command0, help='Command one'):\n    foo_bar = Flag('-f')
         code = f"from argparse import ArgumentParser as AP\np = AP(); p.add_argument('--foo', help={text!r})"
         expected = f"{IMPORT_LINE}\n\n\nclass Command0(Command):  {DISCLAIMER}\n    foo = Option(help='The foo')"
         self.assertEqual(expected, convert_script(Script(code)))
+
+
+class AstVisitorTest(ParserTest):
+    def test_touch_for_unhandled_cases(self):
+        code = """
+from logging import getLogger
+from argparse import Namespace, ArgumentParser as AP
+log = getLogger(__name__)
+def foo():
+    for k, v in {}.items():
+        pass
+    for t in some_iterable:
+        pass
+with foo():
+    a = int
+    b = {'a': 1}['a']
+p = AP()
+        """
+        self.assertEqual(1, len(Script(code).parsers))
+
+    def test_tracked_ref(self):
+        a, b = TrackedRef('foo.bar'), TrackedRef('foo.baz')
+        self.assertEqual('<TrackedRef: foo.bar>', repr(a))
+        self.assertIn(a, {a, b})
+        self.assertNotIn(a, {b})
+        self.assertEqual(a, TrackedRef('foo.bar'))
+
+    def test_with_no_as_name(self):
+        self.assertEqual(1, len(Script('from argparse import ArgumentParser as AP\nwith AP():\n    pass').parsers))
+
+    def test_resolve_ref_no_visit_func(self):
+        class FakeRef:
+            def __init__(self, module, name):
+                self.module, self.name = module, name
+
+        ref = FakeRef('foo', 'bar')
+        visitor = ScriptVisitor()
+        visitor.track_refs_to(ref)  # noqa
+        visitor.scopes['foo'] = ref
+        self.assertIsNone(visitor.resolve_ref('foo.bar'))
+
+    def test_for_multiple_parser_parents(self):
+        code = """
+from argparse import ArgumentParser as AP\np1 = AP()\nsp = p1.add_subparsers()\nsp1 = sp.add_parser('foo')\n
+p2 = AP()\nfor p in (sp1, p2):\n    pass
+        """
+        self.assertEqual(2, len(Script(code).parsers))
+
+    def test_for_no_subparsers(self):
+        code = 'from argparse import ArgumentParser as AP\np1 = AP()\np2 = AP()\nfor p in (p1, p2):\n    pass'
+        self.assertEqual(2, len(Script(code).parsers))
 
 
 class ArgparseConversionCustomSubclassTest(ParserTest):

--- a/tests/test_documentation/test_help_text.py
+++ b/tests/test_documentation/test_help_text.py
@@ -200,8 +200,8 @@ class HelpTextTest(ParserTest):
         expected = """Optional arguments:
   --help, -h                  Show this help message and exit
   --escape ESCAPE, -e ESCAPE  Escape the provided regex special characters (default: '()')
-  --allow_inst, -I            Allow search results that include instrumental versions of songs
-  --full_info, -F             Print all available info about the discovered objects
+  --allow-inst, -I            Allow search results that include instrumental versions of songs
+  --full-info, -F             Print all available info about the discovered objects
   --format {json|json-pretty|json-compact|text|yaml|pprint|csv|table|pseudo-yaml|json-lines|plain|pseudo-json},
     -f {json|json-pretty|json-compact|text|yaml|pprint|csv|table|pseudo-yaml|json-lines|plain|pseudo-json}
                               Output format to use for --full_info (default: 'yaml')
@@ -254,6 +254,14 @@ class HelpTextTest(ParserTest):
         help_text = get_help_text(Foo)
         self.assertIn('--foo-bar', help_text)
         self.assertNotIn('--foo_bar', help_text)
+
+    def test_only_underscore_enabled(self):
+        class Foo(Command, option_name_mode='_'):
+            foo_bar = Flag()
+
+        help_text = get_help_text(Foo)
+        self.assertIn('--foo_bar', help_text)
+        self.assertNotIn('--foo-bar', help_text)
 
     def test_option_name_mode_overrides(self):
         mode_exp_map = {'underscore': ('--foo_a',), 'dash': ('--foo-a',), 'both': ('--foo-a', '--foo_a')}
@@ -654,20 +662,20 @@ class GroupHelpTextTest(ParserTest):
 
     def test_nested_show_tree(self):
         expected = """
-        usage: foo.py [--foo FOO] [--arg_a ARG_A] [--arg_b ARG_B] [--arg_y ARG_Y] [--arg_z ARG_Z] [--bar] [--baz] [--help]
+        usage: foo.py [--foo FOO] [--arg-a ARG_A] [--arg-b ARG_B] [--arg-y ARG_Y] [--arg-z ARG_Z] [--bar] [--baz] [--help]
 
         Optional arguments:
         │ --foo FOO, -f FOO         Do foo
         │ --help, -h                Show this help message and exit
         │
         Mutually exclusive options:
-        ¦ --arg_a ARG_A, -a ARG_A   A
-        ¦ --arg_b ARG_B, -b ARG_B   B
+        ¦ --arg-a ARG_A, -a ARG_A   A
+        ¦ --arg-b ARG_B, -b ARG_B   B
         ¦
         ¦ Mutually dependent options:
-        ¦ ║ --arg_y ARG_Y, -y ARG_Y
+        ¦ ║ --arg-y ARG_Y, -y ARG_Y
         ¦ ║                         Y
-        ¦ ║ --arg_z ARG_Z, -z ARG_Z
+        ¦ ║ --arg-z ARG_Z, -z ARG_Z
         ¦ ║                         Z
         ¦ ║
         ¦

--- a/tests/test_parameters/test_options.py
+++ b/tests/test_parameters/test_options.py
@@ -511,14 +511,18 @@ class TriFlagTest(ParserTest):
         self.assert_parse_results_cases(Foo, success_cases)
 
     def test_auto_long_with_alt(self):
-        class Foo(Command):
-            foo = TriFlag(alt_long='--no-foo')
-            bar = TriFlag('--bar', alt_long='--baz')
-            abc = TriFlag()
+        cases = [({}, '--no-abc'), ({'option_name_mode': '_'}, '--no_abc')]
+        for kwargs, abc_long in cases:
+            with self.subTest(kwargs=kwargs, abc_long=abc_long):
 
-        self.assertEqual(['--no-foo', '--foo'], Foo.foo.option_strs.long)
-        self.assertEqual(['--bar', '--baz'], Foo.bar.option_strs.long)
-        self.assertEqual(['--no_abc', '--abc'], Foo.abc.option_strs.long)
+                class Foo(Command, **kwargs):
+                    foo = TriFlag(alt_long='--no-foo')
+                    bar = TriFlag('--bar', alt_long='--baz')
+                    abc = TriFlag()
+
+                self.assertEqual(['--no-foo', '--foo'], Foo.foo.option_strs.long)
+                self.assertEqual(['--bar', '--baz'], Foo.bar.option_strs.long)
+                self.assertEqual([abc_long, '--abc'], Foo.abc.option_strs.long)
 
 
 class CounterTest(ParserTest):


### PR DESCRIPTION
As stated in #26, the default option name mode for option-like parameters with an underscore in their attribute names has been updated to use a dash in the automatically generated long form option string instead of underscore by default.  Ways to restore the former behavior are mentioned in #26.