### PR TITLE
Fixes for parsing positionals defined after subcommand params

### DIFF
--- a/lib/cli_command_parser/command_parameters.py
+++ b/lib/cli_command_parser/command_parameters.py
@@ -203,6 +203,10 @@ class CommandParameters:
 
     def _process_positionals(self, params: List[BasePositional]):
         var_nargs_param = action_or_sub_cmd = split_index = None
+        parent = self.parent
+        if parent and parent._deferred_positionals:
+            params = parent._deferred_positionals + params
+
         for i, param in enumerate(params):
             if var_nargs_param:
                 raise CommandDefinitionError(
@@ -228,11 +232,7 @@ class CommandParameters:
         if split_index:
             params, self._deferred_positionals = params[:split_index], params[split_index:]
 
-        parent = self.parent
-        if parent and parent._deferred_positionals:
-            self.positionals = parent._deferred_positionals + params
-        else:
-            self.positionals = params
+        self.positionals = params
 
     def _process_options(self, params: Collection[BaseOption]):
         parent = self.parent

--- a/lib/cli_command_parser/command_parameters.py
+++ b/lib/cli_command_parser/command_parameters.py
@@ -85,6 +85,15 @@ class CommandParameters:
             pass
         return self.positionals
 
+    def get_positionals_to_parse(self, ctx: Context) -> List[BasePositional]:
+        positionals = self.all_positionals
+        if not positionals:
+            return []
+        for i, param in enumerate(positionals):
+            if not ctx.num_provided(param):
+                return [p for p in positionals[i:]]
+        return []
+
     @cached_property
     def always_available_action_flags(self) -> Tuple[ActionFlag, ...]:
         """
@@ -202,21 +211,19 @@ class CommandParameters:
         self.groups = sorted(groups)
 
     def _process_positionals(self, params: List[BasePositional]):
-        var_nargs_param = action_or_sub_cmd = split_index = non_required_param = None
+        unfollowable = action_or_sub_cmd = split_index = None
         parent = self.parent
         if parent and parent._deferred_positionals:
             params = parent._deferred_positionals + params
 
         for i, param in enumerate(params):
-            if var_nargs_param:
+            if unfollowable:
+                if 0 in unfollowable.nargs:
+                    why = 'because it is a positional that is not required'
+                else:
+                    why = 'because it accepts a variable number of arguments with no specific choices defined'
                 raise CommandDefinitionError(
-                    f'Additional Positional parameters cannot follow {var_nargs_param} because it accepts'
-                    f' a variable number of arguments with no specific choices defined - param={param!r} is invalid'
-                )
-            elif non_required_param:
-                raise CommandDefinitionError(
-                    f'Additional Positional parameters cannot follow {non_required_param} because it is a positional'
-                    f' that is not required - param={param!r} is invalid'
+                    f'Additional Positional parameters cannot follow {unfollowable} {why} - param={param!r} is invalid'
                 )
             elif isinstance(param, (SubCommand, Action)):
                 if action_or_sub_cmd:
@@ -227,19 +234,20 @@ class CommandParameters:
                 elif isinstance(param, SubCommand):
                     self.sub_command = action_or_sub_cmd = param
                     split_index = i + 1
-                    if param.has_choices and 0 in param.nargs:
-                        non_required_param = param
-                else:
+                    if param.has_choices and 0 in param.nargs:  # It has local choices or is not required
+                        unfollowable = param
+                else:  # It's an Action
                     self.action = action_or_sub_cmd = param
                     if not param.has_choices:
                         raise CommandDefinitionError(f'No choices were registered for {self.action}')
-            elif 0 in param.nargs:
-                non_required_param = param
-            elif param.nargs.variable and not param.has_choices:
-                var_nargs_param = param
+            elif 0 in param.nargs or (param.nargs.variable and not param.has_choices):
+                unfollowable = param
 
         if split_index:
-            params, self._deferred_positionals = params[:split_index], params[split_index:]
+            if self.sub_command.has_local_choices:
+                self._deferred_positionals = params[split_index:]
+            else:
+                params, self._deferred_positionals = params[:split_index], params[split_index:]
 
         self.positionals = params
 
@@ -429,7 +437,10 @@ class CommandParameters:
 
         for choice in self.sub_command.choices.values():
             command = choice.target
-            params = command.__class__.params(command)
+            try:
+                params = command.__class__.params(command)
+            except AttributeError:  # The target was None (it's a subcommand's local choice)
+                continue
             try:
                 param = params.find_option_that_accepts_values(option)
             except KeyError:

--- a/lib/cli_command_parser/testing.py
+++ b/lib/cli_command_parser/testing.py
@@ -105,6 +105,12 @@ class ParserTest(TestCase):
                 with self.subTest(expected='exception', argv=argv):
                     self.assert_parse_fails(cmd_cls, argv, exc, pat, message=message)
 
+    def assert_argv_parse_fails_cases(
+        self, cmd_cls: CommandCls, cases: Iterable[Argv], exc: Type[Exception] = UsageError, message: str = None
+    ):
+        """Convenience method for calling :meth:`.assert_parse_fails_cases` with a default exception type."""
+        self.assert_parse_fails_cases(cmd_cls, cases, exc, message)
+
     def assert_call_fails(
         self,
         func: Callable,

--- a/tests/test_commands/test_param_registry.py
+++ b/tests/test_commands/test_param_registry.py
@@ -65,7 +65,6 @@ class TestParamRegistry(TestCase):
             Bar.parse_and_run(['-h'])
 
     def test_multiple_non_required_positionals_rejected(self):
-        expected_msg = 'because it accepts a variable number of arguments with no specific choices defined'
         for a, b in (('?', '?'), ('?', '*'), ('*', '?'), ('*', '*')):
             with self.subTest(a=a, b=b):
 
@@ -73,7 +72,7 @@ class TestParamRegistry(TestCase):
                     foo = Positional(nargs=a)
                     bar = Positional(nargs=b)
 
-                with self.assertRaisesRegex(CommandDefinitionError, expected_msg):
+                with self.assertRaisesRegex(CommandDefinitionError, 'it is a positional that is not required'):
                     CommandMeta.params(Foo)
 
 

--- a/tests/test_parameters/test_positionals.py
+++ b/tests/test_parameters/test_positionals.py
@@ -54,20 +54,22 @@ class PositionalTest(ParserTest):
                     self.assert_parse_results_cases(Foo, success_cases)
 
     def test_pos_after_unbound_nargs_rejected(self):
-        expected_msg = 'it accepts a variable number of arguments with no specific choices defined'
-        for nargs in ('+', '*', 'REMAINDER'):
+        exp_0 = 'it is a positional that is not required'
+        exp_var = 'it accepts a variable number of arguments with no specific choices defined'
+        for nargs, pat in (('+', exp_var), ('*', exp_0), ('REMAINDER', exp_0)):
             with self.subTest(nargs=nargs):
 
                 class Foo(Command):
                     bar = Positional(nargs=nargs)
                     baz = Positional()
 
-                with self.assertRaisesRegex(CommandDefinitionError, expected_msg):
+                with self.assertRaisesRegex(CommandDefinitionError, pat):
                     Foo.parse([])
 
     def test_sub_cmd_pos_after_unbound_nargs_rejected(self):
-        expected_msg = 'it accepts a variable number of arguments with no specific choices defined'
-        for nargs in ('+', '*', 'REMAINDER'):
+        exp_0 = 'it is a positional that is not required'
+        exp_var = 'it accepts a variable number of arguments with no specific choices defined'
+        for nargs, pat in (('+', exp_var), ('*', exp_0), ('REMAINDER', exp_0)):
             with self.subTest(nargs=nargs):
 
                 class Foo(Command):
@@ -77,8 +79,16 @@ class PositionalTest(ParserTest):
                 class Bar(Foo):
                     baz = Positional()
 
-                with self.assertRaisesRegex(CommandDefinitionError, expected_msg):
+                with self.assertRaisesRegex(CommandDefinitionError, pat):
                     Foo.parse(['bar'])
+
+    def test_pos_after_non_required_sub_cmd_rejected(self):
+        class Foo(Command):
+            sub = SubCommand(required=False)
+            bar = Positional()
+
+        with self.assertRaisesRegex(CommandDefinitionError, 'it is a positional that is not required'):
+            Foo.parse([])
 
     def test_pos_grouped_pos_both_required(self):
         class Foo(Command):

--- a/tests/test_parameters/test_positionals.py
+++ b/tests/test_parameters/test_positionals.py
@@ -3,10 +3,9 @@
 from unittest import main
 from unittest.mock import Mock
 
-from cli_command_parser import Command, ParamGroup
+from cli_command_parser import Command, ParamGroup, SubCommand, Positional
 from cli_command_parser.exceptions import ParameterDefinitionError, CommandDefinitionError, UsageError
 from cli_command_parser.parameters.base import parameter_action, BasePositional
-from cli_command_parser.parameters import Positional
 from cli_command_parser.testing import ParserTest
 
 
@@ -56,7 +55,7 @@ class PositionalTest(ParserTest):
 
     def test_pos_after_unbound_nargs_rejected(self):
         expected_msg = 'it accepts a variable number of arguments with no specific choices defined'
-        for nargs in ('*', 'REMAINDER'):
+        for nargs in ('+', '*', 'REMAINDER'):
             with self.subTest(nargs=nargs):
 
                 class Foo(Command):
@@ -65,6 +64,21 @@ class PositionalTest(ParserTest):
 
                 with self.assertRaisesRegex(CommandDefinitionError, expected_msg):
                     Foo.parse([])
+
+    def test_sub_cmd_pos_after_unbound_nargs_rejected(self):
+        expected_msg = 'it accepts a variable number of arguments with no specific choices defined'
+        for nargs in ('+', '*', 'REMAINDER'):
+            with self.subTest(nargs=nargs):
+
+                class Foo(Command):
+                    sub = SubCommand()
+                    bar = Positional(nargs=nargs)
+
+                class Bar(Foo):
+                    baz = Positional()
+
+                with self.assertRaisesRegex(CommandDefinitionError, expected_msg):
+                    Foo.parse(['bar'])
 
     def test_pos_grouped_pos_both_required(self):
         class Foo(Command):


### PR DESCRIPTION
- Added additional validation to reject positional params that follow other positionals with unbound nargs in more cases
- Fixed parsing for `Positional` params defined after a `SubCommand` in a both base- and sub-commands when the base command has local choices