### PR TITLE
Improved prefixed short option str handling and error_handler specificity

### DIFF
--- a/lib/cli_command_parser/commands.py
+++ b/lib/cli_command_parser/commands.py
@@ -42,6 +42,10 @@ class Command(ABC, metaclass=CommandMeta):
             self.ctx = ctx
         return self
 
+    def __repr__(self) -> str:
+        cls = self.__class__
+        return f'<{cls.__name__} in prog={cls.__class__.meta(cls).prog!r}>'
+
     # region Parse & Run
 
     @classmethod
@@ -247,7 +251,7 @@ class Command(ABC, metaclass=CommandMeta):
             param.func(self, *args, **kwargs)
 
 
-def main(argv: Argv = None, return_command: Bool = False, **kwargs):
+def main(argv: Argv = None, return_command: Bool = False, **kwargs) -> Optional[CommandObj]:
     """
     Convenience function that can be used as the main entry point for a program.
 

--- a/lib/cli_command_parser/exceptions.py
+++ b/lib/cli_command_parser/exceptions.py
@@ -183,9 +183,10 @@ class ParamConflict(MultiParamUsageError):
 class ParamsMissing(UsageError):
     """Error raised when one or more required Parameters were not provided"""
 
-    def __init__(self, params: Collection[ParamOrGroup], message: str = None):
+    def __init__(self, params: Collection[ParamOrGroup], message: str = None, partial: bool = False):
         self.params = params
         self.usage_str = ', '.join(param.format_usage(full=True, delim=' / ') for param in params)
+        self.partial = partial
         if message:
             self.message = message
 
@@ -195,7 +196,8 @@ class ParamsMissing(UsageError):
             message = '; '.join(p.missing_hint for p in self.params if p.missing_hint)
 
         if len(self.params) > 1:
-            prefix = 'arguments missing - the following arguments are required'
+            mid = '- at least one of' if self.partial else '-'
+            prefix = f'arguments missing {mid} the following arguments are required'
         else:
             prefix = 'argument missing - the following argument is required'
         return f'{prefix}: {self.usage_str}{message}'

--- a/lib/cli_command_parser/exceptions.py
+++ b/lib/cli_command_parser/exceptions.py
@@ -241,7 +241,11 @@ class UnsupportedAction(CommandParserException):
 
 
 class Backtrack(CommandParserException):
-    """Raised when backtracking took place"""
+    """Raised when backtracking took place.  Only used internally."""
+
+
+class NextCommand(CommandParserException):
+    """Raised by the parser to advance to the next Command in certain cases.  Only used internally."""
 
 
 # endregion

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -125,8 +125,8 @@ class _Flag(BaseOption[T_co], ABC):
     def take_action(self, value: Optional[str], short_combo: bool = False, opt_str: str = None):
         # log.debug(f'{self!r}.take_action({value!r})')
         ctx.record_action(self)
-        action_method = getattr(self, self.action)
         if value is None:
+            action_method = getattr(self, self.action)
             return action_method(opt_str) if self._use_opt_str else action_method()
 
         raise ParamUsageError(self, f'received value={value!r} but no values are accepted for action={self.action!r}')

--- a/lib/cli_command_parser/parameters/pass_thru.py
+++ b/lib/cli_command_parser/parameters/pass_thru.py
@@ -46,12 +46,14 @@ class PassThru(Parameter):
     ):
         value = ctx.get_parsed_value(self)
         if value is not _NotSet:
-            raise ParamUsageError(self, f'received values={values!r} but a stored value={value!r} already exists')
+            raise ParamUsageError(
+                self,
+                f'can only be specified once - found values={values!r} but a stored value={value!r} already exists',
+            )
 
         ctx.record_action(self)
         normalized = list(map(self.prepare_value, values))
-        action_method = getattr(self, self.action)
-        return action_method(normalized)
+        return getattr(self, self.action)(normalized)
 
     def result_value(self) -> Any:
         value = ctx.get_parsed_value(self)

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Optional, Union, Any, Deque, List
 
 from .context import ActionPhase, Context
 from .exceptions import UsageError, ParamUsageError, NoSuchOption, MissingArgument, ParamsMissing
-from .exceptions import Backtrack, UnsupportedAction
+from .exceptions import Backtrack, NextCommand, UnsupportedAction
 from .nargs import REMAINDER, nargs_max_sum, nargs_min_sum
 from .parse_tree import PosNode
 from .parameters.base import BasicActionMixin, Parameter, BasePositional, BaseOption
@@ -360,7 +360,3 @@ def _to_pop(positionals: List[BasePositional], can_pop: List[int], available: in
             return n
 
     return None
-
-
-class NextCommand(Exception):
-    pass

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -192,19 +192,16 @@ class CommandParser:
         # log.debug(f'handle_short({arg=})')
         try:
             param_val_combos = self.params.short_option_to_param_value_pairs(arg)
-        except KeyError:
+        except KeyError:  # Handles 3 potential KeyErrors for either the full short option or a single-char combo
             self._handle_short_not_found(arg)
         else:
             # log.debug(f'Split {arg=} into {param_val_combos=}')
-            if len(param_val_combos) == 1:
-                opt, param, value = param_val_combos[0]
-                self._handle_short_value(opt, param, value)
-            else:
-                last_opt, last_param, _last_val = param_val_combos[-1]
-                for opt, param, _ in param_val_combos[:-1]:
-                    param.take_action(None, short_combo=True, opt_str=opt)
-
-                self._handle_short_value(last_opt, last_param, None)
+            last = param_val_combos.pop()
+            if param_val_combos:
+                # Note: This loop is only executed for single char combined flags, where the values will always be None
+                for opt, param, value in param_val_combos:
+                    param.take_action(value, short_combo=True, opt_str=opt)
+            self._handle_short_value(*last)
 
     def _handle_short_not_found(self, arg: str):
         if self._maybe_consume_remainder(arg):

--- a/tests/test_commands/test_commands.py
+++ b/tests/test_commands/test_commands.py
@@ -147,6 +147,12 @@ class TestCommands(TestCase):
         del Foo.ctx
         self.assertIsInstance(Foo().ctx, Context)
 
+    def test_prog_in_repr(self):
+        class Foo(Command, prog='foo.py'):
+            pass
+
+        self.assertEqual("<Foo in prog='foo.py'>", repr(Foo()))
+
 
 if __name__ == '__main__':
     try:

--- a/tests/test_core/test_context.py
+++ b/tests/test_core/test_context.py
@@ -33,7 +33,7 @@ class ContextTest(TestCase):
         self.assertNotEqual(default, c.config.ignore_unknown)
 
     def test_double_config_rejected(self):
-        with self.assertRaisesRegex(ValueError, 'Cannot combine config='):
+        with self.assertRaisesRegex(TypeError, 'Cannot combine config='):
             Context(config=CommandConfig(), add_help=False)
 
     def test_explicitly_provided_config_used(self):
@@ -54,14 +54,14 @@ class ContextTest(TestCase):
             pass
 
         context = Context(command=Foo, show_docstring=False)
-        self.assertDictEqual({'show_docstring': False}, context.config.as_dict(False))
-        self.assertEqual(1, len(context.config.parents))
+        self.assertDictEqual({'show_docstring': False, 'add_help': False}, context.config.as_dict(False))
+        self.assertEqual(2, len(context.config._data.maps))
         self.assertFalse(context.config.add_help)
         self.assertFalse(context.config.show_docstring)
 
     def test_config_from_command_with_no_config(self):
         context = Context(command=Command, show_docstring=False)
-        self.assertEqual(0, len(context.config.parents))
+        self.assertEqual(1, len(context.config._data.maps))
         self.assertFalse(context.config.show_docstring)
 
     def test_allow_argv_prog_from_parent(self):

--- a/tests/test_core/test_error_handling.py
+++ b/tests/test_core/test_error_handling.py
@@ -6,7 +6,7 @@ from unittest import TestCase, main
 from unittest.mock import Mock, patch
 
 import cli_command_parser.error_handling
-from cli_command_parser.error_handling import ErrorHandler, no_exit_handler
+from cli_command_parser.error_handling import ErrorHandler, Handler, no_exit_handler
 from cli_command_parser.exceptions import CommandParserException, ParserExit, ParamUsageError, InvalidChoice
 from cli_command_parser.exceptions import ParamConflict, ParamsMissing, MultiParamUsageError
 from cli_command_parser import Command, Flag
@@ -51,6 +51,22 @@ class ErrorHandlingTest(TestCase):
 
     def test_error_handler_repr(self):
         self.assertIn('handlers=', repr(ErrorHandler()))
+
+    def test_most_specific_handler_chosen(self):
+        handler = ErrorHandler()
+        handler.register(lambda e: None, Exception)
+        exc = ParamUsageError(Flag('--foo'), 'test')
+        self.assertIs(CommandParserException.exit, handler.get_handler(ParamUsageError, exc))
+
+    def test_handler_equality(self):
+        def foo(e):
+            pass
+
+        a = Handler(TypeError, foo)
+        b = Handler(TypeError, foo)
+        c = Handler(ValueError, foo)
+        self.assertEqual(a, b)
+        self.assertNotEqual(a, c)
 
 
 class TestCommandErrorHandling(TestCase):

--- a/tests/test_parameters/test_groups.py
+++ b/tests/test_parameters/test_groups.py
@@ -82,7 +82,7 @@ class GroupTest(_GroupTest):
             (['-B'], {'bar': False, 'baz': True}),
             (['-bB'], {'bar': True, 'baz': True}),
         ]
-        fail_cases = [([], UsageError)]
+        fail_cases = [([], ParamsMissing, 'at least one of the following arguments are required')]
         self.assert_cases_for_cmds(success_cases, fail_cases, Foo1, Foo2)
 
     def test_required_param_missing_from_non_required_group(self):
@@ -263,7 +263,11 @@ class MutuallyDependentGroupTest(_GroupTest):
             (['-b', '--baz'], {'bar': True, 'baz': True}),
             (['--baz', '--bar'], {'bar': True, 'baz': True}),
         ]
-        fail_cases = [([], UsageError), (['-b'], UsageError), (['-B'], UsageError)]
+        fail_cases = [
+            ([], ParamsMissing, '- the following arguments are required'),
+            (['-b'], ParamsMissing),
+            (['-B'], ParamsMissing),
+        ]
         self.assert_parse_results_cases(Foo, success_cases)
         self.assert_parse_fails_cases(Foo, fail_cases)
 

--- a/tests/test_parsing/test_parse_flags.py
+++ b/tests/test_parsing/test_parse_flags.py
@@ -87,21 +87,20 @@ class ParseFlagsTest(ParserTest):
                 self.assert_parse_fails_cases(Foo, fail_cases)
 
     def test_combined_flags_ambiguous_strict_rejected(self):
+        class Foo(Command, ambiguous_short_combos=AmbiguousComboMode.STRICT):
+            a = Flag('-a')
+            b = Flag('-b')
+            c = Flag('-c')
+            ab = Flag('-ab')
+            bc = Flag('-bc')
+            abc = Flag('-abc')
+
         exp_error_pat = (
             'Ambiguous short form for --ab / -ab - it conflicts with: --a / -a, --b / -b\n'
             'Ambiguous short form for --abc / -abc - it conflicts with: --a / -a, --b / -b, --c / -c\n'
             'Ambiguous short form for --bc / -bc - it conflicts with: --b / -b, --c / -c'
         )
         with self.assertRaisesRegex(AmbiguousShortForm, exp_error_pat):
-
-            class Foo(Command, ambiguous_short_combos=AmbiguousComboMode.STRICT):
-                a = Flag('-a')
-                b = Flag('-b')
-                c = Flag('-c')
-                ab = Flag('-ab')
-                bc = Flag('-bc')
-                abc = Flag('-abc')
-
             get_params(Foo)
 
     def test_combined_flags_ambiguous_strict_parsing(self):

--- a/tests/test_parsing/test_parse_options.py
+++ b/tests/test_parsing/test_parse_options.py
@@ -4,7 +4,7 @@ from unittest import main
 
 from cli_command_parser import Command, Option, Flag, Positional, REMAINDER, BaseOption, ctx
 from cli_command_parser.core import CommandMeta
-from cli_command_parser.exceptions import UsageError, NoSuchOption, MissingArgument
+from cli_command_parser.exceptions import UsageError, NoSuchOption, MissingArgument, AmbiguousShortForm
 from cli_command_parser.nargs import Nargs
 from cli_command_parser.parameters.base import parameter_action
 from cli_command_parser.testing import ParserTest
@@ -75,7 +75,7 @@ class OptionTest(ParserTest):
         ]
         self.assert_parse_results_cases(Foo, success_cases)
 
-    def test_short_value_ambiguous(self):
+    def test_short_value_ambiguous_permissive(self):
         class Foo(Command):
             foo = Option('-f')
             foobar = Option('-foobar')
@@ -105,6 +105,15 @@ class OptionTest(ParserTest):
             (['--foorab'], MissingArgument),
         ]
         self.assert_parse_fails_cases(Foo, fail_cases)
+
+    def test_short_value_ambiguous_strict(self):
+        class Foo(Command, ambiguous_short_combos='strict'):
+            foo = Option('-f')
+            foobar = Option('-foobar')
+            foorab = Option('-foorab')
+
+        with self.assertRaises(AmbiguousShortForm):
+            Foo.parse([])
 
     def test_custom_type_starting_with_dash(self):
         class TimeOffset:

--- a/tests/test_parsing/test_parse_options.py
+++ b/tests/test_parsing/test_parse_options.py
@@ -2,9 +2,9 @@
 
 from unittest import main
 
-from cli_command_parser import Command, Option, Flag, Positional, REMAINDER, BaseOption, ctx
+from cli_command_parser import Command, Option, Flag, Positional, SubCommand, REMAINDER, BaseOption, ctx
 from cli_command_parser.core import CommandMeta
-from cli_command_parser.exceptions import UsageError, NoSuchOption, MissingArgument, AmbiguousShortForm
+from cli_command_parser.exceptions import UsageError, NoSuchOption, MissingArgument, AmbiguousShortForm, AmbiguousCombo
 from cli_command_parser.nargs import Nargs
 from cli_command_parser.parameters.base import parameter_action
 from cli_command_parser.testing import ParserTest
@@ -233,6 +233,32 @@ class OptionTest(ParserTest):
 
                 self.assert_parse_results_cases(Foo, success_cases)
                 self.assert_parse_fails_cases(Foo, fail_cases, UsageError)
+
+    def test_2c_short_in_sub_cmd_with_base_1c_short_prefix(self):
+        class Foo(Command):
+            sub = SubCommand()
+            foo = Option('-f')
+
+        class Bar(Foo):
+            foobar = Option('-fb')
+
+        success_cases = [
+            (['bar'], {'sub': 'bar', 'foo': None, 'foobar': None}),
+            (['bar', '-fx'], {'sub': 'bar', 'foo': 'x', 'foobar': None}),
+            (['bar', '-f=x'], {'sub': 'bar', 'foo': 'x', 'foobar': None}),
+            (['bar', '-f', 'x'], {'sub': 'bar', 'foo': 'x', 'foobar': None}),
+            (['bar', '--foo', 'x'], {'sub': 'bar', 'foo': 'x', 'foobar': None}),
+            (['bar', '-fb=x'], {'sub': 'bar', 'foo': None, 'foobar': 'x'}),
+            (['bar', '-fb', 'x'], {'sub': 'bar', 'foo': None, 'foobar': 'x'}),
+            (['bar', '--foobar', 'x'], {'sub': 'bar', 'foo': None, 'foobar': 'x'}),
+            (['bar', '-f=x', '-fb=y'], {'sub': 'bar', 'foo': 'x', 'foobar': 'y'}),
+            (['bar', '-fb=y', '-f=x'], {'sub': 'bar', 'foo': 'x', 'foobar': 'y'}),
+            (['bar', '--foobar', 'y', '--foo', 'x'], {'sub': 'bar', 'foo': 'x', 'foobar': 'y'}),
+            (['bar', '--foo', 'x', '--foobar', 'y'], {'sub': 'bar', 'foo': 'x', 'foobar': 'y'}),
+        ]
+        self.assert_parse_results_cases(Foo, success_cases)
+        fail_cases = [['bar', '-fby'], ['bar', '-fbx'], ['bar', '-fbar']]
+        self.assert_parse_fails_cases(Foo, fail_cases, AmbiguousCombo)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
- Improved the way ErrorHandler chooses the handler to use for a given exception when multiple handlers have been registered for superclasses of that exception, so the most specific one will be chosen
- Improved the parser's handling of an exact match for a subcommand's short option str when the base command has a short option str that is a prefix of that option str
- Improved the error message when no args were provided for a required ParamGroup that only requires at least one param to have a value