### PR TITLE
Positional inheritance improvements + nargs=REMAINDER support

### DIFF
--- a/docs/_src/parameters.rst
+++ b/docs/_src/parameters.rst
@@ -49,6 +49,8 @@ Common parameters that are supported when initializing most Parameters:
     - ``'?'``: One argument may be provided, but it is not required.  Generally only useful for Positional Parameters.
     - ``'*'``: Any number of arguments may be provided, including none.  The arguments will be collected in a list.
     - ``'+'``: One or more arguments may be provided.  The arguments will be collected in a list.
+    - ``'REMAINDER'``: All remaining arguments will be collected in a list.  Prevents any type casting or choice
+      restrictions from being used, and implies ``allow_leading_dash=AllowLeadingDash.ALWAYS``.
     - ``(N₀, N₁)`` (a tuple of 2 integers): Accept exactly either ``N₀`` or ``N₁`` arguments.  ``N₀`` must be less
       than ``N₁``.
     - ``(N, None)`` (a tuple of an integer and ``None``): Similar to ``'+'``, accept a minimum of ``N`` arguments, or

--- a/lib/cli_command_parser/context.py
+++ b/lib/cli_command_parser/context.py
@@ -182,7 +182,7 @@ class Context(AbstractContextManager):  # Extending AbstractContextManager to ma
 
             params = self.params
             if params:
-                for group in (params.positionals, params.options, (params.pass_thru,)):
+                for group in (params.all_positionals, params.options, (params.pass_thru,)):
                     for param in group:
                         if param and param not in exclude:
                             try:

--- a/lib/cli_command_parser/conversion/command_builder.py
+++ b/lib/cli_command_parser/conversion/command_builder.py
@@ -449,6 +449,7 @@ class ParamConverter(Converter[ParserArg], converts=ParserArg):
         nargs = self.ast_obj.init_func_kwargs.get('nargs')
         if not nargs:
             return False
+        # TODO: Refactor to take advantage of new nargs=REMAINDER support
         return nargs in self.ast_obj.get_tracked_refs('argparse', 'REMAINDER', ())
 
     @cached_property

--- a/lib/cli_command_parser/core.py
+++ b/lib/cli_command_parser/core.py
@@ -162,12 +162,7 @@ class CommandMeta(ABCMeta, type):
         else:
             return first if include_abc else parent
 
-        try:
-            mro = type.mro(cls)[1:]
-        except TypeError:  # a Command object was provided instead of a Command class
-            cls = cls.__class__
-            mro = type.mro(cls)[1:]
-
+        cls, mro = _mro(cls)
         first = parent = None
         for parent_cls in mro:
             if isinstance(parent_cls, mcs):
@@ -198,6 +193,14 @@ class CommandMeta(ABCMeta, type):
             parent_meta = mcs._from_parent(mcs.meta, type.mro(cls)[1:])
             cls.__metadata = meta = ProgramMetadata.for_command(cls, parent=parent_meta, no_sys_argv=no_sys_argv)
         return meta
+
+
+def _mro(cmd_cls):
+    try:
+        return cmd_cls, type.mro(cmd_cls)[1:-1]  # 0 is always the class itself, -1 is always object
+    except TypeError:  # a Command object was provided instead of a Command class
+        cmd_cls = cmd_cls.__class__
+        return cmd_cls, type.mro(cmd_cls)[1:-1]
 
 
 def _choice_items(choice: OptStr, choices: Optional[Choices]) -> Sequence[Tuple[OptStr, OptStr]]:

--- a/lib/cli_command_parser/formatting/commands.py
+++ b/lib/cli_command_parser/formatting/commands.py
@@ -57,7 +57,7 @@ class CommandHelpFormatter:
         if meta.usage:
             return meta.usage
 
-        params = self.params.positionals + self.params.options  # noqa
+        params = self.params.all_positionals + self.params.options  # noqa
         pass_thru = self.params.pass_thru
         if pass_thru is not None:
             params.append(pass_thru)
@@ -155,7 +155,7 @@ def get_formatter(command: CommandAny) -> CommandHelpFormatter:
 
 def get_usage_sub_cmds(command: CommandCls):
     cmd_mcs: Type[CommandMeta] = command.__class__  # Using metaclass to avoid potentially overwritten attrs
-    parent: CommandType = cmd_mcs.parent(command)
+    parent: CommandType = cmd_mcs.parent(command, False)
     if not parent:
         return []
 

--- a/lib/cli_command_parser/formatting/params.py
+++ b/lib/cli_command_parser/formatting/params.py
@@ -424,16 +424,16 @@ class GroupHelpFormatter(ParamHelpFormatter, param_cls=ParamGroup):  # noqa  # p
         if description:
             return description
         group = self.param
-        if not group.description and not group._name:
-            if ctx.config.show_group_type and (group.mutually_exclusive or group.mutually_dependent):
-                return 'Mutually {} options'.format('exclusive' if group.mutually_exclusive else 'dependent')
-            else:
-                return 'Optional arguments'
-        else:
+        if group.description or group._name:
             description = group.description or f'{group.name} options'
             if ctx.config.show_group_type and (group.mutually_exclusive or group.mutually_dependent):
-                description += ' (mutually {})'.format('exclusive' if group.mutually_exclusive else 'dependent')
+                description += f' (mutually {"exclusive" if group.mutually_exclusive else "dependent"})'
             return description
+        elif ctx.config.show_group_type and (group.mutually_exclusive or group.mutually_dependent):
+            return f'Mutually {"exclusive" if group.mutually_exclusive else "dependent"} options'
+
+        adjective = 'Required' if group.required else 'Other' if group.contains_required else 'Optional'
+        return f'{adjective} arguments'
 
     def _get_spacer(self) -> str:
         group = self.param

--- a/lib/cli_command_parser/parameters/groups.py
+++ b/lib/cli_command_parser/parameters/groups.py
@@ -241,7 +241,11 @@ class ParamGroup(ParamBase):
     @property
     def contains_positional(self) -> bool:
         # Used by the help text formatter when grouping parameters / groups
-        return any(isinstance(p, BasePositional) for p in self)
+        return any(isinstance(p, BasePositional) for p in self.members)
+
+    @property
+    def contains_required(self) -> bool:
+        return any(p.required for p in self.members)
 
     @property
     def show_in_help(self) -> bool:

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -10,7 +10,6 @@ from abc import ABC
 from functools import partial, update_wrapper
 from typing import Any, Optional, Callable, Sequence, Iterator, Union, TypeVar, Tuple
 
-from ..config import AllowLeadingDash
 from ..context import ctx, ParseState
 from ..exceptions import ParameterDefinitionError, BadArgument, CommandDefinitionError, ParamUsageError
 from ..inputs import normalize_input_type
@@ -91,10 +90,9 @@ class Option(BasicActionMixin, BaseOption[T_co]):
             raise ParameterDefinitionError(f'Invalid nargs={self.nargs} for action={action!r}')
         super().__init__(*option_strs, action=action, default=default, required=required, **kwargs)
         self.type = normalize_input_type(type, choices)
+        self._validate_nargs_and_allow_leading_dash(allow_leading_dash)
         if env_var:
             self.env_var = env_var
-        if allow_leading_dash is not None:
-            self.allow_leading_dash = AllowLeadingDash(allow_leading_dash)
 
     def env_vars(self) -> Iterator[str]:
         env_var = self.env_var

--- a/lib/cli_command_parser/parameters/pass_thru.py
+++ b/lib/cli_command_parser/parameters/pass_thru.py
@@ -29,7 +29,7 @@ class PassThru(Parameter):
     :param kwargs: Additional keyword arguments to pass to :class:`.Parameter`.
     """
 
-    nargs = Nargs('*')
+    nargs = Nargs('REMAINDER')
     missing_hint: str = "missing pass thru args separated from others with '--'"
 
     def __init__(self, action: str = 'store_all', default: Any = _NotSet, required: Bool = False, **kwargs):

--- a/lib/cli_command_parser/parameters/positionals.py
+++ b/lib/cli_command_parser/parameters/positionals.py
@@ -8,7 +8,6 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from ..config import AllowLeadingDash
 from ..exceptions import ParameterDefinitionError
 from ..inputs import normalize_input_type
 from ..nargs import Nargs, NargsValue
@@ -78,5 +77,4 @@ class Positional(BasicActionMixin, BasePositional, default_ok=True):
         kwargs.setdefault('required', required)
         super().__init__(action=action, default=default, **kwargs)
         self.type = normalize_input_type(type, choices)
-        if allow_leading_dash is not None:
-            self.allow_leading_dash = AllowLeadingDash(allow_leading_dash)
+        self._validate_nargs_and_allow_leading_dash(allow_leading_dash)

--- a/lib/cli_command_parser/parse_tree.py
+++ b/lib/cli_command_parser/parse_tree.py
@@ -260,7 +260,7 @@ class PosNode(MutableMapping[Word, 'PosNode']):
     @classmethod
     def build_tree(cls, command: CommandCls) -> PosNode:
         root = cls(None, None, target=command)
-        process_params(command, [root], command.__class__.params(command).positionals)
+        process_params(command, [root], command.__class__.params(command).all_positionals)
         return root
 
     def update_node(self, word: Word, param: BasePositional, target: Target) -> PosNode:
@@ -358,7 +358,7 @@ def process_param(command: CommandCls, nodes: Iterable[PosNode], param: BasePosi
                 new_nodes.update(node.update_node(choice.choice, param, target) for node in nodes)
             else:
                 choice_nodes = {node.update_node(choice.choice, param, target) for node in nodes}
-                new_nodes.update(process_params(target, choice_nodes, params.positionals))
+                new_nodes.update(process_params(target, choice_nodes, params.all_positionals))
 
         return new_nodes
 

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -40,7 +40,7 @@ class CommandParser:
         self._last = None
         self.ctx = ctx
         self.params = ctx.params
-        self.positionals = ctx.params.positionals.copy()
+        self.positionals = ctx.params.all_positionals.copy()
         if ctx.config.reject_ambiguous_pos_combos:
             PosNode.build_tree(ctx.command)
 

--- a/tests/test_core/test_nargs.py
+++ b/tests/test_core/test_nargs.py
@@ -2,7 +2,7 @@
 
 from unittest import TestCase, main
 
-from cli_command_parser.nargs import Nargs
+from cli_command_parser.nargs import Nargs, REMAINDER
 
 
 class NargsTest(TestCase):
@@ -49,43 +49,59 @@ class NargsTest(TestCase):
 
     def test_star(self):
         nargs = Nargs('*')
-        self.assertIs(nargs.range, None)
-        self.assertEqual(nargs.min, 0)
-        self.assertIs(nargs.max, None)
-        self.assertEqual(nargs.allowed, (0, None))
-        self.assertTrue(nargs.variable)
         self.assertIn('*', repr(nargs))
         self.assertEqual(str(nargs), '0 or more')
-        self.assertEqual(nargs, Nargs('*'))
-        self.assertNotIn(-1, nargs)
-        self.assertIn(0, nargs)
-        self.assertIn(1, nargs)
-        self.assertIn(2, nargs)
-        self.assertFalse(nargs.satisfied(-1))
-        self.assertTrue(nargs.satisfied(0))
-        self.assertTrue(nargs.satisfied(1))
-        self.assertTrue(nargs.satisfied(2))
-        self.assertTrue(nargs.satisfied(100))
 
     def test_plus(self):
         nargs = Nargs('+')
-        self.assertIs(nargs.range, None)
-        self.assertEqual(nargs.min, 1)
-        self.assertIs(nargs.max, None)
-        self.assertEqual(nargs.allowed, (1, None))
-        self.assertTrue(nargs.variable)
         self.assertIn('+', repr(nargs))
         self.assertEqual(str(nargs), '1 or more')
-        self.assertEqual(nargs, Nargs('+'))
-        self.assertNotIn(-1, nargs)
-        self.assertNotIn(0, nargs)
-        self.assertIn(1, nargs)
-        self.assertIn(2, nargs)
-        self.assertFalse(nargs.satisfied(-1))
-        self.assertFalse(nargs.satisfied(0))
-        self.assertTrue(nargs.satisfied(1))
-        self.assertTrue(nargs.satisfied(2))
-        self.assertTrue(nargs.satisfied(100))
+
+    def test_remainder(self):
+        for init_val in ('REMAINDER', REMAINDER):
+            nargs = Nargs(init_val)
+            self.assertIn('REMAINDER', repr(nargs))
+            self.assertEqual(str(nargs), 'REMAINDER')
+
+    def test_0_to_unbound(self):
+        for init_val, expected_max in (('*', None), ('REMAINDER', REMAINDER)):
+            with self.subTest(init_val=init_val):
+                nargs = Nargs(init_val)
+                self.assertIs(nargs.range, None)
+                self.assertEqual(nargs.min, 0)
+                self.assertIs(nargs.max, expected_max)
+                self.assertEqual(nargs.allowed, (0, expected_max))
+                self.assertTrue(nargs.variable)
+                self.assertEqual(nargs, Nargs(init_val))
+                self.assertNotIn(-1, nargs)
+                self.assertIn(0, nargs)
+                self.assertIn(1, nargs)
+                self.assertIn(2, nargs)
+                self.assertFalse(nargs.satisfied(-1))
+                self.assertTrue(nargs.satisfied(0))
+                self.assertTrue(nargs.satisfied(1))
+                self.assertTrue(nargs.satisfied(2))
+                self.assertTrue(nargs.satisfied(100))
+
+    def test_1_to_unbound(self):
+        for init_val, expected_max in (('+', None), ((1, REMAINDER), REMAINDER)):
+            with self.subTest(init_val=init_val):
+                nargs = Nargs(init_val)
+                self.assertIs(nargs.range, None)
+                self.assertEqual(nargs.min, 1)
+                self.assertIs(nargs.max, expected_max)
+                self.assertEqual(nargs.allowed, (1, expected_max))
+                self.assertTrue(nargs.variable)
+                self.assertEqual(nargs, Nargs(init_val))
+                self.assertNotIn(-1, nargs)
+                self.assertNotIn(0, nargs)
+                self.assertIn(1, nargs)
+                self.assertIn(2, nargs)
+                self.assertFalse(nargs.satisfied(-1))
+                self.assertFalse(nargs.satisfied(0))
+                self.assertTrue(nargs.satisfied(1))
+                self.assertTrue(nargs.satisfied(2))
+                self.assertTrue(nargs.satisfied(100))
 
     def test_tuple_static(self):
         for n in range(11):

--- a/tests/test_parameters/test_misc.py
+++ b/tests/test_parameters/test_misc.py
@@ -38,8 +38,8 @@ class PassThruTest(ParserTest):
             baz = PassThru()
 
         success_cases = [
-            (['--bar', '--', 'a', 'b', 'c'], {'bar': True, 'baz': ['a', 'b', 'c']}),
-            (['--', '--bar', '--', 'a', 'b', 'c'], {'bar': False, 'baz': ['--bar', '--', 'a', 'b', 'c']}),
+            (['--bar', '--', 'a', 'b', '--c', '---x'], {'bar': True, 'baz': ['a', 'b', '--c', '---x']}),
+            (['--', '--bar', '--', 'a', '-b', 'c'], {'bar': False, 'baz': ['--bar', '--', 'a', '-b', 'c']}),
             (['--bar', '--'], {'bar': True, 'baz': []}),
             (['--', '--bar'], {'bar': False, 'baz': ['--bar']}),
             (['--'], {'bar': False, 'baz': []}),
@@ -105,6 +105,8 @@ class PassThruTest(ParserTest):
         self.assertEqual('[-- FOO]', PassThru(name='foo', required=False).formatter.format_basic_usage())
         self.assertEqual('-- FOO', PassThru(name='foo', required=True).formatter.format_basic_usage())
 
+    # region Unsupported Kwargs
+
     def test_nargs_not_allowed(self):
         with self.assertRaises(TypeError):
             PassThru(nargs='+')
@@ -120,6 +122,8 @@ class PassThruTest(ParserTest):
     def test_allow_leading_dash_not_allowed(self):
         with self.assertRaises(TypeError):
             PassThru(allow_leading_dash=True)
+
+    # endregion
 
 
 class MiscParameterTest(ParserTest):

--- a/tests/test_parsing/test_value_handling.py
+++ b/tests/test_parsing/test_value_handling.py
@@ -2,9 +2,8 @@
 
 from unittest import main
 
-from cli_command_parser.commands import Command
+from cli_command_parser import Command, Positional, Option
 from cli_command_parser.exceptions import NoSuchOption, BadArgument, UsageError
-from cli_command_parser.parameters import Positional, Option
 from cli_command_parser.testing import ParserTest
 
 


### PR DESCRIPTION
- Adjusted default group help text section titles to use slightly more descriptive values when no name or description was provided
- Fixed inheritance of Positional parameters between base and non-sub-command sub-classes
- Added support/handling for `nargs=REMAINDER` for Option and Positional params in addition to the already existing support for similar behavior with PassThru parameters