### PR TITLE
ErrorHandler improvements + new OptionNameMode.NONE

### DIFF
--- a/docs/_src/conf.py
+++ b/docs/_src/conf.py
@@ -62,6 +62,7 @@ autodoc_default_options = {
     'member-order': 'bysource',
     'special-members': '__init_subclass__,__call__',
     'private-members': '_pre_init_actions_,_init_command_,_before_main_,_after_main_',
+    'ignore-module-all': True,
 }
 autodoc_typehints_format = 'short'
 

--- a/docs/_src/configuration.rst
+++ b/docs/_src/configuration.rst
@@ -39,7 +39,8 @@ Error Handling Options
 ----------------------
 
 :error_handler: The :class:`.ErrorHandler` to be used by :meth:`.Command.__call__` to wrap :meth:`.Command.main`, or
-  None to disable error handling.  Defaults to :obj:`~.error_handling.extended_error_handler`.
+  None to disable error handling.  Defaults to :obj:`~.error_handling.extended_error_handler`.  See
+  :doc:`error_handlers` for more details.
 :always_run_after_main: Whether :meth:`.Command._after_main_` should always be called, even if an exception
   was raised in :meth:`.Command.main` (similar to a ``finally`` block) (default: False)
 

--- a/docs/_src/error_handlers.rst
+++ b/docs/_src/error_handlers.rst
@@ -1,0 +1,93 @@
+Error Handling
+**************
+
+Error handler functions can be registered to automatically handle exceptions that were not caught inside Commands.  The
+error handler that should be used for a given Command can be specified through :class:`.CommandConfig` or, more
+easily, through the :ref:`error_handler class keyword argument<configuration:Error Handling Options>` when defining
+a Command.
+
+All :class:`ErrorHandlers<.ErrorHandler>` will catch :class:`.CommandParserException` exceptions and handle them by
+calling the exception's :meth:`~.CommandParserException.exit` method.
+
+There are three ErrorHandler instances included by default:
+
+    1. :obj:`~.error_handling.error_handler`:
+        - Catches :class:`python:KeyboardInterrupt` and calls :func:`python:print`
+        - Catches :class:`python:BrokenPipeError` and takes no further action (it prevents a stack trace from being
+          printed for it)
+
+    1. :obj:`~.error_handling.extended_error_handler`:
+        - The default error handler
+        - Handles everything that :obj:`~.error_handling.error_handler` does
+        - The only difference between this handler and :obj:`~.error_handling.error_handler` is that an additional
+          handler is registered only when running on Windows to catch :class:`python:OSError` and work around a bug
+          related to the broken pipe error number: :func:`~.error_handling.handle_win_os_pipe_error`
+
+    1. :obj:`~.error_handling.no_exit_handler`:
+        - Overrides the :class:`.CommandParserException` exception handler to call the exception's
+          :meth:`~.CommandParserException.show` method instead of :meth:`~.CommandParserException.exit`.
+
+
+Configuration
+=============
+
+Example of how to use :obj:`~.error_handling.error_handler` instead of :obj:`~.error_handling.extended_error_handler`::
+
+    from cli_command_parser import Command, Option, error_handler
+
+    class MyCommand(Command, error_handler=error_handler):
+        foo = Option()
+
+
+Example of how to disable all error handling, including the handler for :class:`.CommandParserException`::
+
+    from cli_command_parser import Command, Option
+
+    class MyCommand(Command, error_handler=None):
+        foo = Option()
+
+
+Defining Error Handlers
+=======================
+
+To define an error handler function for an additional exception class, the :class:`.ErrorHandler` object can be used
+as a decorator on the function that will handle the exception.
+
+Similar to :meth:`python:object.__exit__`, if the error handler function returns a truthy value, then the exception
+will be considered handled.  Behavior differs in the case of ``0``, which will be treated as a value with which
+:func:`python:sys.exit` should be called.  In fact, :func:`python:sys.exit` will be called with any truthy value other
+than ``True`` that is returned by the error handler function.
+
+To indicate that the error was not handled, and that any other (less specific) error handlers that may match the
+exception should be tried, the handler function should return ``False`` or any other falsey value (other than ``0``).
+
+Alternatively, the handler function may call :func:`python:sys.exit` directly, if desired.  Similar to ``__exit__``,
+the exception that was passed to the handler function should NOT be re-raised by the handler function.
+
+If no handler function can be found for a given exception, or if none of them indicate that the exception was handled
+or should result in a call to :func:`python:sys.exit`, then the exception will be propagated as usual (which should
+result in the traceback being printed by the interpreter).
+
+Example of adding a handler for a custom ``MyException`` exception to the default
+:obj:`~.error_handling.extended_error_handler`::
+
+    import sys
+    from cli_command_parser import extended_error_handler
+
+    @extended_error_handler(MyException)
+    def handle_my_exception(exc: MyException):
+        print(f'Unable to proceed due to {exc}', file=sys.stderr)
+        return 1
+
+
+Advanced
+========
+
+For repos that contain many separate entry points defined in a ``cli`` package or similar, a common error handler
+function can be defined / registered in the package's ``__init__.py``.  This will result in that handler function being
+used automatically for all of the modules within that package (and its sub-packages) without needing to explicitly
+import it in any of them.
+
+One example use case for that approach would be for user-facing scripts to have a catch-all handler registered for
+``Exception``, where the handler logs just the error message by default, and only logs the full traceback when the user
+specified ``--verbose`` output or similar.

--- a/docs/_src/index.rst
+++ b/docs/_src/index.rst
@@ -136,6 +136,9 @@ Configuring & Documenting Commands
 :doc:`examples`
     Automatically generated documentation for the :gh_proj_url:`example scripts <tree/main/examples>` in this project.
 
+:doc:`error_handlers`
+    How to define custom error handlers for exceptions that were not caught inside Commands.
+
 
 Advanced
 ========
@@ -183,6 +186,7 @@ Indices and Tables
    inputs
    configuration
    documentation
+   error_handlers
    advanced
    testing
 

--- a/lib/cli_command_parser/__init__.py
+++ b/lib/cli_command_parser/__init__.py
@@ -30,7 +30,7 @@ from .exceptions import (
     NoActiveContext,
     AmbiguousParseTree,
 )
-from .error_handling import ErrorHandler, error_handler, no_exit_handler
+from .error_handling import ErrorHandler, error_handler, no_exit_handler, extended_error_handler
 from .formatting.commands import get_formatter
 from .nargs import REMAINDER
 from .parameters import (

--- a/lib/cli_command_parser/command_parameters.py
+++ b/lib/cli_command_parser/command_parameters.py
@@ -241,6 +241,8 @@ class CommandParameters:
         for param in params:
             options.append(param)
             opts = param.option_strs
+            if not opts.has_min_opts():
+                raise ParameterDefinitionError(f'No option strings were registered for param={param!r}')
             self._process_option_strs(param, 'long', opts.long, option_map, combo_option_map)
             self._process_option_strs(param, 'short', opts.short, option_map, combo_option_map)
 

--- a/lib/cli_command_parser/commands.py
+++ b/lib/cli_command_parser/commands.py
@@ -127,7 +127,7 @@ class Command(ABC, metaclass=CommandMeta):
         Primary entry point for running a command.  Subclasses generally should not override this method.
 
         Handles exceptions using the configured :class:`.ErrorHandler`.  Alternate error handlers can be specified
-        via the :paramref:`~.core.CommandMeta.__new__.error_handler` parameter during Command class initialization.
+        via the :paramref:`~.core.CommandMeta.error_handler` parameter during Command class initialization.
         To skip error handling, define the class with ``error_handler=None``.
 
         Calls the following methods in order:
@@ -163,11 +163,11 @@ class Command(ABC, metaclass=CommandMeta):
         The first method called by :meth:`.__call__` (before :meth:`.main` and others).
 
         Validates the number of ActionFlags that were specified, and calls all of the specified
-        :obj:`~.parameters.before_main` / :obj:`~.parameters.action_flag` actions such as ``--help`` that were
+        :func:`~.options.before_main` / :obj:`~.options.action_flag` actions such as ``--help`` that were
         defined with ``before_main=True`` and ``always_available=True`` in their configured order.
 
-        :param args: Positional arguments to pass to the :obj:`~.parameters.action_flag` methods
-        :param kwargs: Keyword arguments to pass to the :obj:`~.parameters.action_flag` methods
+        :param args: Positional arguments to pass to the :obj:`~.options.action_flag` methods
+        :param kwargs: Keyword arguments to pass to the :obj:`~.options.action_flag` methods
         """
         ctx = self.__ctx
         n_flags = ctx.action_flag_count
@@ -204,11 +204,11 @@ class Command(ABC, metaclass=CommandMeta):
         """
         Called by :meth:`.__call__` after :meth:`._init_command_` and before :meth:`.main` is called.
 
-        Calls all of the specified :obj:`~.parameters.before_main` / :obj:`~.parameters.action_flag` actions that were
-        defined with ``before_main=True`` and ``always_available=False`` in their configured order.
+        Calls all of the specified :func:`~.options.before_main` / :obj:`~.options.action_flag` actions that
+        were defined with ``before_main=True`` and ``always_available=False`` in their configured order.
 
-        :param args: Positional arguments to pass to the :obj:`~.parameters.action_flag` methods
-        :param kwargs: Keyword arguments to pass to the :obj:`~.parameters.action_flag` methods
+        :param args: Positional arguments to pass to the :obj:`~.options.action_flag` methods
+        :param kwargs: Keyword arguments to pass to the :obj:`~.options.action_flag` methods
         """
         for param in self.__ctx.iter_action_flags(ActionPhase.BEFORE_MAIN):
             param.func(self, *args, **kwargs)
@@ -218,9 +218,9 @@ class Command(ABC, metaclass=CommandMeta):
         Primary method that is called when running a Command.
 
         If any arguments were specified that are associated with triggering a method that was decorated / registered as
-        a positional :class:`~.parameters.Action`'s target method, then that method is called here.
+        a positional :class:`~.choice_map.Action`'s target method, then that method is called here.
 
-        Commands that do not have any positional :class:`Actions<.parameters.Action>` can override this method, and do
+        Commands that do not have any positional :class:`Actions<.choice_map.Action>` can override this method, and do
         **not** need to call ``super().main(*args, **kwargs)``.
 
         Initialization code that is common for all actions, or that should be run before :meth:`._before_main_` should
@@ -241,11 +241,11 @@ class Command(ABC, metaclass=CommandMeta):
     def _after_main_(self, *args, **kwargs):
         """
         Called by :meth:`.__call__` after :meth:`.main` is called.  Calls all of the specified
-        :obj:`~.parameters.after_main` / :obj:`~.parameters.action_flag` actions that were defined with
+        :func:`~.options.after_main` / :obj:`~.options.action_flag` actions that were defined with
         ``before_main=False`` in their configured order.
 
-        :param args: Positional arguments to pass to the :obj:`~.parameters.action_flag` methods
-        :param kwargs: Keyword arguments to pass to the :obj:`~.parameters.action_flag` methods
+        :param args: Positional arguments to pass to the :obj:`~.options.action_flag` methods
+        :param kwargs: Keyword arguments to pass to the :obj:`~.options.action_flag` methods
         """
         for param in self.__ctx.iter_action_flags(ActionPhase.AFTER_MAIN):
             param.func(self, *args, **kwargs)

--- a/lib/cli_command_parser/config.py
+++ b/lib/cli_command_parser/config.py
@@ -85,6 +85,9 @@ class OptionNameMode(FixedFlag):
       in help text
     :BOTH_DASH: Both ``--foo-bar`` and ``--foo_bar`` will be accepted, but only ``--foo-bar`` with be displayed
       in help text
+    :NONE: No long form option string will be added.  At least one short form option string must be defined.  Note that
+      it is NOT necessary to use ``name_mode=None`` to prevent the automatic creation of long form option strings - if
+      any long form option strings are explicitly provided for a given Parameter, then no automatic ones will be added.
 
     If a long form is provided explicitly for a given optional Parameter, then this setting will be ignored.
 
@@ -103,14 +106,15 @@ class OptionNameMode(FixedFlag):
     #                         & 4  -> display options set
     BOTH_UNDERSCORE = 15    # & 8  -> show only underscore version
     BOTH_DASH = 23          # & 16 -> show only dash version
+    NONE = 32
 
     @classmethod
-    def _missing_(cls, value: Union[str, int]) -> OptionNameMode:
+    def _missing_(cls, value: Union[str, int, None]) -> OptionNameMode:
         try:
             return OPT_NAME_MODE_ALIASES[value]
         except KeyError:
             pass
-        return super()._missing_(value)
+        return cls.NONE if value is None else super()._missing_(value)
 
 
 OPT_NAME_MODE_ALIASES = {

--- a/lib/cli_command_parser/exceptions.py
+++ b/lib/cli_command_parser/exceptions.py
@@ -41,12 +41,13 @@ __all__ = [
 class CommandParserException(Exception):
     """Base class for all other Command Parser exceptions"""
 
-    code: int = 2
+    code: int = 3
 
-    def show(self):
+    def show(self) -> bool:
         message = str(self)
         if message:
             print(message, file=sys.stderr)
+        return True
 
     def exit(self):
         self.show()
@@ -56,11 +57,11 @@ class CommandParserException(Exception):
 class ParserExit(CommandParserException):
     """Exception used to exit with the given message and status code"""
 
-    def __init__(self, message: str = None, code: int = None):
+    def __init__(self, message: str = None, code: int = 0):
         self.code = code
         self.message = message
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.message or ''
 
 

--- a/lib/cli_command_parser/inputs/numeric.py
+++ b/lib/cli_command_parser/inputs/numeric.py
@@ -23,6 +23,14 @@ class NumericInput(InputType[NT], ABC):
     type: NumType
 
     def is_valid_type(self, value: str) -> bool:
+        """
+        Called during parsing when :meth:`.Parameter.would_accept` is called to determine if the value would be
+        accepted later for processing / conversion when called.
+
+        :param value: The parsed argument to validate
+        :return: True if this input would accept it for processing later (where it may still be rejected), False if
+          it should be rejected before attempting to process / convert / store it.
+        """
         try:
             self.type(value)
         except (ValueError, TypeError):

--- a/lib/cli_command_parser/parameters/base.py
+++ b/lib/cli_command_parser/parameters/base.py
@@ -613,7 +613,7 @@ class BaseOption(Parameter[T_co], ABC):
     _opt_str_cls: Type[OptionStrings] = OptionStrings
     option_strs: OptionStrings
 
-    def __init__(self, *option_strs: str, action: str, name_mode: Union[OptionNameMode, str] = None, **kwargs):
+    def __init__(self, *option_strs: str, action: str, name_mode: Union[OptionNameMode, str, None] = _NotSet, **kwargs):
         _validate_opt_strs(option_strs)
         super().__init__(action, **kwargs)
         self.option_strs = self._opt_str_cls(option_strs, name_mode)

--- a/tests/test_documentation/test_help_text.py
+++ b/tests/test_documentation/test_help_text.py
@@ -262,7 +262,8 @@ class HelpTextTest(ParserTest):
 
     def test_option_name_mode_overrides(self):
         mode_exp_map = {'underscore': ('--foo_a',), 'dash': ('--foo-a',), 'both': ('--foo-a', '--foo_a')}
-        base_expected = ('--foo_b', '--foo-c', '--foo-d', '--foo_d', '--eeee')
+        base_expected = ('--foo_b', '--foo-c', '--foo-d', '--foo_d', '--eeee', '-ff', '-fg')
+        never_expected = ('--foo-e', '--foo_e', '--foo-f', '--foo_f', '--foo-g', '--foo_g')
         for mode, expected_a in mode_exp_map.items():
             with self.subTest(mode=mode):
 
@@ -272,12 +273,13 @@ class HelpTextTest(ParserTest):
                     foo_c = Flag(name_mode='dash')
                     foo_d = Flag(name_mode='both')
                     foo_e = Flag('--eeee')
+                    foo_f = Flag('-ff', name_mode=None)
+                    foo_g = Flag('-fg', name_mode='NONE')
 
                 help_text = get_help_text(Foo)
                 self.assertTrue(all(exp in help_text for exp in base_expected))
                 self.assertTrue(all(exp in help_text for exp in expected_a))
-                self.assertNotIn('--foo_e', help_text)
-                self.assertNotIn('--foo-e', help_text)
+                self.assertTrue(all(val not in help_text for val in never_expected))
 
     def test_tri_flag_no_alt_short(self):
         class Foo(Command):

--- a/tests/test_examples/test_examples_via_subprocess.py
+++ b/tests/test_examples/test_examples_via_subprocess.py
@@ -15,7 +15,7 @@ EXAMPLES_DIR = Path(__file__).resolve().parents[2].joinpath('examples')
 # WORKERS = 8
 
 try:
-    from testtools import ConcurrentTestSuite, iterate_tests
+    from testtools import ConcurrentTestSuite, iterate_tests  # noqa
 except ImportError:
     pass  # This is only used to improve run time when testing locally; they are not essential
 else:
@@ -79,7 +79,7 @@ class ExampleScriptTest(TestCase):
 class ActionWithArgsTest(ExampleScriptTest, file='action_with_args.py'):
     def test_no_args(self):
         code, stdout, stderr = self.call_script()
-        self.assertEqual(2, code)
+        self.assertEqual(3, code)
         self.assertEqual('argument {echo|split|double|reverse}: missing required argument value\n', stderr)
 
     def test_help(self):
@@ -100,14 +100,14 @@ class ActionWithArgsTest(ExampleScriptTest, file='action_with_args.py'):
 
     def test_echo_no_args(self):
         code, stdout, stderr = self.call_script('echo')
-        self.assertEqual(2, code)
+        self.assertEqual(3, code)
         self.assertEqual('argument missing - the following argument is required: TEXT [TEXT ...]\n', stderr)
 
 
 class SharedLoggingInitTest(ExampleScriptTest, file='shared_logging_init.py'):
     def test_no_args(self):
         code, stdout, stderr = self.call_script()
-        self.assertEqual(2, code)
+        self.assertEqual(3, code)
         self.assertEqual('argument {show}: missing required argument value\n', stderr)
 
     def test_help(self):
@@ -118,7 +118,7 @@ class SharedLoggingInitTest(ExampleScriptTest, file='shared_logging_init.py'):
 
     def test_show_no_args(self):
         code, stdout, stderr = self.call_script('show')
-        self.assertEqual(2, code)
+        self.assertEqual(3, code)
         self.assertEqual(stderr, 'argument {attrs|hello|log_test|rst}: missing required argument value\n')
 
     def test_show_help(self):
@@ -156,7 +156,7 @@ class SharedLoggingInitTest(ExampleScriptTest, file='shared_logging_init.py'):
 
     def test_show_oops(self):
         code, stdout, stderr = self.call_script('show', 'oops')
-        self.assertEqual(2, code)
+        self.assertEqual(3, code)
         expected = (
             "argument {attrs|hello|log_test|rst}: invalid choice: 'oops'"
             " (choose from: 'attrs', 'hello', 'log_test', 'rst')\n"

--- a/tests/test_parsing/test_parse_options.py
+++ b/tests/test_parsing/test_parse_options.py
@@ -251,6 +251,8 @@ class OptionTest(ParserTest):
             (['bar', '-fb=x'], {'sub': 'bar', 'foo': None, 'foobar': 'x'}),
             (['bar', '-fb', 'x'], {'sub': 'bar', 'foo': None, 'foobar': 'x'}),
             (['bar', '--foobar', 'x'], {'sub': 'bar', 'foo': None, 'foobar': 'x'}),
+            (['bar', '-fb', 'x', '-f', 'y'], {'sub': 'bar', 'foo': 'y', 'foobar': 'x'}),
+            (['bar', '-f', 'y', '-fb', 'x'], {'sub': 'bar', 'foo': 'y', 'foobar': 'x'}),
             (['bar', '-f=x', '-fb=y'], {'sub': 'bar', 'foo': 'x', 'foobar': 'y'}),
             (['bar', '-fb=y', '-f=x'], {'sub': 'bar', 'foo': 'x', 'foobar': 'y'}),
             (['bar', '--foobar', 'y', '--foo', 'x'], {'sub': 'bar', 'foo': 'x', 'foobar': 'y'}),


### PR DESCRIPTION
- Made it easier to exit with a specific exit code from a registered error handler function
- Made it possible to have a less specific error handler handle an exception that a more specific one did not handle
- Expanded documentation related to error handlers
- Added a new `OptionNameMode.NONE` to allow Option/Flag/etc params to be defined with only a short option string, if desired