### PR TITLE
Minor improvements to argparse conversion

### DIFF
--- a/lib/cli_command_parser/conversion/command_builder.py
+++ b/lib/cli_command_parser/conversion/command_builder.py
@@ -643,9 +643,16 @@ class FlagArgs(OptionArgs):
                 action = None
         else:
             if default == opposite:
-                default = None
+                const = None
+                if action == 'store_true':
+                    default = None
+            elif not default and action == 'store_false':
+                default = 'True'
+                const = None
+            else:
+                const = value if default else None
+
             action = None
-            const = value if default else None
 
         kwargs['type'] = kwargs['nargs'] = None
         if action:

--- a/lib/cli_command_parser/conversion/command_builder.py
+++ b/lib/cli_command_parser/conversion/command_builder.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import keyword
 import logging
 from abc import ABC, abstractmethod
-from ast import literal_eval, Attribute, Name, GeneratorExp, Subscript, DictComp, ListComp, SetComp
+from ast import literal_eval, Attribute, Name, GeneratorExp, Subscript, DictComp, ListComp, SetComp, Constant, Str
 from dataclasses import dataclass, fields
 from itertools import count
 from typing import TYPE_CHECKING, Union, Optional, Iterator, Iterable, Type, TypeVar, Generic, List, Tuple
@@ -370,6 +370,10 @@ class ParamConverter(Converter[ParserArg], converts=ParserArg):
         return next(name for name in self._attr_name_candidates() if name not in RESERVED)
 
     def _attr_name_candidates(self) -> Iterator[str]:
+        dest = self.ast_obj.init_func_raw_kwargs.get('dest')
+        if dest is not None and isinstance(dest, (Constant, Str)):  # Str is for 3.7 compatibility
+            yield getattr(dest, dest._fields[0])  # .value for Constant, .s for Str
+
         long, short, plain = self._grouped_opt_strs
         if self.is_positional or self.is_pass_thru:
             yield from plain

--- a/lib/cli_command_parser/conversion/command_builder.py
+++ b/lib/cli_command_parser/conversion/command_builder.py
@@ -31,13 +31,16 @@ def convert_script(script: Script, add_methods: bool = False) -> str:
 
 class Converter(Generic[AC], ABC):
     converts: Type[AC] = None
+    newline_between_members: bool = False
     _ac_converter_map = {}
 
-    def __init_subclass__(cls, converts: Type[AC] = None, **kwargs):
+    def __init_subclass__(cls, converts: Type[AC] = None, newline_between_members: bool = None, **kwargs):
         super().__init_subclass__(**kwargs)
         if converts:
             cls.converts = converts
             cls._ac_converter_map[converts] = cls
+        if newline_between_members is not None:
+            cls.newline_between_members = newline_between_members
 
     def __init__(self, ast_obj: Union[AC, Script], parent: Optional[Converter] = None):
         self.ast_obj = ast_obj
@@ -90,7 +93,10 @@ class ConverterGroup(Generic[C]):
         yield from self.members
 
     def format_all(self, indent: int = 0) -> Iterator[str]:
-        for member in self.members:
+        newline_between_members = self.member_type.newline_between_members
+        for i, member in enumerate(self.members):
+            if i and newline_between_members:
+                yield ''
             yield from member.format_lines(indent)
 
 
@@ -284,7 +290,7 @@ class ParserConverter(CollectionConverter[AstArgumentParser], converts=AstArgume
     # endregion
 
 
-class GroupConverter(CollectionConverter[ArgGroup], converts=ArgGroup):
+class GroupConverter(CollectionConverter[ArgGroup], converts=ArgGroup, newline_between_members=True):
     ast_obj: ArgGroup
 
     def format_lines(self, indent: int = 4) -> Iterator[str]:

--- a/lib/cli_command_parser/conversion/visitor.py
+++ b/lib/cli_command_parser/conversion/visitor.py
@@ -137,20 +137,22 @@ class ScriptVisitor(NodeVisitor):
     # endregion
 
     def resolve_ref(self, name: Union[str, AST, Attribute, Name, expr]):
-        if not isinstance(name, str):
-            name = get_name_repr(name)
-        try:
-            return self.scopes[name]
-        except KeyError:
-            pass
-        try:
-            obj_name, attr = name.rsplit('.', 1)
-        except ValueError:
-            return None
-        try:
-            obj = self.scopes[obj_name]
-        except KeyError:
-            return None
+        if isinstance(name, Attribute) and isinstance(name.value, Call):
+            obj = self.visit_Call(name.value)
+            attr = name.attr
+        else:
+            if not isinstance(name, str):
+                name = get_name_repr(name)
+            try:
+                return self.scopes[name]
+            except KeyError:
+                pass
+            try:
+                obj_name, attr = name.rsplit('.', 1)
+                obj = self.scopes[obj_name]
+            except (ValueError, KeyError):
+                return None
+
         try:
             can_call = attr in obj.visit_funcs
         except (AttributeError, TypeError):

--- a/tests/test_conversion/test_convert_argparse.py
+++ b/tests/test_conversion/test_convert_argparse.py
@@ -337,9 +337,17 @@ group.add_argument('--foo')"""
         expected = prep_expected("foo = Flag(action='append_const', const='bar')")
         self.assert_strings_equal(expected, prep_and_convert("'--foo', action='append_const', const='bar'"))
 
-    def test_flag_remove_redundant_default(self):
+    def test_flag_remove_redundant_default_true(self):
         expected = prep_expected('foo = Flag()')
         self.assert_strings_equal(expected, prep_and_convert("'--foo', action='store_true', default=False"))
+
+    def test_flag_remove_redundant_default_false(self):
+        expected = prep_expected('foo = Flag(default=True)')
+        self.assert_strings_equal(expected, prep_and_convert("'--foo', action='store_false', default=True"))
+
+    def test_flag_store_false(self):
+        expected = prep_expected('foo = Flag(default=True)')
+        self.assert_strings_equal(expected, prep_and_convert("'--foo', action='store_false'"))
 
     # endregion
 

--- a/tests/test_conversion/test_convert_argparse.py
+++ b/tests/test_conversion/test_convert_argparse.py
@@ -236,6 +236,24 @@ class Command9(Command1, choice='123 456'):\n    pass\n\n
         expected = prep_expected(f"with ParamGroup('Misc Group', description='{desc}'):", '    foo = Positional()')
         self.assert_strings_equal(expected, convert_script(Script(code)))
 
+    def test_space_between_groups(self):
+        parts = (prep_args(), prep_group("'--foo'", title='A', var='a'), prep_group("'--bar'", title='B', var='b'))
+        expected = prep_expected(
+            "with ParamGroup('A'):", '    foo = Option()', '', "with ParamGroup('B'):", '    bar = Option()'
+        )
+        self.assertEqual(expected, convert_script(Script('\n'.join(parts))))
+
+    def test_chained_mutually_exclusive_group_in_named_group(self):
+        code = f"""{prep_args()}
+group = p.add_argument_group('Exclusive Options').add_mutually_exclusive_group()
+group.add_argument('--foo')"""
+        expected = prep_expected(
+            "with ParamGroup(description='Exclusive Options'):",
+            '    with ParamGroup(mutually_exclusive=True):',
+            '        foo = Option()',
+        )
+        self.assert_strings_equal(expected, convert_script(Script(code)))
+
     # endregion
 
     # region Param Converter

--- a/tests/test_conversion/test_convert_argparse.py
+++ b/tests/test_conversion/test_convert_argparse.py
@@ -349,6 +349,14 @@ group.add_argument('--foo')"""
         expected = prep_expected('foo = Flag(default=True)')
         self.assert_strings_equal(expected, prep_and_convert("'--foo', action='store_false'"))
 
+    def test_negative_flag_with_dest(self):
+        expected = prep_expected("bar = Flag('--foo', '-f', default=True)")
+        self.assert_strings_equal(expected, prep_and_convert("'--foo', '-f', dest='bar', action='store_false'"))
+
+    def test_positive_flag_with_dest(self):
+        expected = prep_expected("bar = Flag('--foo', '-f')")
+        self.assert_strings_equal(expected, prep_and_convert("'--foo', '-f', dest='bar', action='store_true'"))
+
     # endregion
 
     # region Add Methods


### PR DESCRIPTION
- Fixed spacing between consecutive ParamGroups
- Added visitor handling for chained tracked method calls
- Fixed conversion of Flags with `action='store_false'`
- Improved conversion of options with `dest='...'` so the dest becomes the attr name instead of the first long option