### PR TITLE
Enabled Positional params after a SubCommand param and added entry_points prog detection

### DIFF
--- a/docs/_src/index.rst
+++ b/docs/_src/index.rst
@@ -82,6 +82,23 @@ with optional dependencies::
     $ pip install -U cli-command-parser[wcwidth]
 
 
+Python Version Compatibility
+============================
+
+Python versions 3.7 and above are currently supported.  CLI Command Parser will no longer support 3.7 after 2023-04-30,
+ahead of the `official end of support for 3.7 on 2023-06-27 <https://devguide.python.org/versions/>`__.
+
+When using 3.7 or 3.8, some additional packages that backport functionality that was added in later Python versions
+are required for compatibility.
+
+To use the argparse to cli-command-parser conversion script with Python 3.7 or 3.8, there is a dependency on
+`astunparse <https://astunparse.readthedocs.io>`__.  If you are using Python 3.9 or above, then ``astunparse`` is not
+necessary because the relevant code was added to the stdlib ``ast`` module.  If you're unsure, you can install
+cli-command-parser with the following command to automatically handle whether that extra dependency is needed or not::
+
+    $ pip install -U cli-command-parser[conversion]
+
+
 User Guide
 **********
 

--- a/lib/cli_command_parser/commands.py
+++ b/lib/cli_command_parser/commands.py
@@ -108,11 +108,11 @@ class Command(ABC, metaclass=CommandMeta):
         cmd_cls = cls
         with ExitStack() as stack:
             stack.enter_context(ctx)
-            sub_cmd = CommandParser.parse_args(ctx)
+            sub_cmd = CommandParser.parse_args_and_get_next_cmd(ctx)
             while sub_cmd:
                 cmd_cls = sub_cmd
                 ctx = stack.enter_context(ctx._sub_context(cmd_cls))
-                sub_cmd = CommandParser.parse_args(ctx)
+                sub_cmd = CommandParser.parse_args_and_get_next_cmd(ctx)
 
             return cmd_cls()
 

--- a/lib/cli_command_parser/context.py
+++ b/lib/cli_command_parser/context.py
@@ -69,6 +69,7 @@ class Context(AbstractContextManager):  # Extending AbstractContextManager to ma
     prog: OptStr = None
     _terminal_width: Optional[int]
     allow_argv_prog: Bool = True
+    _provided: Dict[ParamOrGroup, int]
 
     def __init__(
         self,
@@ -236,6 +237,9 @@ class Context(AbstractContextManager):  # Extending AbstractContextManager to ma
     def num_provided(self, param: ParamOrGroup) -> int:
         """Not intended to be called by users.  Used by Parameters during parsing to handle nargs."""
         return self._provided[param]
+
+    def get_missing(self) -> List[Parameter]:
+        return [p for p in self.params.required_check_params() if self._provided[p] == 0]
 
     # endregion
 

--- a/lib/cli_command_parser/parameters/base.py
+++ b/lib/cli_command_parser/parameters/base.py
@@ -22,7 +22,7 @@ except ImportError:
 
 from ..annotations import get_descriptor_value_type
 from ..config import CommandConfig, OptionNameMode, AllowLeadingDash
-from ..context import Context, ctx, get_current_context, ParseState
+from ..context import Context, ctx, get_current_context
 from ..exceptions import ParameterDefinitionError, BadArgument, MissingArgument, InvalidChoice
 from ..exceptions import ParamUsageError, NoActiveContext, UnsupportedAction
 from ..inputs import InputType, normalize_input_type
@@ -277,7 +277,7 @@ class Parameter(ParamBase, Generic[T_co], ABC):
         if show_default is not None:
             self.show_default = show_default
 
-    def _init_value_factory(self, state: ParseState):
+    def _init_value_factory(self):
         return _NotSet
 
     def __set_name__(self, command: CommandCls, name: str):
@@ -489,10 +489,10 @@ class BasicActionMixin:
     nargs: Nargs
     type: Optional[Callable]
 
-    def _init_value_factory(self, state: ParseState):
+    def _init_value_factory(self):
         if self.action == 'append':
             return []
-        return super()._init_value_factory(state)  # noqa
+        return super()._init_value_factory()  # noqa
 
     @parameter_action
     def store(self: Parameter, value: T_co):
@@ -524,7 +524,7 @@ class BasicActionMixin:
         if not values:
             return values
 
-        ctx.set_parsed_value(self, self._init_value_factory(ctx.state))
+        ctx.set_parsed_value(self, self._init_value_factory())
         ctx._provided[self] = 0
         return values
 

--- a/lib/cli_command_parser/parameters/choice_map.py
+++ b/lib/cli_command_parser/parameters/choice_map.py
@@ -11,7 +11,7 @@ from string import whitespace, printable
 from typing import Type, TypeVar, Generic, Optional, Callable, Union, Collection, Mapping, NoReturn, Dict
 from types import MethodType
 
-from ..context import ctx, ParseState
+from ..context import ctx
 from ..exceptions import ParameterDefinitionError, BadArgument, MissingArgument, InvalidChoice, CommandDefinitionError
 from ..formatting.utils import format_help_entry
 from ..nargs import Nargs
@@ -100,7 +100,7 @@ class ChoiceMap(BasePositional[str], Generic[T]):
         self.description = description
         self.choices = {}
 
-    def _init_value_factory(self, state: ParseState):
+    def _init_value_factory(self):
         return []
 
     # region Choice Registration

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -10,7 +10,7 @@ from abc import ABC
 from functools import partial, update_wrapper
 from typing import Any, Optional, Callable, Sequence, Iterator, Union, TypeVar, Tuple
 
-from ..context import ctx, ParseState
+from ..context import ctx
 from ..exceptions import ParameterDefinitionError, BadArgument, CommandDefinitionError, ParamUsageError
 from ..inputs import normalize_input_type
 from ..nargs import Nargs, NargsValue
@@ -116,7 +116,7 @@ class _Flag(BaseOption[T_co], ABC):
             raise TypeError(f"{self.__class__.__name__}.__init__() got an unexpected keyword argument: 'metavar'")
         super().__init__(*option_strs, **kwargs)
 
-    def _init_value_factory(self, state: ParseState):
+    def _init_value_factory(self):
         if self.action == 'store_const':
             return self.default
         else:
@@ -397,7 +397,7 @@ class Counter(BaseOption[int], accepts_values=True, accepts_none=True):
         super().__init__(*option_strs, action=action, default=default, **kwargs)
         self.const = const
 
-    def _init_value_factory(self, state: ParseState):
+    def _init_value_factory(self):
         return self.default
 
     def prepare_value(self, value: Optional[str], short_combo: bool = False, pre_action: bool = False) -> int:

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -66,14 +66,12 @@ class CommandParser:
     def __parse_args(cls, ctx: Context) -> Optional[CommandType]:
         params = ctx.params
         sub_cmd_param = params.sub_command
-        if sub_cmd_param and not sub_cmd_param.choices:
-            raise CommandDefinitionError(f'{ctx.command}.{sub_cmd_param.name} = {sub_cmd_param} has no sub Commands')
 
         cls(ctx)._parse_args(ctx)
         params.validate_groups()
 
         if sub_cmd_param:
-            next_cmd = sub_cmd_param.target()  # type: CommandType
+            next_cmd: CommandType = sub_cmd_param.target()
             missing = cls._missing(params, ctx)
             if missing and next_cmd.__class__.parent(next_cmd) is not ctx.command:
                 ctx.state = ParseState.FAILED
@@ -88,7 +86,7 @@ class CommandParser:
             if not ctx.categorized_action_flags[ActionPhase.PRE_INIT]:
                 raise ParamsMissing(missing)
         elif ctx.remaining and not ctx.config.ignore_unknown:
-            raise NoSuchOption('unrecognized arguments: {}'.format(' '.join(ctx.remaining)))
+            raise NoSuchOption(f'unrecognized arguments: {" ".join(ctx.remaining)}')
 
         return None
 

--- a/readme.rst
+++ b/readme.rst
@@ -81,6 +81,16 @@ with optional dependencies::
 
     $ pip install -U cli-command-parser[wcwidth]
 
+
+Python Version Compatibility
+============================
+
+Python versions 3.7 and above are currently supported.  CLI Command Parser will no longer support 3.7 after 2023-04-30,
+ahead of the `official end of support for 3.7 on 2023-06-27 <https://devguide.python.org/versions/>`__.
+
+When using 3.7 or 3.8, some additional packages that backport functionality that was added in later Python versions
+are required for compatibility.
+
 To use the argparse to cli-command-parser conversion script with Python 3.7 or 3.8, there is a dependency on
 `astunparse <https://astunparse.readthedocs.io>`__.  If you are using Python 3.9 or above, then ``astunparse`` is not
 necessary because the relevant code was added to the stdlib ``ast`` module.  If you're unsure, you can install

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,8 @@ packages = find:
 package_dir = = lib
 python_requires = >=3.7
 tests_require = testtools; coverage
+install_requires =
+    importlib_metadata; python_version<"3.8"
 
 [options.packages.find]
 where = lib

--- a/tests/test_commands/test_param_registry.py
+++ b/tests/test_commands/test_param_registry.py
@@ -27,7 +27,7 @@ class TestParamRegistry(TestCase):
             a = SubCommand()
             b = SubCommand()
 
-        with self.assertRaises(CommandDefinitionError):
+        with self.assertRaisesRegex(CommandDefinitionError, 'Only 1 Action xor SubCommand is allowed'):
             Foo.parse([])
 
     def test_action_with_sub_cmd_rejected(self):
@@ -44,18 +44,8 @@ class TestParamRegistry(TestCase):
             a = SubCommand()
             b = Action()
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'may not follow the sub command SubCommand'):
+        with self.assertRaisesRegex(CommandDefinitionError, 'Only 1 Action xor SubCommand is allowed'):
             Foo.parse([])
-
-    def test_positional_after_sub_cmd_rejected(self):
-        with self.assertRaisesRegex(CommandDefinitionError, 'may not follow the sub command'):
-
-            class Foo(Command):
-                sub = SubCommand()
-                pos = Positional()
-
-            class Bar(Foo, choice='bar'):
-                pass
 
     def test_no_help(self):
         class Foo(Command, add_help=False, error_handler=None):
@@ -75,6 +65,7 @@ class TestParamRegistry(TestCase):
             Bar.parse_and_run(['-h'])
 
     def test_multiple_non_required_positionals_rejected(self):
+        expected_msg = 'because it accepts a variable number of arguments with no specific choices defined'
         for a, b in (('?', '?'), ('?', '*'), ('*', '?'), ('*', '*')):
             with self.subTest(a=a, b=b):
 
@@ -82,7 +73,7 @@ class TestParamRegistry(TestCase):
                     foo = Positional(nargs=a)
                     bar = Positional(nargs=b)
 
-                with self.assertRaises(CommandDefinitionError):
+                with self.assertRaisesRegex(CommandDefinitionError, expected_msg):
                     CommandMeta.params(Foo)
 
 

--- a/tests/test_commands/test_sub_commands.py
+++ b/tests/test_commands/test_sub_commands.py
@@ -65,8 +65,9 @@ class SubCommandTest(ParserTest):
         class Foo(Command):
             sub_cmd = SubCommand()
 
-        with self.assertRaises(CommandDefinitionError):
-            Foo.parse([])
+        for args in ([], ['foo']):
+            with self.assertRaisesRegex(CommandDefinitionError, 'has no sub Commands'):
+                Foo.parse(args)
 
     # endregion
 

--- a/tests/test_core/test_context.py
+++ b/tests/test_core/test_context.py
@@ -4,7 +4,7 @@ from unittest import TestCase, main
 
 from cli_command_parser import Command, CommandConfig
 from cli_command_parser.core import CommandMeta
-from cli_command_parser.context import Context, ActionPhase, ctx, get_current_context, ParseState
+from cli_command_parser.context import Context, ActionPhase, ctx, get_current_context
 from cli_command_parser.context import get_context, get_parsed, get_raw_arg
 from cli_command_parser.error_handling import extended_error_handler
 from cli_command_parser.parameters import Flag, SubCommand, Positional
@@ -204,16 +204,12 @@ class ContextTest(TestCase):
 
     # endregion
 
-    def test_state_done(self):
-        for state, expected in zip(ParseState, (False, True, True)):
-            self.assertEqual(state.done, expected)
-
     def test_repr(self):
         class Foo(Command):
             pass
 
-        self.assertEqual('<Context[state=ParseState.INITIAL, command=Foo]>', repr(Foo().ctx))
-        self.assertEqual('<Context[state=ParseState.INITIAL, command=None]>', repr(Context()))
+        self.assertEqual('<Context[command=Foo]>', repr(Foo().ctx))
+        self.assertEqual('<Context[command=None]>', repr(Context()))
 
 
 if __name__ == '__main__':

--- a/tests/test_core/test_metadata.py
+++ b/tests/test_core/test_metadata.py
@@ -3,23 +3,41 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase, main
-from unittest.mock import patch
+from unittest.mock import patch, Mock, seal
 
-from cli_command_parser import Command, Context
+from cli_command_parser import Command, Context, main as ccp_main
 from cli_command_parser.core import CommandMeta
-from cli_command_parser.metadata import ProgramMetadata, Metadata, _path_and_globals, _description, _doc_name, _prog
+from cli_command_parser.metadata import ProgramMetadata, Metadata, ProgFinder
+from cli_command_parser.metadata import _path_and_globals, _description, _doc_name, _prog_finder, EntryPoint
+
+MODULE = 'cli_command_parser.metadata'
+THIS_FILE = Path(__file__)
 
 
 class Foo(Command):
     pass
 
 
+def ep_scripts(*name_val_tuples):
+    cs = 'console_scripts'
+    return tuple(EntryPoint(name, val, cs) for name, val in name_val_tuples)
+
+
 class MetadataTest(TestCase):
     def test_repr(self):
-        meta = CommandMeta.meta(Foo)
-        meta_repr = repr(meta)
+        meta_repr = repr(CommandMeta.meta(Foo))
         self.assertRegex(meta_repr, r'\s{8}path=.*?/commands.py')
         self.assertRegex(meta_repr, r'\s{4}path=.*?/test_metadata.py')
+
+    def test_metadata_self(self):
+        self.assertIsInstance(ProgramMetadata.prog, Metadata)
+        self.assertEqual('Metadata(default=None)', repr(ProgramMetadata.prog))
+
+    def test_bad_arg(self):
+        with self.assertRaisesRegex(TypeError, 'Invalid arguments for ProgramMetadata: bar, foo'):
+            ProgramMetadata(foo=123, bar=456)
+
+    # region Docstring / Description
 
     def test_cmd_doc_dedented(self):
         class Bar(Command):
@@ -30,6 +48,21 @@ class MetadataTest(TestCase):
             """
 
         self.assertEqual('Foo\nBar\nBaz\n', Bar.__class__.meta(Bar).description)
+
+    def test_empty_doc_ignored(self):
+        self.assertIs(None, _description(None, '\n\n'))
+
+    def test_doc_str_non_pkg(self):
+        meta = ProgramMetadata(doc_str=' test ')
+        self.assertEqual('test', meta.get_doc_str())
+        self.assertEqual(' test ', meta.get_doc_str(False))
+
+    def test_doc_str_pkg(self):
+        meta = ProgramMetadata(doc_str=' test ', pkg_doc_str=' pkg test ')
+        self.assertEqual('pkg test', meta.get_doc_str())
+        self.assertEqual(' pkg test ', meta.get_doc_str(False))
+
+    # endregion
 
     def test_extended_epilog(self):
         meta = ProgramMetadata(
@@ -42,6 +75,11 @@ class MetadataTest(TestCase):
     def test_extended_epilog_no_email(self):
         meta = ProgramMetadata(prog='foo', epilog='test', version='4.3.2', url='http://fake.com')
         self.assertEqual('test\n\nOnline documentation: http://fake.com', meta.format_epilog())
+
+    def test_doc_name_prog(self):
+        self.assertEqual('test_123', _doc_name(None, Path('UNKNOWN'), 'test_123'))
+
+    # region Docs URL
 
     def test_doc_url_none(self):
         self.assertIs(None, ProgramMetadata(url='https://github.com/foo').docs_url)
@@ -56,53 +94,78 @@ class MetadataTest(TestCase):
     def test_docs_url_not_https(self):
         self.assertIs(None, ProgramMetadata.for_command(Foo, url='hxxps://test.com/fake').docs_url)
 
-    def test_doc_name_prog(self):
-        self.assertEqual('test_123', _doc_name(None, Path('UNKNOWN'), 'test_123'))
+    # endregion
 
-    def test_empty_doc_ignored(self):
-        self.assertIs(None, _description(None, '\n\n'))
+    # region Path & Globals
 
     def test_cwd_default(self):
         self.assertEqual(Path.cwd().joinpath('UNKNOWN'), _path_and_globals(None, None)[0])  # noqa
 
     def test_path_from_cmd(self):
-        self.assertEqual(Path(__file__).resolve(), _path_and_globals(Foo)[0])
+        self.assertEqual(THIS_FILE.resolve(), _path_and_globals(Foo)[0])
 
     def test_explicit_path(self):
         path = Path('.')
         self.assertEqual(path, _path_and_globals(Foo, path)[0])
 
+    # endregion
+
+
+class MetadataProgTest(TestCase):
     def test_prog_from_path_on_no_sys_argv(self):
-        path = Path(__file__)
         with patch('sys.argv', []):
-            self.assertEqual(path.name, _prog(None, path, None, False)[0])
+            # self.assertEqual(path.name, _prog(None, path, None, False)[0])
+            self.assertEqual(THIS_FILE.name, _prog_finder.normalize(None, THIS_FILE, None, False, Mock())[0])
 
     def test_prog_from_sys_argv(self):
-        path = Path(__file__)
         name = 'example_test_123.py'
         with TemporaryDirectory() as tmp_dir:
             tmp_path = Path(tmp_dir).joinpath(name)
             tmp_path.touch()
             with patch('sys.argv', [tmp_path.as_posix()]), Context():
-                self.assertEqual(name, _prog(None, path, None, False)[0])
+                # self.assertEqual(name, _prog(None, path, None, False)[0])
+                self.assertEqual(name, _prog_finder.normalize(None, THIS_FILE, None, False, Mock())[0])
 
-    def test_doc_str_non_pkg(self):
-        meta = ProgramMetadata(doc_str=' test ')
-        self.assertEqual('test', meta.get_doc_str())
-        self.assertEqual(' test ', meta.get_doc_str(False))
+    def test_entry_points_old(self):
+        entry_points = {'console_scripts': ep_scripts(('bar.py', 'foo:bar'), ('baz.py', 'foo:baz'))}
+        expected = {'foo': {'bar': 'bar.py', 'baz': 'baz.py'}}
+        with patch(f'{MODULE}.entry_points', side_effect=[TypeError, entry_points]):  # Simulate py 3.8/3.9
+            self.assertDictEqual(expected, ProgFinder().mod_obj_prog_map)
 
-    def test_doc_str_pkg(self):
-        meta = ProgramMetadata(doc_str=' test ', pkg_doc_str=' pkg test ')
-        self.assertEqual('pkg test', meta.get_doc_str())
-        self.assertEqual(' pkg test ', meta.get_doc_str(False))
+    def test_entry_points_new(self):
+        entry_points = ep_scripts(('bar.py', 'foo:bar'), ('baz.py', 'foo:baz'))
+        expected = {'foo': {'bar': 'bar.py', 'baz': 'baz.py'}}
+        with patch(f'{MODULE}.entry_points', return_value=entry_points):
+            self.assertDictEqual(expected, ProgFinder().mod_obj_prog_map)
 
-    def test_metadata_self(self):
-        self.assertIsInstance(ProgramMetadata.prog, Metadata)
-        self.assertEqual('Metadata(default=None)', repr(ProgramMetadata.prog))
+    def test_prog_from_entry_point_main(self):
+        Cmd = type('Cmd', (Command,), {'__module__': 'foo.bar'})
+        entry_points = ep_scripts(('bar.py', 'foo.bar:bar'), ('baz.py', 'foo.bar:main'))
+        mod = Mock(main=ccp_main)
+        seal(mod)  # Trigger the obj = getattr(...) AttributeError
+        with patch(f'{MODULE}.modules', {'foo.bar': mod}), patch(f'{MODULE}.entry_points', return_value=entry_points):
+            self.assertEqual('baz.py', ProgFinder().normalize(None, THIS_FILE, None, False, Cmd)[0])  # noqa
 
-    def test_bad_arg(self):
-        with self.assertRaisesRegex(TypeError, 'Invalid arguments for ProgramMetadata: bar, foo'):
-            ProgramMetadata(foo=123, bar=456)
+    def test_prog_from_entry_point_method(self):
+        Cmd = type('Cmd', (Command,), {'__module__': 'foo.bar'})
+        entry_points = ep_scripts(('bar.py', 'foo.bar:bar'), ('baz.py', 'foo.bar:Cmd.parse_and_run'))
+        with patch(f'{MODULE}.modules', {'foo.bar': Mock(Cmd=Cmd)}):
+            with patch(f'{MODULE}.entry_points', return_value=entry_points):
+                self.assertEqual('baz.py', ProgFinder().normalize(None, THIS_FILE, None, False, Cmd)[0])  # noqa
+
+    def test_prog_from_entry_point_with_extras(self):
+        Cmd = type('Cmd', (Command,), {'__module__': 'foo.bar'})
+        entry_points = ep_scripts(('bar.py', 'foo.bar:bar'), ('baz.py', 'foo.bar:main [test]'))
+        with patch(f'{MODULE}.modules', {'foo.bar': Mock(main=ccp_main)}):
+            with patch(f'{MODULE}.entry_points', return_value=entry_points):
+                self.assertEqual('baz.py', ProgFinder().normalize(None, THIS_FILE, None, False, Cmd)[0])  # noqa
+
+    def test_prog_no_entry_point_found(self):
+        Cmd = type('Cmd', (Command,), {'__module__': 'foo.bar'})
+        entry_points = ep_scripts(('bar.py', 'foo.bar:bar'), ('baz.py', 'foo.bar:main'))
+        with patch(f'{MODULE}.modules', {'foo.bar': Mock()}):
+            with patch(f'{MODULE}.entry_points', return_value=entry_points):
+                self.assertEqual(THIS_FILE.name, ProgFinder().normalize(None, THIS_FILE, None, False, Cmd)[0])  # noqa
 
 
 if __name__ == '__main__':

--- a/tests/test_parameters/test_action_flags.py
+++ b/tests/test_parameters/test_action_flags.py
@@ -102,7 +102,7 @@ class ActionFlagTest(ParserTest):
                     self.assertFalse(parsed[a])
 
     def test_no_reassign(self):
-        with self.assertRaises(CommandDefinitionError):
+        with self.assertRaisesRegex(CommandDefinitionError, 'Cannot re-assign the func to call for ActionFlag'):
 
             class Foo(Command):
                 foo = ActionFlag()(Mock())
@@ -116,7 +116,7 @@ class ActionFlagTest(ParserTest):
             bar = ActionFlag('-b', order=1)(Mock())
             baz = ActionFlag('-b', order=2)(Mock())
 
-        with self.assertRaises(CommandDefinitionError):
+        with self.assertRaisesRegex(CommandDefinitionError, "short option='-b' conflict for command="):
             Foo.parse([])
 
     def test_extra_flags_provided_cause_error(self):
@@ -300,7 +300,7 @@ class ActionFlagTest(ParserTest):
             foo = before_main(order=1)(Mock(__doc__=''))
             bar = before_main(order=2, always_available=True)(Mock(__doc__=''))
 
-        with self.assertRaisesRegex(CommandDefinitionError, r'invalid parameters: \{\(True, 2\): ActionFlag\(\'bar\','):
+        with self.assertRaisesRegex(CommandDefinitionError, r"invalid parameters: \{\(True, 2\): ActionFlag\('bar',"):
             Foo.parse([])
 
 

--- a/tests/test_parameters/test_actions.py
+++ b/tests/test_parameters/test_actions.py
@@ -94,7 +94,7 @@ class ActionTest(TestCase):
         self.assertEqual(foo.text, ['bar'])
 
     def test_reject_double_choice(self):
-        with self.assertRaises(CommandDefinitionError):
+        with self.assertRaisesRegex(CommandDefinitionError, 'Cannot combine a positional method_or_choice='):
 
             class Foo(Command):
                 action = Action()

--- a/tests/test_parameters/test_choice_maps.py
+++ b/tests/test_parameters/test_choice_maps.py
@@ -11,7 +11,7 @@ from cli_command_parser.testing import ParserTest
 
 class ChoiceMapTest(ParserTest):
     def test_reassign_choice_rejected(self):
-        with self.assertRaises(CommandDefinitionError):
+        with self.assertRaisesRegex(CommandDefinitionError, 'Invalid choice=.*- already assigned to Choice'):
 
             class Foo(Command):
                 action = Action()
@@ -73,7 +73,7 @@ class ChoiceMapTest(ParserTest):
             def foo(self):
                 pass
 
-        with self.assertRaises(CommandDefinitionError):
+        with self.assertRaisesRegex(CommandDefinitionError, 'No choices were registered for Action'):
             foo = Foo.parse([])
             del Foo.action.choices['foo']
             foo.action  # noqa
@@ -114,14 +114,14 @@ class ChoiceMapTest(ParserTest):
             sub = SubCommand()
 
         Foo.sub.register(Mock(__name__='bar'))
-        with self.assertRaises(CommandDefinitionError):
+        with self.assertRaisesRegex(CommandDefinitionError, 'Invalid choice=.*with parent=None - already assigned to'):
             Foo.sub.register(Mock(__name__='bar'))
 
     def test_redundant_sub_cmd_choice_rejected(self):
         class Foo(Command):
             sub = SubCommand()
 
-        with self.assertRaises(CommandDefinitionError):
+        with self.assertRaisesRegex(CommandDefinitionError, 'Cannot combine a positional command_or_choice='):
             Foo.sub.register('foo', choice='foo')
 
     def test_custom_action_choice(self):

--- a/tests/test_parameters/test_choice_maps.py
+++ b/tests/test_parameters/test_choice_maps.py
@@ -41,16 +41,7 @@ class ChoiceMapTest(ParserTest):
         class Foo(Command):
             action = Action()
 
-        self.assert_parse_fails(Foo, [], CommandDefinitionError)
-
-    def test_missing_action_target_forced(self):
-        class Foo(Command):
-            action = Action()
-
-        with Context():
-            with self.assertRaises(BadArgument):
-                Foo.action.validate('-foo')
-            self.assertIs(None, Foo.action.validate('foo'))
+        self.assert_parse_fails_cases(Foo, [[], ['foo'], ['-f']], CommandDefinitionError)
 
     def test_choice_map_too_many(self):
         class Foo(Command):

--- a/tests/test_parameters/test_misc.py
+++ b/tests/test_parameters/test_misc.py
@@ -291,7 +291,7 @@ class UnlikelyToBeReachedParameterTest(ParserTest):
         with Context(['--bar', 'a'], Foo) as ctx:
             foo = Foo()  # This is NOT the recommended way of initializing a Command
             with self.assertRaises(BadArgument):
-                CommandParser.parse_args(ctx)
+                CommandParser.parse_args_and_get_next_cmd(ctx)
             with self.assertRaisesRegex(BadArgument, r'expected nargs=.* values but found \d+'):
                 foo.bar  # noqa
 

--- a/tests/test_parameters/test_misc.py
+++ b/tests/test_parameters/test_misc.py
@@ -64,7 +64,7 @@ class PassThruTest(ParserTest):
             bar = PassThru()
             baz = PassThru()
 
-        with self.assertRaises(CommandDefinitionError):
+        with self.assertRaisesRegex(CommandDefinitionError, 'it cannot follow another PassThru param'):
             Foo.parse([])
 
     def test_double_dash_without_pass_thru_rejected(self):
@@ -91,7 +91,7 @@ class PassThruTest(ParserTest):
         class Bar(Foo):
             pt2 = PassThru()
 
-        with self.assertRaises(CommandDefinitionError):
+        with self.assertRaisesRegex(CommandDefinitionError, 'it cannot follow another PassThru param'):
             Bar.parse([])
 
     def test_extra_rejected(self):
@@ -194,7 +194,7 @@ class MiscParameterTest(ParserTest):
             bar = Flag('-b')
             baz = Option('-b')
 
-        with self.assertRaises(CommandDefinitionError):
+        with self.assertRaisesRegex(CommandDefinitionError, "short option='-b' conflict for command="):
             Foo.parse([])
 
     def test_config_no_context_explicit_command(self):

--- a/tests/test_parameters/test_options.py
+++ b/tests/test_parameters/test_options.py
@@ -487,7 +487,7 @@ class TriFlagTest(ParserTest):
                     bar = TriFlag('-b', **case)
                     baz = Flag('-B')
 
-                with self.assertRaises(CommandDefinitionError):
+                with self.assertRaisesRegex(CommandDefinitionError, 'option=.* conflict for command='):
                     Foo.parse([])
 
     def test_no_alt_short(self):

--- a/tests/test_parameters/test_positionals.py
+++ b/tests/test_parameters/test_positionals.py
@@ -55,6 +55,7 @@ class PositionalTest(ParserTest):
                     self.assert_parse_results_cases(Foo, success_cases)
 
     def test_pos_after_unbound_nargs_rejected(self):
+        expected_msg = 'it accepts a variable number of arguments with no specific choices defined'
         for nargs in ('*', 'REMAINDER'):
             with self.subTest(nargs=nargs):
 
@@ -62,7 +63,7 @@ class PositionalTest(ParserTest):
                     bar = Positional(nargs=nargs)
                     baz = Positional()
 
-                with self.assertRaises(CommandDefinitionError):
+                with self.assertRaisesRegex(CommandDefinitionError, expected_msg):
                     Foo.parse([])
 
     def test_pos_grouped_pos_both_required(self):

--- a/tests/test_parsing/test_param_combos.py
+++ b/tests/test_parsing/test_param_combos.py
@@ -263,7 +263,7 @@ class ParamComboTest(ParserTest):
             baz = Option('-b')
 
         bar_expected = {'pos': 'a', 'sub': 'bar', 'bar': 'c'}
-        baz_expected = {'pos': 'a', 'sub': 'bar', 'baz': 'c'}
+        baz_expected = {'pos': 'a', 'sub': 'baz', 'baz': 'c'}
         success_cases = [
             (['bar', 'a', '-b', 'c'], bar_expected),
             (['bar', '-b', 'c', 'a'], bar_expected),

--- a/tests/test_parsing/test_param_combos.py
+++ b/tests/test_parsing/test_param_combos.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python
 
-from unittest import main, skip
+from abc import ABC
+from unittest import main
 
 from cli_command_parser.commands import Command
 from cli_command_parser.config import AmbiguousComboMode
 from cli_command_parser.core import get_params
 from cli_command_parser.exceptions import NoSuchOption, ParamsMissing, UsageError, MissingArgument, ParamUsageError
-from cli_command_parser.exceptions import AmbiguousCombo, AmbiguousShortForm
+from cli_command_parser.exceptions import AmbiguousCombo, AmbiguousShortForm, CommandDefinitionError
 from cli_command_parser.parameters import Positional, Option, Flag, Counter, SubCommand
 from cli_command_parser.testing import ParserTest
 
@@ -250,38 +251,6 @@ class ParamComboTest(ParserTest):
         ]
         self.assert_parse_fails_cases(Foo, fail_cases, UsageError)
 
-    @skip('This case is not currently supported')  # TODO: Should this be supported?
-    def test_common_positional_after_sub_command(self):
-        class Foo(Command):
-            sub = SubCommand()
-            pos = Positional()
-
-        class Bar(Foo):
-            bar = Option('-b')
-
-        class Baz(Foo):
-            baz = Option('-b')
-
-        bar_expected = {'pos': 'a', 'sub': 'bar', 'bar': 'c'}
-        baz_expected = {'pos': 'a', 'sub': 'baz', 'baz': 'c'}
-        success_cases = [
-            (['bar', 'a', '-b', 'c'], bar_expected),
-            (['bar', '-b', 'c', 'a'], bar_expected),
-            (['-b', 'c', 'bar', 'a'], bar_expected),
-            (['baz', 'a', '-b', 'c'], baz_expected),
-            (['baz', '-b', 'c', 'a'], baz_expected),
-            (['-b', 'c', 'baz', 'a'], baz_expected),
-            (['bar', 'a'], {'pos': 'a', 'sub': 'bar', 'bar': None}),
-            (['baz', 'a'], {'pos': 'a', 'sub': 'baz', 'baz': None}),
-        ]
-        self.assert_parse_results_cases(Foo, success_cases)
-        # fmt: off
-        fail_cases = [
-            ['a', 'bar'], ['a', 'baz'], ['baz'], ['bar'], ['a'], ['-b', 'c', 'bar'], ['-b', 'c', 'baz'], ['-b', 'c']
-        ]
-        # fmt: on
-        self.assert_parse_fails_cases(Foo, fail_cases, UsageError)
-
     def test_sub_cmd_optional_before_base_positional(self):
         class Foo(Command):
             foo = Positional()
@@ -381,6 +350,100 @@ class ParamComboTest(ParserTest):
         fail_cases = [['-b', 'a'], ['a', '-b'], ['a', '-b', 'c']]
         self.assert_parse_results_cases(Foo, success_cases)
         self.assert_parse_fails_cases(Foo, fail_cases, UsageError)
+
+
+class PositionalAfterSubcommandTest(ParserTest):
+    def test_common_positional_after_sub_command(self):
+        class Foo(Command):
+            sub = SubCommand()
+            pos = Positional()
+
+        class Bar(Foo):
+            bar = Option('-b')
+
+        class Baz(Foo):
+            baz = Option('-b')
+
+        bar_expected = {'pos': 'a', 'sub': 'bar', 'bar': 'c'}
+        baz_expected = {'pos': 'a', 'sub': 'baz', 'baz': 'c'}
+        success_cases = [
+            (['bar', 'a', '-b', 'c'], bar_expected),
+            (['bar', '-b', 'c', 'a'], bar_expected),
+            (['baz', 'a', '-b', 'c'], baz_expected),
+            (['baz', '-b', 'c', 'a'], baz_expected),
+            (['bar', 'a'], {'pos': 'a', 'sub': 'bar', 'bar': None}),
+            (['baz', 'a'], {'pos': 'a', 'sub': 'baz', 'baz': None}),
+        ]
+        self.assert_parse_results_cases(Foo, success_cases)
+        # fmt: off
+        fail_cases = [
+            ['a', 'bar'], ['a', 'baz'], ['baz'], ['bar'], ['a'], ['-b', 'c', 'bar'], ['-b', 'c', 'baz'], ['-b', 'c'],
+            ['-b', 'c', 'bar', 'a'], ['-b', 'c', 'baz', 'a'], [],
+        ]
+        # fmt: on
+        self.assert_parse_fails_cases(Foo, fail_cases, UsageError)
+
+    def test_pos_in_one_sub_cmd(self):
+        class Cmd(Command):
+            sub = SubCommand()
+            pre = Positional()
+
+        class Foo(Cmd):
+            foo = Positional()
+            bar = Option('-b')
+
+        class Bar(Cmd):
+            baz = Option('-b')
+
+        foo_expected = {'pre': 'a', 'sub': 'foo', 'bar': 'c', 'foo': '2'}
+        bar_expected = {'pre': 'a', 'sub': 'bar', 'baz': 'c'}
+        success_cases = [
+            (['foo', 'a', '2', '-b', 'c'], foo_expected),
+            (['foo', 'a', '-b', 'c', '2'], foo_expected),
+            (['foo', '-b', 'c', 'a', '2'], foo_expected),
+            (['bar', 'a', '-b', 'c'], bar_expected),
+            (['bar', '-b', 'c', 'a'], bar_expected),
+            (['foo', 'x', '2'], {'pre': 'x', 'sub': 'foo', 'bar': None, 'foo': '2'}),
+            (['bar', 'x'], {'pre': 'x', 'sub': 'bar', 'baz': None}),
+        ]
+        self.assert_parse_results_cases(Cmd, success_cases)
+        # fmt: off
+        fail_cases = [
+            ['a', 'bar'], ['a', 'foo'], ['foo'], ['bar'], ['a'], ['-b', 'c', 'bar'], ['-b', 'c', 'foo'], ['-b', 'c'],
+            ['-b', 'c', 'bar', 'a'], ['-b', 'c', 'foo', 'a'], ['foo', '-b', 'c', 'a'], ['foo', 'x'], [],
+        ]
+        # fmt: on
+        self.assert_parse_fails_cases(Cmd, fail_cases, UsageError)
+
+    def test_middle_abc_subcommand_positional_basic(self):
+        class Base(Command):
+            sub = SubCommand()
+            pre = Positional()
+
+        class Mid(Base, ABC):
+            mid = Positional()
+
+        class A(Mid):
+            bar = Flag('-b')
+
+        success_cases = [
+            (['a', '1', '2', '-b'], {'sub': 'a', 'pre': '1', 'mid': '2', 'bar': True}),
+            (['a', '1', '-b', '2'], {'sub': 'a', 'pre': '1', 'mid': '2', 'bar': True}),
+            (['a', '-b', '1', '2'], {'sub': 'a', 'pre': '1', 'mid': '2', 'bar': True}),
+            (['a', 'b', 'c'], {'sub': 'a', 'pre': 'b', 'mid': 'c', 'bar': False}),
+            (['-b', 'a', 'b', 'c'], {'sub': 'a', 'pre': 'b', 'mid': 'c', 'bar': True}),
+        ]
+        self.assert_parse_results_cases(Base, success_cases)
+        fail_cases = [[], ['a'], ['a', 'b']]
+        self.assert_parse_fails_cases(Base, fail_cases, UsageError)
+
+    def test_no_sub_cmds(self):
+        class Cmd(Command):
+            sub = SubCommand()
+            pre = Positional()
+
+        with self.assertRaisesRegex(CommandDefinitionError, 'has no sub Commands'):
+            Cmd.parse([])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Removed the exception that would be raised when attempting to use a Positional param after a SubCommand param, and added handling for such Positionals to be parsed as expected
- Improved automatic `prog` detection for scripts defined as `console_scripts` in `entry_points`, which is mostly useful for generating RST documentation