### PR TITLE
Added support for string values with a leading dash

### DIFF
--- a/docs/_src/parameters.rst
+++ b/docs/_src/parameters.rst
@@ -122,6 +122,11 @@ The generic :class:`.Option` parameter that accepts arbitrary values or lists of
   will not be checked.  If multiple env variable names/keys were provided, then they will be checked in the order
   that they were provided.  When enabled, values from env variables take precedence over the default value.  When
   enabled and the Parameter is required, then either a CLI value or an env var value must be provided.
+:allow_leading_dash: Whether string values may begin with a dash (``-``).  By default, if a value begins with a dash,
+  it is only accepted if it appears to be a negative numeric value.  Use ``True`` / ``always`` /
+  ``AllowLeadingDash.ALWAYS`` to allow any value that begins with a dash (as long as it is not an option string for an
+  Option/Flag/etc).  To reject all values beginning with a dash, including numbers, use ``False`` / ``never`` /
+  ``AllowLeadingDash.NEVER``.
 
 
 Given the following example Command::
@@ -322,6 +327,11 @@ The generic :class:`.Positional` parameter that accepts arbitrary values or list
 :default: Only supported when ``action='store'`` and 0 values are allowed by the specified ``nargs``.  Defaults
   to ``None`` under those conditions.
 :choices: A container that holds the specific values that users must pick from.  By default, any value is allowed.
+:allow_leading_dash: Whether string values may begin with a dash (``-``).  By default, if a value begins with a dash,
+  it is only accepted if it appears to be a negative numeric value.  Use ``True`` / ``always`` /
+  ``AllowLeadingDash.ALWAYS`` to allow any value that begins with a dash (as long as it is not an option string for an
+  Option/Flag/etc).  To reject all values beginning with a dash, including numbers, use ``False`` / ``never`` /
+  ``AllowLeadingDash.NEVER``.
 
 
 :gh_examples:`Example command <echo.py>`::

--- a/lib/cli_command_parser/__init__.py
+++ b/lib/cli_command_parser/__init__.py
@@ -4,7 +4,14 @@ Command Parser
 :author: Doug Skrypa
 """
 
-from .config import CommandConfig, ShowDefaults, OptionNameMode, SubcommandAliasHelpMode
+from .config import (
+    CommandConfig,
+    ShowDefaults,
+    OptionNameMode,
+    SubcommandAliasHelpMode,
+    AmbiguousComboMode,
+    AllowLeadingDash,
+)
 from .commands import Command, main
 from .context import Context, get_current_context, ctx, get_parsed, get_context, get_raw_arg
 from .exceptions import (

--- a/lib/cli_command_parser/command_parameters.py
+++ b/lib/cli_command_parser/command_parameters.py
@@ -277,7 +277,7 @@ class CommandParameters:
         for param in action_flags:
             if param.func is None:
                 raise ParameterDefinitionError(f'No function was registered for param={param!r}')
-            grouped_ordered_flags[param.before_main][param.order].append(param)
+            grouped_ordered_flags[param.before_main][param.order].append(param)  # noqa  # PyCharm infers the wrong type
 
         found_non_always = False
         invalid = {}

--- a/lib/cli_command_parser/config.py
+++ b/lib/cli_command_parser/config.py
@@ -24,6 +24,7 @@ __all__ = [
     'OptionNameMode',
     'SubcommandAliasHelpMode',
     'AmbiguousComboMode',
+    'AllowLeadingDash',
     'DEFAULT_CONFIG',
 ]
 
@@ -176,6 +177,36 @@ class AmbiguousComboMode(MissingMixin, Enum):
     IGNORE = 'ignore'           # Ignore potentially ambiguous combinations of short options entirely
     PERMISSIVE = 'permissive'   # Allow multi-char short options that overlap with a single char one for exact matches
     STRICT = 'strict'           # Reject multi-char short options that overlap with a single char one before parsing
+
+
+class AllowLeadingDash(Enum):
+    """
+    How a given Parameter should handle values with a leading dash (``-``).  Only configurable at the Parameter level,
+    not the Command level.
+
+    The behavior based on each supported option:
+
+    :NUMERIC: Allow numeric values like ``-5`` and ``-1.3``, but reject values like ``-d``.
+    :ALWAYS: Always allow values with a leading dash.
+    :NEVER: Never allow values with a leading dash.
+    """
+
+    NUMERIC = 'numeric'     # Allow a leading dash when the value is numeric
+    ALWAYS = 'always'       # Always allow a leading dash
+    NEVER = 'never'         # Never allow a leading dash
+
+    @classmethod
+    def _missing_(cls, value):
+        if isinstance(value, str):
+            try:
+                return cls._member_map_[value.upper()]  # noqa
+            except KeyError:
+                pass
+        elif value is True:
+            return cls.ALWAYS
+        elif value is False:
+            return cls.NEVER
+        return super()._missing_(value)  # noqa
 
 
 # endregion

--- a/lib/cli_command_parser/formatting/params.py
+++ b/lib/cli_command_parser/formatting/params.py
@@ -405,7 +405,6 @@ class PassThruHelpFormatter(ParamHelpFormatter, param_cls=PassThru):
 
 class GroupHelpFormatter(ParamHelpFormatter, param_cls=ParamGroup):  # noqa  # pylint: disable=W0223
     required_formatter_map: BoolFormatterMap = {True: '{{{}}}'.format, False: '[{}]'.format}
-    # TODO: #18 Group order changes between invocations - should be sorted as declared or alphanumerically (config?)
 
     def _get_choice_delim(self) -> str:
         param: ParamGroup = self.param

--- a/lib/cli_command_parser/parameters/choice_map.py
+++ b/lib/cli_command_parser/parameters/choice_map.py
@@ -150,10 +150,9 @@ class ChoiceMap(BasePositional[str], Generic[T]):
         return n_values
 
     def validate(self, value: str):
-        values = ctx.get_parsed_value(self).copy()
-        values.append(value)
         choices = self.choices
         if choices:
+            values = (*ctx.get_parsed_value(self), value)
             choice = ' '.join(values)
             if choice in choices:
                 return
@@ -163,6 +162,7 @@ class ChoiceMap(BasePositional[str], Generic[T]):
             if not any(c.startswith(prefix) for c in choices if c):
                 raise InvalidChoice(self, prefix[:-1], choices)
         elif value.startswith('-'):
+            # Note: choices with a leading dash are rejected by `_validate_positional`
             raise BadArgument(self, f'invalid value={value!r}')
 
     def result_value(self) -> OptStr:

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -73,7 +73,11 @@ class Option(BasicActionMixin, BaseOption[T_co]):
         if nargs is not None:
             self.nargs = Nargs(nargs)
         if 0 in self.nargs:
-            raise ParameterDefinitionError(f'Invalid nargs={self.nargs} - use Flag or Counter for Options with 0 args')
+            details = 'use Flag or Counter for Options with 0 args'
+            if isinstance(nargs, range) and nargs.start == 0 and nargs.step != nargs.stop:
+                suffix = f', {nargs.step}' if nargs.step != 1 else ''
+                details = f'try using range({nargs.step}, {nargs.stop}{suffix}) instead, or {details}'
+            raise ParameterDefinitionError(f'Invalid nargs={nargs!r} - {details}')
         if action is _NotSet:
             action = 'store' if self.nargs == 1 else 'append'
         elif action == 'store' and self.nargs != 1:

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -54,6 +54,11 @@ class Option(BasicActionMixin, BaseOption[T_co]):
       will not be checked.  If multiple env variable names/keys were provided, then they will be checked in the order
       that they were provided.  When enabled, values from env variables take precedence over the default value.  When
       enabled and the Parameter is required, then either a CLI value or an env var value must be provided.
+    :param allow_leading_dash: Whether string values may begin with a dash (``-``).  By default, if a value begins with
+      a dash, it is only accepted if it appears to be a negative numeric value.  Use ``True`` / ``always`` /
+      ``AllowLeadingDash.ALWAYS`` to allow any value that begins with a dash (as long as it is not an option string for
+      an Option/Flag/etc).  To reject all values beginning with a dash, including numbers, use ``False`` / ``never`` /
+      ``AllowLeadingDash.NEVER``.
     :param kwargs: Additional keyword arguments to pass to :class:`.BaseOption`.
     """
 

--- a/lib/cli_command_parser/parameters/positionals.py
+++ b/lib/cli_command_parser/parameters/positionals.py
@@ -42,6 +42,11 @@ class Positional(BasicActionMixin, BasePositional, default_ok=True):
       an empty list will be returned for this Parameter.
     :param choices: A container that holds the specific values that users must pick from.  By default, any value is
       allowed.
+    :param allow_leading_dash: Whether string values may begin with a dash (``-``).  By default, if a value begins with
+      a dash, it is only accepted if it appears to be a negative numeric value.  Use ``True`` / ``always`` /
+      ``AllowLeadingDash.ALWAYS`` to allow any value that begins with a dash (as long as it is not an option string for
+      an Option/Flag/etc).  To reject all values beginning with a dash, including numbers, use ``False`` / ``never`` /
+      ``AllowLeadingDash.NEVER``.
     :param kwargs: Additional keyword arguments to pass to :class:`.BasePositional`.
     """
 

--- a/lib/cli_command_parser/parameters/positionals.py
+++ b/lib/cli_command_parser/parameters/positionals.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from ..config import AllowLeadingDash
 from ..exceptions import ParameterDefinitionError
 from ..inputs import normalize_input_type
 from ..nargs import Nargs, NargsValue
@@ -15,7 +16,7 @@ from ..utils import _NotSet
 from .base import BasicActionMixin, BasePositional
 
 if TYPE_CHECKING:
-    from ..typing import InputTypeFunc, ChoicesType
+    from ..typing import InputTypeFunc, ChoicesType, LeadingDash
 
 __all__ = ['Positional']
 
@@ -52,6 +53,7 @@ class Positional(BasicActionMixin, BasePositional, default_ok=True):
         default: Any = _NotSet,
         *,
         choices: ChoicesType = None,
+        allow_leading_dash: LeadingDash = None,
         **kwargs,
     ):
         if nargs is not None:
@@ -71,3 +73,5 @@ class Positional(BasicActionMixin, BasePositional, default_ok=True):
         kwargs.setdefault('required', required)
         super().__init__(action=action, default=default, **kwargs)
         self.type = normalize_input_type(type, choices)
+        if allow_leading_dash is not None:
+            self.allow_leading_dash = AllowLeadingDash(allow_leading_dash)

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -28,10 +28,12 @@ __all__ = ['CommandParser']
 class CommandParser:
     """Stateful parser used for a single pass of argument parsing"""
 
-    __slots__ = ('_last', 'arg_deque', 'ctx', 'deferred', 'node', 'params', 'positionals')
+    __slots__ = ('_last', 'arg_deque', 'ctx', 'deferred', 'params', 'positionals')
 
     arg_deque: Optional[Deque[str]]
     deferred: Optional[List[str]]
+    params: CommandParameters
+    positionals: List[BasePositional]
     _last: Optional[Parameter]
 
     def __init__(self, ctx: Context):

--- a/lib/cli_command_parser/typing.py
+++ b/lib/cli_command_parser/typing.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
     from enum import Enum
     from pathlib import Path
     from .commands import Command
-    from .config import CommandConfig
+    from .config import CommandConfig, AllowLeadingDash
     from .core import CommandMeta
     from .inputs import InputType
     from .parameters import Parameter, ParamGroup
@@ -48,6 +48,7 @@ Converter = Union[Deserializer, Serializer]
 
 Config = Optional['CommandConfig']
 AnyConfig = Union[Config, Dict[str, Any]]
+LeadingDash = Union['AllowLeadingDash', str, bool]
 
 Param = TypeVar('Param', bound='Parameter')
 ParamList = List[Param]

--- a/lib/cli_command_parser/utils.py
+++ b/lib/cli_command_parser/utils.py
@@ -19,7 +19,6 @@ except ImportError:
 FlagEnum = TypeVar('FlagEnum', bound='FixedFlag')
 _NotSet = object()
 
-
 # region Text Processing / Formatting
 
 
@@ -31,7 +30,7 @@ def short_repr(obj: Any, max_len: int = 100, sep: str = '...', func: Callable[[A
     obj_repr = func(obj)
     if len(obj_repr) > max_len:
         part_len = (max_len - len(sep)) // 2
-        return '{}{}{}'.format(obj_repr[:part_len], sep, obj_repr[-part_len:])
+        return f'{obj_repr[:part_len]}{sep}{obj_repr[-part_len:]}'
     return obj_repr
 
 
@@ -123,7 +122,7 @@ class FixedFlag(Flag, metaclass=FixedFlagMeta):
         if self._name_ is None or '|' in self._name_:  # | check is for 3.11 where pseudo-members are assigned names
             val = self._value_
             members = ((mem, mem._value_) for mem in self.__class__)
-            return sorted(mem for mem, mem_val in members if mem_val & val == mem_val)
+            return sorted(mem for mem, mem_val in members if mem_val & val == mem_val)  # noqa
         return [self]
 
     def __lt__(self, other: FlagEnum) -> bool:

--- a/readme.rst
+++ b/readme.rst
@@ -81,6 +81,13 @@ with optional dependencies::
 
     $ pip install -U cli-command-parser[wcwidth]
 
+To use the argparse to cli-command-parser conversion script with Python 3.7 or 3.8, there is a dependency on
+`astunparse <https://astunparse.readthedocs.io>`__.  If you are using Python 3.9 or above, then ``astunparse`` is not
+necessary because the relevant code was added to the stdlib ``ast`` module.  If you're unsure, you can install
+cli-command-parser with the following command to automatically handle whether that extra dependency is needed or not::
+
+    $ pip install -U cli-command-parser[conversion]
+
 
 Links
 *****

--- a/tests/test_commands/test_sub_commands.py
+++ b/tests/test_commands/test_sub_commands.py
@@ -4,8 +4,8 @@ from abc import ABC
 from unittest import main
 from unittest.mock import Mock
 
-from cli_command_parser import Command, SubCommand, Counter, Option, Positional, Flag, TriFlag
-from cli_command_parser.exceptions import CommandDefinitionError, MissingArgument
+from cli_command_parser import Command, SubCommand, Counter, Option, Positional, Flag, TriFlag, ParamGroup
+from cli_command_parser.exceptions import CommandDefinitionError, MissingArgument, UsageError
 from cli_command_parser.formatting.commands import get_formatter
 from cli_command_parser.testing import RedirectStreams, ParserTest, get_help_text
 
@@ -233,13 +233,14 @@ class SubCommandTest(ParserTest):
 
         with self.subTest(case='parsing'):
             success_cases = [
-                (['a', '-b1', '-B', 'a'], {'foo': None, 'bar': 1, 'baz': 'a', 'sub_cmd': 'a'}),
+                (['a', '-b1', '-B', 'a', '-fx'], {'foo': 'x', 'bar': 1, 'baz': 'a', 'sub_cmd': 'a'}),
                 (['b', '-b2', '-B', 'a'], {'foo': None, 'bar': 2, 'baz': 'a', 'sub_cmd': 'b'}),
                 (['a'], {'foo': None, 'bar': None, 'baz': None, 'sub_cmd': 'a'}),
                 (['b'], {'foo': None, 'bar': None, 'baz': None, 'sub_cmd': 'b'}),
             ]
             self.assert_parse_results_cases(Base, success_cases)
-            self.assert_parse_fails(Base, ['mid'])
+            fail_cases = [['mid'], ['mid', 'a'], ['mid', 'b'], ['a', 'mid'], ['b', 'mid']]
+            self.assert_parse_fails_cases(Base, fail_cases, UsageError)
 
     def test_config_inherited(self):
         class Base(Command, option_name_mode='-'):

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -4,7 +4,7 @@ from itertools import product, starmap
 from operator import or_
 from unittest import TestCase, main
 
-from cli_command_parser.config import CommandConfig, ShowDefaults, ConfigItem, DEFAULT_CONFIG
+from cli_command_parser.config import CommandConfig, ShowDefaults, ConfigItem, DEFAULT_CONFIG, AllowLeadingDash
 
 
 class ConfigTest(TestCase):
@@ -66,6 +66,12 @@ class ConfigTest(TestCase):
     def test_ro_del_rejected(self):
         with self.assertRaises(AttributeError):
             del DEFAULT_CONFIG.usage_column_width
+
+    def test_invalid_allow_leading_dash(self):
+        with self.assertRaises(ValueError):
+            AllowLeadingDash('foo')
+        with self.assertRaises(ValueError):
+            AllowLeadingDash(1)
 
 
 if __name__ == '__main__':

--- a/tests/test_documentation/test_help_text.py
+++ b/tests/test_documentation/test_help_text.py
@@ -364,7 +364,8 @@ class SubcommandHelpAndRstTest(ParserTest):
             sc_kwargs = {}
 
         with self.subTest(mode=mode, **cmd_kwargs):
-            expected_help, expected_rst = get_expected_help_and_rst(help_header, param_help_map)
+            expected_help = prep_expected_help_text(help_header, param_help_map)
+            expected_rst = prep_expected_rst('    |             |     {:<13s} |\n', param_help_map)
 
             class Foo(Command, **cmd_kwargs):
                 sub_cmd = SubCommand(**sc_kwargs)
@@ -480,14 +481,17 @@ class SubcommandHelpAndRstTest(ParserTest):
                     pass
 
 
-def get_expected_help_and_rst(help_header: str, param_help_map: Dict[str, str]) -> Tuple[str, str]:
-    kf = '    {:s}\n'.format
-    hf = '    {:<25s} {}\n'.format
-    rf = '    |             |     {:<13s} |\n'.format
-    expected_help = help_header + ''.join(hf(k, v) if v else kf(k) for k, v in param_help_map.items())
+def prep_expected_help_text(help_header: str, param_help_map: Dict[str, str], indent: int = 4) -> str:
+    prefix = ' ' * indent
+    kf = f'{prefix}{{:s}}\n'.format
+    hf = f'{prefix}{{:<25s}} {{}}\n'.format
+    return help_header + ''.join(hf(k, v) if v else kf(k) for k, v in param_help_map.items())
+
+
+def prep_expected_rst(table_fmt_str: str, param_help_map: Dict[str, str]) -> str:
+    rf = table_fmt_str.format
     table = RstTable.from_dict({f'``{k}``': v for k, v in param_help_map.items()}, use_table_directive=False)
-    expected_rst = ''.join(rf(line) for line in table.iter_build() if line)
-    return expected_help, expected_rst
+    return ''.join(rf(line) for line in table.iter_build() if line)
 
 
 class ShowDefaultsTest(TestCase):

--- a/tests/test_parameters/test_choice_maps.py
+++ b/tests/test_parameters/test_choice_maps.py
@@ -3,8 +3,7 @@
 from unittest import main
 from unittest.mock import Mock
 
-from cli_command_parser import Command
-from cli_command_parser.context import Context
+from cli_command_parser import Command, Context
 from cli_command_parser.exceptions import CommandDefinitionError, BadArgument, InvalidChoice
 from cli_command_parser.parameters.choice_map import SubCommand, Action, Choice
 from cli_command_parser.testing import ParserTest
@@ -135,6 +134,8 @@ class ChoiceMapTest(ParserTest):
 
         self.assertIn('foo', Foo.action.choices)
 
+    # region Kwargs Not Allowed
+
     def test_nargs_not_allowed_sub_cmd(self):
         with self.assertRaises(TypeError):
             SubCommand(nargs='+')
@@ -147,6 +148,10 @@ class ChoiceMapTest(ParserTest):
         with self.assertRaises(TypeError):
             SubCommand(choices=(1, 2))
 
+    def test_allow_leading_dash_not_allowed_sub_cmd(self):
+        with self.assertRaises(TypeError):
+            SubCommand(allow_leading_dash=True)
+
     def test_nargs_not_allowed_action(self):
         with self.assertRaises(TypeError):
             Action(nargs='+')
@@ -158,6 +163,12 @@ class ChoiceMapTest(ParserTest):
     def test_choices_not_allowed_action(self):
         with self.assertRaises(TypeError):
             Action(choices=(1, 2))
+
+    def test_allow_leading_dash_not_allowed_action(self):
+        with self.assertRaises(TypeError):
+            Action(allow_leading_dash=True)
+
+    # endregion
 
     def test_choice_format_help(self):
         choice = Choice('test', help='Example choice')

--- a/tests/test_parameters/test_misc.py
+++ b/tests/test_parameters/test_misc.py
@@ -117,6 +117,10 @@ class PassThruTest(ParserTest):
         with self.assertRaises(TypeError):
             PassThru(choices=(1, 2))
 
+    def test_allow_leading_dash_not_allowed(self):
+        with self.assertRaises(TypeError):
+            PassThru(allow_leading_dash=True)
+
 
 class MiscParameterTest(ParserTest):
     def test_param_knows_command(self):

--- a/tests/test_parameters/test_options.py
+++ b/tests/test_parameters/test_options.py
@@ -84,6 +84,26 @@ class OptionTest(ParserTest):
         ]
         self.assert_call_fails_cases(Option, fail_cases)
 
+    def test_nargs_0_range_tip_step_1(self):
+        expected = r'try using range\(1, 2\) instead, or use Flag or Counter for Options with 0 args'
+        with self.assertRaisesRegex(ParameterDefinitionError, expected):
+
+            class Foo(Command):
+                bar = Option(nargs=range(2))
+
+    def test_nargs_0_range_tip_step_2_matches_stop(self):
+        with self.assertRaisesRegex(ParameterDefinitionError, 'use Flag or Counter for Options with 0 args'):
+
+            class Foo(Command):
+                bar = Option(nargs=range(0, 2, 2))
+
+    def test_nargs_0_range_tip_step_2(self):
+        expected = r'try using range\(2, 3, 2\) instead, or use Flag or Counter for Options with 0 args'
+        with self.assertRaisesRegex(ParameterDefinitionError, expected):
+
+            class Foo(Command):
+                bar = Option(nargs=range(0, 3, 2))
+
     def test_bad_option_strs_rejected(self):
         # fmt: off
         fail_cases = [

--- a/tests/test_parameters/test_options.py
+++ b/tests/test_parameters/test_options.py
@@ -342,6 +342,10 @@ class FlagTest(ParserTest):
         with self.assertRaises(TypeError):
             Flag(choices=(1, 2))
 
+    def test_allow_leading_dash_not_allowed(self):
+        with self.assertRaises(TypeError):
+            Flag(allow_leading_dash=True)
+
     def test_name_both(self):
         class Foo(Command, option_name_mode='*'):
             foo_bar = Flag('-b')
@@ -418,6 +422,10 @@ class TriFlagTest(ParserTest):
     def test_metavar_not_allowed(self):
         with self.assertRaises(TypeError):
             TriFlag(metavar='foo')
+
+    def test_allow_leading_dash_not_allowed(self):
+        with self.assertRaises(TypeError):
+            TriFlag(allow_leading_dash=True)
 
     def test_bad_consts(self):
         exc = ParameterDefinitionError
@@ -660,6 +668,10 @@ class CounterTest(ParserTest):
     def test_choices_not_allowed(self):
         with self.assertRaises(TypeError):
             Counter(choices=(1, 2))
+
+    def test_allow_leading_dash_not_allowed(self):
+        with self.assertRaises(TypeError):
+            Counter(allow_leading_dash=True)
 
 
 if __name__ == '__main__':

--- a/tests/test_parameters/test_positionals.py
+++ b/tests/test_parameters/test_positionals.py
@@ -3,8 +3,8 @@
 from unittest import main
 from unittest.mock import Mock
 
-from cli_command_parser import Command
-from cli_command_parser.exceptions import ParameterDefinitionError, CommandDefinitionError
+from cli_command_parser import Command, ParamGroup
+from cli_command_parser.exceptions import ParameterDefinitionError, CommandDefinitionError, UsageError
 from cli_command_parser.parameters.base import parameter_action, BasePositional
 from cli_command_parser.parameters import Positional
 from cli_command_parser.testing import ParserTest
@@ -60,6 +60,17 @@ class PositionalTest(ParserTest):
 
         with self.assertRaises(CommandDefinitionError):
             Foo.parse([])
+
+    def test_pos_grouped_pos_both_required(self):
+        class Foo(Command):
+            bar = Positional()
+            with ParamGroup():
+                baz = Positional()
+
+        success_cases = [(['a', 'b'], {'bar': 'a', 'baz': 'b'})]
+        self.assert_parse_results_cases(Foo, success_cases)
+        fail_cases = [[], ['a']]
+        self.assert_parse_fails_cases(Foo, fail_cases, UsageError)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Improved the error message when attempting to use `nargs=range(2)` or similar for an Option to suggest an alternative
- Added `allow_leading_dash` option for `Option` and `Positional` parameters, with the default matching the old behavior of only allowing numeric values that begin with a dash