### PR TITLE
Added support for Flag/TriFlag values from env variables

### DIFF
--- a/docs/_src/parameters.rst
+++ b/docs/_src/parameters.rst
@@ -96,6 +96,11 @@ Options support two additional initialization parameters:
       generated long form based on the Parameter's name will not be added.
 :name_mode: Override the configured :ref:`configuration:Parsing Options:option_name_mode` for this
   Option/Flag/Counter/etc.
+:env_var: A string or sequence (tuple, list, etc) of strings representing environment variables that should
+  be searched for a value when no value was provided via CLI.  If a value was provided via CLI, then these variables
+  will not be checked.  If multiple env variable names/keys were provided, then they will be checked in the order
+  that they were provided.  When enabled, values from env variables take precedence over the default value.  When
+  enabled and the Parameter is required, then either a CLI value or an env var value must be provided.
 
 .. note::
     Automatically abbreviated option strings are not supported.  To accept a particular option string, it must be
@@ -119,11 +124,6 @@ The generic :class:`.Option` parameter that accepts arbitrary values or lists of
 **Unique Option initialization parameters:**
 
 :choices: A container that holds the specific values that users must pick from.  By default, any value is allowed.
-:env_var: A string or sequence (tuple, list, etc) of strings representing environment variables that should
-  be searched for a value when no value was provided via CLI.  If a value was provided via CLI, then these variables
-  will not be checked.  If multiple env variable names/keys were provided, then they will be checked in the order
-  that they were provided.  When enabled, values from env variables take precedence over the default value.  When
-  enabled and the Parameter is required, then either a CLI value or an env var value must be provided.
 :allow_leading_dash: Whether string values may begin with a dash (``-``).  By default, if a value begins with a dash,
   it is only accepted if it appears to be a negative numeric value.  Use ``True`` / ``always`` /
   ``AllowLeadingDash.ALWAYS`` to allow any value that begins with a dash (as long as it is not an option string for an
@@ -169,8 +169,16 @@ parameters have a default value of ``False``, and will change to ``True`` if pro
 :const: The constant value to store / append.  If a ``default`` value is provided that is not a bool, then this
   must also be provided.  Defaults to ``True`` when ``default`` is ``False`` (the default when it is not specified),
   and to ``False`` when ``default`` is ``True``.
+:type: A callable (function, class, etc.) that accepts a single string argument and returns a boolean value, which
+  should be called on environment variable values, if any are configured for this Flag via
+  :ref:`parameters:Options:env_var`.  It should return a truthy value if any action should be taken (i.e.,
+  if the constant should be stored/appended), or a falsey value for no action to be taken.  The
+  :func:`default function<.str_to_bool>` handles parsing ``1`` / ``true`` / ``yes`` and similar as ``True``,
+  and ``0`` / ``false`` / ``no`` and similar as ``False``.
+:strict_env: When ``True`` (the default), if an :ref:`parameters:Options:env_var` is used as the source of
+  a value for this parameter and that value is invalid, then parsing will fail.  When ``False``, invalid values from
+  environment variables will be ignored (and a warning message will be logged).
 :nargs: Not supported.
-:type: Not supported.
 
 
 :gh_examples:`Example command <simple_flags.py>`::
@@ -230,6 +238,15 @@ provided, respectively.
 :alt_help: The help text to display with the alternate option strings.
 :default: The default value to use if neither the primary or alternate options are provided.  Defaults to None.
 :name_mode: Override the configured :ref:`configuration:Parsing Options:option_name_mode` for the TriFlag.
+:type: A callable (function, class, etc.) that accepts a single string argument and returns a boolean value, which
+  should be called on environment variable values, if any are configured for this TriFlag via
+  :ref:`parameters:Options:env_var`.  It should return a truthy value if the primary constant should be
+  stored, or a falsey value if the alternate constant should be stored.  The :func:`default function<.str_to_bool>`
+  handles parsing ``1`` / ``true`` / ``yes`` and similar as ``True``, and ``0`` / ``false`` / ``no`` and similar
+  as ``False``.
+:strict_env: When ``True`` (the default), if an :ref:`parameters:Options:env_var` is used as the source of
+  a value for this parameter and that value is invalid, then parsing will fail.  When ``False``, invalid values from
+  environment variables will be ignored (and a warning message will be logged).
 
 
 Example::

--- a/lib/cli_command_parser/command_parameters.py
+++ b/lib/cli_command_parser/command_parameters.py
@@ -498,13 +498,8 @@ class CommandParameters:
     def try_env_params(self, ctx: Context) -> Iterator[Option]:
         """Yields Option parameters that have an environment variable configured, and did not have any CLI values."""
         for param in self.options:
-            try:
-                param.env_var  # noqa
-            except AttributeError:
-                pass
-            else:
-                if ctx.num_provided(param) == 0:
-                    yield param
+            if param.env_var and ctx.num_provided(param) == 0:
+                yield param
 
     def required_check_params(self) -> Iterator[Parameter]:
         ignore = SubCommand

--- a/lib/cli_command_parser/commands.py
+++ b/lib/cli_command_parser/commands.py
@@ -39,7 +39,7 @@ class Command(ABC, metaclass=CommandMeta):
         self = super().__new__(cls)
         self.__ctx = ctx
         if not hasattr(self, 'ctx'):
-            self.ctx = ctx
+            self.ctx: Context = ctx  # noqa  # PyCharm complains this is invalid, but doesn't understand it without it
         return self
 
     def __repr__(self) -> str:

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -175,6 +175,7 @@ class Flag(_Flag[Union[TD, TC]], accepts_values=False, accepts_none=True):
             kwargs.setdefault('show_default', False)
         super().__init__(*option_strs, action=action, default=default, **kwargs)
         self.const = const
+        # TODO: Support env_var
 
     @parameter_action
     def store_const(self):
@@ -221,7 +222,7 @@ class TriFlag(_Flag[Union[TD, TC, TA]], accepts_values=False, accepts_none=True,
         alt_short: str = None,
         alt_help: str = None,
         action: str = 'store_const',
-        default: TD = None,
+        default: TD = _NotSet,
         **kwargs,
     ):
         if alt_short and '-' in alt_short[1:]:
@@ -237,6 +238,8 @@ class TriFlag(_Flag[Union[TD, TC, TA]], accepts_values=False, accepts_none=True,
             msg = f'Invalid consts={consts!r} - expected a 2-tuple of (positive, negative) constants to store'
             raise ParameterDefinitionError(msg) from e
 
+        if default is _NotSet and not kwargs.get('required', False):
+            default = None
         if default in consts:
             raise ParameterDefinitionError(
                 f'Invalid default={default!r} with consts={consts!r} - the default must not match either value'

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -6,20 +6,25 @@ Optional Parameters
 
 from __future__ import annotations
 
-from abc import ABC
+import logging
+from abc import ABC, abstractmethod
 from functools import partial, update_wrapper
-from typing import Any, Optional, Callable, Sequence, Iterator, Union, TypeVar, Tuple
+from typing import TYPE_CHECKING, Any, Optional, Callable, Union, TypeVar, Tuple
 
 from ..context import ctx
 from ..exceptions import ParameterDefinitionError, BadArgument, CommandDefinitionError, ParamUsageError, ParamConflict
 from ..inputs import normalize_input_type
 from ..nargs import Nargs, NargsValue
-from ..typing import Bool, T_co, ChoicesType, InputTypeFunc, CommandCls, CommandObj, OptStr, LeadingDash
-from ..utils import _NotSet
+from ..typing import T_co, TypeFunc
+from ..utils import _NotSet, ValueSource, str_to_bool
 from .base import BasicActionMixin, BaseOption, parameter_action
 from .option_strings import TriFlagOptionStrings
 
+if TYPE_CHECKING:
+    from ..typing import Bool, ChoicesType, InputTypeFunc, CommandCls, CommandObj, OptStr, ValSrc, LeadingDash
+
 __all__ = ['Option', 'Flag', 'TriFlag', 'ActionFlag', 'Counter', 'action_flag', 'before_main', 'after_main']
+log = logging.getLogger(__name__)
 
 TD = TypeVar('TD')
 TC = TypeVar('TC')
@@ -48,11 +53,6 @@ class Option(BasicActionMixin, BaseOption[T_co]):
       used as if it was provided here.  When both are present, this argument takes precedence.
     :param choices: A container that holds the specific values that users must pick from.  By default, any value is
       allowed.
-    :param env_var: A string or sequence (tuple, list, etc) of strings representing environment variables that should
-      be searched for a value when no value was provided via CLI.  If a value was provided via CLI, then these variables
-      will not be checked.  If multiple env variable names/keys were provided, then they will be checked in the order
-      that they were provided.  When enabled, values from env variables take precedence over the default value.  When
-      enabled and the Parameter is required, then either a CLI value or an env var value must be provided.
     :param allow_leading_dash: Whether string values may begin with a dash (``-``).  By default, if a value begins with
       a dash, it is only accepted if it appears to be a negative numeric value.  Use ``True`` / ``always`` /
       ``AllowLeadingDash.ALWAYS`` to allow any value that begins with a dash (as long as it is not an option string for
@@ -60,8 +60,6 @@ class Option(BasicActionMixin, BaseOption[T_co]):
       ``AllowLeadingDash.NEVER``.
     :param kwargs: Additional keyword arguments to pass to :class:`.BaseOption`.
     """
-
-    env_var: Union[str, Sequence[str]] = None
 
     def __init__(
         self,
@@ -72,7 +70,6 @@ class Option(BasicActionMixin, BaseOption[T_co]):
         required: Bool = False,
         type: InputTypeFunc = None,  # noqa
         choices: ChoicesType = None,
-        env_var: Union[str, Sequence[str]] = None,
         allow_leading_dash: LeadingDash = None,
         **kwargs,
     ):
@@ -91,30 +88,25 @@ class Option(BasicActionMixin, BaseOption[T_co]):
         super().__init__(*option_strs, action=action, default=default, required=required, **kwargs)
         self.type = normalize_input_type(type, choices)
         self._validate_nargs_and_allow_leading_dash(allow_leading_dash)
-        if env_var:
-            self.env_var = env_var
-
-    def env_vars(self) -> Iterator[str]:
-        env_var = self.env_var
-        if env_var:
-            if isinstance(env_var, str):
-                yield env_var
-            else:
-                yield from env_var
 
 
 class _Flag(BaseOption[T_co], ABC):
     nargs = Nargs(0)
+    type = staticmethod(str_to_bool)  # Without staticmethod, this would be interpreted as a normal method
+    strict_env: bool
     _use_opt_str: bool = False
 
     def __init_subclass__(cls, use_opt_str: bool = False, **kwargs):  # pylint: disable=W0222
         super().__init_subclass__(**kwargs)
         cls._use_opt_str = use_opt_str
 
-    def __init__(self, *option_strs: str, **kwargs):
+    def __init__(self, *option_strs: str, type: TypeFunc = None, strict_env: bool = True, **kwargs):  # noqa
         if 'metavar' in kwargs:
             raise TypeError(f"{self.__class__.__name__}.__init__() got an unexpected keyword argument: 'metavar'")
         super().__init__(*option_strs, **kwargs)
+        self.strict_env = strict_env
+        if type is not None:
+            self.type = type
 
     def _init_value_factory(self):
         if self.action == 'store_const':
@@ -122,14 +114,35 @@ class _Flag(BaseOption[T_co], ABC):
         else:
             return []
 
-    def take_action(self, value: Optional[str], short_combo: bool = False, opt_str: str = None):
+    def take_action(
+        self, value: Optional[str], short_combo: bool = False, opt_str: str = None, src: ValSrc = ValueSource.CLI
+    ):
         # log.debug(f'{self!r}.take_action({value!r})')
         ctx.record_action(self)
         if value is None:
             action_method = getattr(self, self.action)
             return action_method(opt_str) if self._use_opt_str else action_method()
+        elif src != ValueSource.CLI:
+            src, env_var = src
+            try:
+                return self.take_env_var_action(value, env_var)
+            except ParamUsageError as e:
+                if not self.strict_env:
+                    log.warning(e)
+                    return
+                raise
 
         raise ParamUsageError(self, f'received value={value!r} but no values are accepted for action={self.action!r}')
+
+    def prepare_env_var_value(self, value: str, env_var: str) -> T_co:
+        try:
+            return self.type(value)
+        except Exception as e:
+            raise ParamUsageError(self, f'unable to parse value={value!r} from env_var={env_var!r}: {e}') from e
+
+    @abstractmethod
+    def take_env_var_action(self, value: str, env_var: str):
+        raise NotImplementedError
 
     def would_accept(self, value: Optional[str], short_combo: bool = False) -> bool:  # noqa
         return value is None
@@ -153,6 +166,15 @@ class Flag(_Flag[Union[TD, TC]], accepts_values=False, accepts_none=True):
       ``const=True`` (the default), and to ``True`` when ``const=False``.  Defaults to ``None`` for any other
       constant.
     :param const: The constant value to store/append when this parameter is specified.  Defaults to ``True``.
+    :param type: A callable (function, class, etc.) that accepts a single string argument and returns a boolean value,
+      which should be called on environment variable values, if any are configured for this Flag via
+      :paramref:`.BaseOption.env_var`.  It should return a truthy value if any action should be taken (i.e., if the
+      constant should be stored/appended), or a falsey value for no action to be taken.  The
+      :func:`default function<.str_to_bool>` handles parsing ``1`` / ``true`` / ``yes`` and similar as ``True``,
+      and ``0`` / ``false`` / ``no`` and similar as ``False``.
+    :param strict_env: When ``True`` (the default), if an :paramref:`.BaseOption.env_var` is used as the source of a
+      value for this parameter and that value is invalid, then parsing will fail.  When ``False``, invalid values from
+      environment variables will be ignored (and a warning message will be logged).
     :param kwargs: Additional keyword arguments to pass to :class:`.BaseOption`.
     """
 
@@ -175,7 +197,10 @@ class Flag(_Flag[Union[TD, TC]], accepts_values=False, accepts_none=True):
             kwargs.setdefault('show_default', False)
         super().__init__(*option_strs, action=action, default=default, **kwargs)
         self.const = const
-        # TODO: Support env_var
+
+    def take_env_var_action(self, value: str, env_var: str):
+        if self.prepare_env_var_value(value, env_var):
+            getattr(self, self.action)()
 
     @parameter_action
     def store_const(self):
@@ -204,6 +229,15 @@ class TriFlag(_Flag[Union[TD, TC, TA]], accepts_values=False, accepts_none=True,
     :param default: The default value to use if neither the primary or alternate options are provided.  Defaults
       to None.
     :param name_mode: Override the configured :ref:`configuration:Parsing Options:option_name_mode` for this TriFlag.
+    :param type: A callable (function, class, etc.) that accepts a single string argument and returns a boolean value,
+      which should be called on environment variable values, if any are configured for this TriFlag via
+      :paramref:`.BaseOption.env_var`.  It should return a truthy value if the primary constant should be stored, or a
+      falsey value if the alternate constant should be stored.  The :func:`default function<.str_to_bool>` handles
+      parsing ``1`` / ``true`` / ``yes`` and similar as ``True``, and ``0`` / ``false`` / ``no`` and similar
+      as ``False``.
+    :param strict_env: When ``True`` (the default), if an :paramref:`.BaseOption.env_var` is used as the source of a
+      value for this parameter and that value is invalid, then parsing will fail.  When ``False``, invalid values from
+      environment variables will be ignored (and a warning message will be logged).
     :param kwargs: Additional keyword arguments to pass to :class:`.BaseOption`.
     """
 
@@ -264,15 +298,27 @@ class TriFlag(_Flag[Union[TD, TC, TA]], accepts_values=False, accepts_none=True,
 
     @parameter_action
     def store_const(self, opt_str: str):
-        ctx.set_parsed_value(self, self._get_const(opt_str))
+        self._store_const(self._get_const(opt_str))
 
-    def take_action(self, value: Optional[str], short_combo: bool = False, opt_str: str = None):
+    def _store_const(self, const: Union[TC, TA]):
+        ctx.set_parsed_value(self, const)
+
+    def take_action(
+        self, value: Optional[str], short_combo: bool = False, opt_str: str = None, src: ValSrc = ValueSource.CLI
+    ):
         if value is None:
             prev_parsed = ctx.get_parsed_value(self)
             const = self._get_const(opt_str)
             if prev_parsed is not self.default and prev_parsed != const:
                 raise ParamConflict([self])
-        return super().take_action(value, short_combo, opt_str)
+        return super().take_action(value, short_combo, opt_str, src)
+
+    def take_env_var_action(self, value: str, env_var: str):
+        parsed = self.prepare_env_var_value(value, env_var)
+        self._store_const(self.consts[0] if parsed else self.consts[1])
+
+
+# region Action Flag
 
 
 class ActionFlag(Flag, repr_attrs=('order', 'before_main')):
@@ -385,6 +431,9 @@ def before_main(*option_strs: str, order: Union[int, float] = 1, func: Callable 
 def after_main(*option_strs: str, order: Union[int, float] = 1, func: Callable = None, **kwargs) -> ActionFlag:
     """An ActionFlag that will be executed after :meth:`.Command.main`"""
     return ActionFlag(*option_strs, order=order, func=func, before_main=False, **kwargs)
+
+
+# endregion
 
 
 class Counter(BaseOption[int], accepts_values=True, accepts_none=True):

--- a/lib/cli_command_parser/parameters/pass_thru.py
+++ b/lib/cli_command_parser/parameters/pass_thru.py
@@ -6,16 +6,16 @@ PassThru Parameters
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Collection, Any
+from typing import TYPE_CHECKING, Any
 
 from ..context import ctx
 from ..exceptions import ParamUsageError, MissingArgument
 from ..nargs import Nargs
-from ..utils import _NotSet
+from ..utils import _NotSet, ValueSource
 from .base import Parameter, parameter_action
 
 if TYPE_CHECKING:
-    from ..typing import Bool
+    from ..typing import Bool, Strings, ValSrc
 
 __all__ = ['PassThru']
 
@@ -38,11 +38,11 @@ class PassThru(Parameter):
         super().__init__(action=action, required=required, default=default, **kwargs)
 
     @parameter_action
-    def store_all(self, values: Collection[str]):
+    def store_all(self, values: Strings):
         ctx.set_parsed_value(self, values)
 
     def take_action(  # pylint: disable=W0237
-        self, values: Collection[str], short_combo: bool = False, opt_str: str = None
+        self, values: Strings, short_combo: bool = False, opt_str: str = None, src: ValSrc = ValueSource.CLI
     ):
         value = ctx.get_parsed_value(self)
         if value is not _NotSet:

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -17,6 +17,7 @@ from .exceptions import Backtrack, NextCommand, UnsupportedAction
 from .nargs import REMAINDER, nargs_max_sum, nargs_min_sum
 from .parse_tree import PosNode
 from .parameters.base import BasicActionMixin, Parameter, BasePositional, BaseOption
+from .utils import ValueSource
 
 if TYPE_CHECKING:
     from .command_parameters import CommandParameters
@@ -112,6 +113,7 @@ class CommandParser:
     def _parse_env_vars(self, ctx: Context):
         # TODO: It would be helpful to store arg provenance for error messages, especially for a conflict between
         #  mutually exclusive params when they were provided via env
+        env = ValueSource.ENV
         for param in self.params.try_env_params(ctx):
             for env_var in param.env_vars():
                 try:
@@ -119,7 +121,7 @@ class CommandParser:
                 except KeyError:
                     pass
                 else:
-                    param.take_action(value)
+                    param.take_action(value, src=(env, env_var))
                     break
 
     def handle_pass_thru(self, ctx: Context) -> Deque[str]:

--- a/lib/cli_command_parser/typing.py
+++ b/lib/cli_command_parser/typing.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from .core import CommandMeta
     from .inputs import InputType
     from .parameters import Parameter, ParamGroup
+    from .utils import ValueSource
 
 T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)
@@ -30,6 +31,7 @@ RngType = Union[range, int, Sequence[int]]
 
 InputTypeFunc = Union[None, TypeFunc, 'InputType', range, Type['Enum']]
 ChoicesType = Optional[Collection[Any]]
+ValSrc = Union['ValueSource', Tuple['ValueSource', str]]
 
 Bool = Union[bool, Any]
 Strs = Union[str, Sequence[str]]

--- a/lib/cli_command_parser/utils.py
+++ b/lib/cli_command_parser/utils.py
@@ -6,7 +6,7 @@ Utilities for working with terminals, strings, and Enums.
 
 from __future__ import annotations
 
-from enum import Flag, EnumMeta
+from enum import Flag, Enum, EnumMeta
 from shutil import get_terminal_size
 from time import monotonic
 from typing import Any, Callable, TypeVar, List
@@ -143,3 +143,21 @@ class Terminal:  # pylint: disable=R0903
             self._width = get_terminal_size()[0]
             self._last_time = monotonic()
         return self._width
+
+
+class ValueSource(Enum):
+    CLI = 'cli'
+    ENV = 'env'
+
+
+def str_to_bool(value: str) -> bool:
+    try:
+        return bool(int(value))
+    except (TypeError, ValueError):
+        pass
+    lower = value.lower()
+    if lower in {'t', 'true', 'y', 'yes'}:
+        return True
+    elif lower in {'f', 'false', 'n', 'no'}:
+        return False
+    raise ValueError(f'Unable to parse boolean value from value={value!r}')

--- a/tests/test_parameters/test_action_flags.py
+++ b/tests/test_parameters/test_action_flags.py
@@ -287,10 +287,6 @@ class ActionFlagTest(ParserTest):
         with self.assertRaises(TypeError):
             ActionFlag(nargs='+')
 
-    def test_type_not_allowed(self):
-        with self.assertRaises(TypeError):
-            ActionFlag(type=int)
-
     def test_choices_not_allowed(self):
         with self.assertRaises(TypeError):
             ActionFlag(choices=(1, 2))

--- a/tests/test_parameters/test_flags.py
+++ b/tests/test_parameters/test_flags.py
@@ -4,7 +4,7 @@ import re
 from unittest import main
 
 from cli_command_parser import Command, Flag, TriFlag
-from cli_command_parser.exceptions import ParameterDefinitionError, CommandDefinitionError
+from cli_command_parser.exceptions import ParameterDefinitionError, CommandDefinitionError, ParamUsageError
 from cli_command_parser.testing import ParserTest, get_help_text, get_usage_text
 
 STANDALONE_DASH_B_LC = re.compile(r'(?<!-)-b\b')
@@ -35,6 +35,7 @@ class FlagTest(ParserTest):
                 class Foo(Command):
                     bar: annotation = Flag()
 
+                self.assertNotEqual(Foo.bar.type, annotation)
                 self.assert_parse_results_cases(Foo, [(['--bar'], {'bar': True}), ([], {'bar': False})])
 
     # region Test Param Actions
@@ -72,10 +73,6 @@ class FlagTest(ParserTest):
     def test_nargs_not_allowed(self):
         with self.assertRaises(TypeError):
             Flag(nargs='+')
-
-    def test_type_not_allowed(self):
-        with self.assertRaises(TypeError):
-            Flag(type=int)
 
     def test_metavar_not_allowed(self):
         with self.assertRaisesRegex(TypeError, 'got an unexpected keyword argument:'):
@@ -156,6 +153,100 @@ class FlagTest(ParserTest):
 
     # endregion
 
+    # region Env Var Handling
+
+    def test_env_var(self):
+        class Foo(Command):
+            bar = Flag('-b', env_var='BAR')
+
+        t, f = {'bar': True}, {'bar': False}
+        cases = [
+            ([], {}, f),
+            (['-b'], {'BAR': '0'}, t),  # cli takes precedence
+            ([], {'BAR': '0'}, f),  # env false ignored
+            ([], {'BAR': 'f'}, f),  # env false ignored
+            ([], {'BAR': '1'}, t),
+            ([], {'BAR': 'true'}, t),
+            ([], {'BAR': 'TruE'}, t),
+        ]
+        self.assert_env_parse_results_cases(Foo, cases)
+
+        with self.env_vars('invalid value', BAR='foo'):
+            with self.assertRaisesRegex(ParamUsageError, 'unable to parse value=.*? from env_var='):
+                Foo.parse([])
+
+    def test_env_vars(self):
+        class Foo(Command):
+            bar = Flag('-b', env_var=('FOO', 'BAR'))
+
+        t, f = {'bar': True}, {'bar': False}
+        # fmt: off
+        cases = [
+            ([], {}, f),
+            (['-b'], {'FOO': '0'}, t),              # cli takes precedence
+            (['-b'], {'BAR': '0'}, t),              # cli takes precedence
+            ([], {'BAR': '0'}, f),                  # env false ignored
+            ([], {'FOO': 'false', 'BAR': '1'}, f),  # stops after first found env var
+            ([], {'FOO': 'true', 'BAR': '0'}, t),   # stops after first found env var
+            ([], {'FOO': '1'}, t),
+            ([], {'BAR': '1'}, t),
+            ([], {'BAR': 'true'}, t),
+            ([], {'FOO': 'TruE'}, t),
+            ([], {'BAR': 'TruE'}, t),
+        ]
+        # fmt: on
+        self.assert_env_parse_results_cases(Foo, cases)
+
+    def test_env_var_invalid_permissive(self):
+        class Foo(Command):
+            bar = Flag('-b', env_var='BAR', strict_env=False)
+
+        with self.assertLogs('cli_command_parser.parameters.options', 'WARNING'):
+            self.assert_env_parse_results(Foo, [], {'BAR': 'foo'}, {'bar': False})
+
+    def test_non_default_const_stored_from_env_var(self):
+        class Foo(Command):
+            bar = Flag('-b', env_var='BAR', default=True)
+
+        t, f = {'bar': False}, {'bar': True}
+        cases = [
+            ([], {}, f),
+            (['-b'], {'BAR': '0'}, t),  # cli takes precedence
+            ([], {'BAR': '0'}, f),  # env false ignored
+            ([], {'BAR': 'f'}, f),  # env false ignored
+            ([], {'BAR': '1'}, t),
+            ([], {'BAR': 'true'}, t),
+            ([], {'BAR': 'TruE'}, t),
+        ]
+        self.assert_env_parse_results_cases(Foo, cases)
+
+    def test_custom_env_var_type(self):
+        def parse_bool(value: str) -> bool:
+            if value == 'foo':
+                return True
+            elif value == 'bar':
+                return False
+            raise ValueError
+
+        class Foo(Command):
+            bar = Flag('-b', type=parse_bool, env_var='BAR')
+
+        t, f = {'bar': True}, {'bar': False}
+        cases = [
+            ([], {}, f),
+            (['-b'], {'BAR': '123'}, t),  # cli takes precedence
+            ([], {'BAR': 'bar'}, f),
+            ([], {'BAR': 'foo'}, t),
+        ]
+        self.assert_env_parse_results_cases(Foo, cases)
+
+        for val in ('1', 'true', '0', 'false'):
+            with self.env_vars(f'invalid value={val}', BAR=val):
+                with self.assertRaisesRegex(ParamUsageError, 'unable to parse value=.*? from env_var='):
+                    Foo.parse([])
+
+    # endregion
+
 
 class TriFlagTest(ParserTest):
     def test_trinary(self):
@@ -181,10 +272,6 @@ class TriFlagTest(ParserTest):
     def test_nargs_not_allowed(self):
         with self.assertRaises(TypeError):
             TriFlag(nargs='+')
-
-    def test_type_not_allowed(self):
-        with self.assertRaises(TypeError):
-            TriFlag(type=int)
 
     def test_choices_not_allowed(self):
         with self.assertRaises(TypeError):
@@ -364,6 +451,30 @@ class TriFlagTest(ParserTest):
         self.assert_parse_results_cases(Foo, success_cases)
         fail_cases = [['--bar'], ['--no-bar'], ['--no_bar']]
         self.assert_argv_parse_fails_cases(Foo, fail_cases)
+
+    # endregion
+
+    # region Env Var Handling
+
+    def test_env_var(self):
+        class Foo(Command):
+            bar = TriFlag('-b', alt_short='-B', env_var='BAR')
+
+        d, t, f = {'bar': None}, {'bar': True}, {'bar': False}
+        cases = [
+            ([], {}, d),
+            (['-b'], {'BAR': '0'}, t),  # cli takes precedence
+            ([], {'BAR': '0'}, f),
+            ([], {'BAR': 'f'}, f),
+            ([], {'BAR': '1'}, t),
+            ([], {'BAR': 'true'}, t),
+            ([], {'BAR': 'TruE'}, t),
+        ]
+        self.assert_env_parse_results_cases(Foo, cases)
+
+        with self.env_vars('invalid value', BAR='foo'):
+            with self.assertRaisesRegex(ParamUsageError, 'unable to parse value=.*? from env_var='):
+                Foo.parse([])
 
     # endregion
 


### PR DESCRIPTION
- Fixed the default `default` value for `TriFlag` so a `TriFlag` can be marked as required
- Added support for all params that extend BaseOption (including / especially Flag/TriFlag/etc) to pull values from environment variables when not provided via CLI