### PR TITLE
Removed Python 3.7 Support + Added use_env_value Option for Flag/TriFlag

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11"]
     steps:
       - name: Add test locales
         run: |

--- a/bin/argparse_to_command.py
+++ b/bin/argparse_to_command.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 import logging
+from functools import cached_property
 from pathlib import Path
 
 from cli_command_parser import Command, Counter, Positional, Flag, ParamGroup, SubCommand, main
-from cli_command_parser.compat import cached_property
 from cli_command_parser.inputs import Path as IPath
 
 log = logging.getLogger(__name__)

--- a/docs/_src/index.rst
+++ b/docs/_src/index.rst
@@ -3,7 +3,7 @@ CLI Command Parser
 
 |downloads| |py_version| |coverage_badge| |build_status| |Blue|
 
-.. |py_version| image:: https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20-blue
+.. |py_version| image:: https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20-blue
     :target: https://pypi.org/project/cli-command-parser/
 
 .. |coverage_badge| image:: https://codecov.io/gh/dskrypa/cli_command_parser/branch/main/graph/badge.svg
@@ -85,13 +85,13 @@ with optional dependencies::
 Python Version Compatibility
 ============================
 
-Python versions 3.7 and above are currently supported.  CLI Command Parser will no longer support 3.7 after 2023-04-30,
-ahead of the `official end of support for 3.7 on 2023-06-27 <https://devguide.python.org/versions/>`__.
+Python versions 3.8 and above are currently supported.  The last release of CLI Command Parser that supported 3.7 was
+2023-04-30.  Support for Python 3.7 `officially ends on 2023-06-27 <https://devguide.python.org/versions/>`__.
 
-When using 3.7 or 3.8, some additional packages that backport functionality that was added in later Python versions
+When using Python 3.8, some additional packages that backport functionality that was added in later Python versions
 are required for compatibility.
 
-To use the argparse to cli-command-parser conversion script with Python 3.7 or 3.8, there is a dependency on
+To use the argparse to cli-command-parser conversion script with Python 3.8, there is a dependency on
 `astunparse <https://astunparse.readthedocs.io>`__.  If you are using Python 3.9 or above, then ``astunparse`` is not
 necessary because the relevant code was added to the stdlib ``ast`` module.  If you're unsure, you can install
 cli-command-parser with the following command to automatically handle whether that extra dependency is needed or not::
@@ -175,7 +175,7 @@ Indices and Tables
 
 .. toctree::
    :caption: User Guide
-   :maxdepth: 3
+   :maxdepth: 4
    :hidden:
 
    intro

--- a/docs/_src/parameters.rst
+++ b/docs/_src/parameters.rst
@@ -174,10 +174,15 @@ parameters have a default value of ``False``, and will change to ``True`` if pro
   :ref:`parameters:Options:env_var`.  It should return a truthy value if any action should be taken (i.e.,
   if the constant should be stored/appended), or a falsey value for no action to be taken.  The
   :func:`default function<.str_to_bool>` handles parsing ``1`` / ``true`` / ``yes`` and similar as ``True``,
-  and ``0`` / ``false`` / ``no`` and similar as ``False``.
+  and ``0`` / ``false`` / ``no`` and similar as ``False``.  If :ref:`parameters:Flag:use_env_value` is ``True``, then
+  this function should return either the default or constant value instead.
 :strict_env: When ``True`` (the default), if an :ref:`parameters:Options:env_var` is used as the source of
   a value for this parameter and that value is invalid, then parsing will fail.  When ``False``, invalid values from
   environment variables will be ignored (and a warning message will be logged).
+:use_env_value: If ``True``, when an :ref:`parameters:Options:env_var` is used as the source of a value for this Flag,
+  the parsed value will be stored as this Flag's value (it must match either the default or constant value).  If
+  ``False`` (the default), then the parsed value will be used to determine whether this Flag's normal action should be
+  taken as if it was specified via a CLI argument.
 :nargs: Not supported.
 
 
@@ -243,10 +248,15 @@ provided, respectively.
   :ref:`parameters:Options:env_var`.  It should return a truthy value if the primary constant should be
   stored, or a falsey value if the alternate constant should be stored.  The :func:`default function<.str_to_bool>`
   handles parsing ``1`` / ``true`` / ``yes`` and similar as ``True``, and ``0`` / ``false`` / ``no`` and similar
-  as ``False``.
+  as ``False``.  If :ref:`parameters:TriFlag:use_env_value` is ``True``, then this function should return the primary
+  or alternate constant or the default value instead.
 :strict_env: When ``True`` (the default), if an :ref:`parameters:Options:env_var` is used as the source of
   a value for this parameter and that value is invalid, then parsing will fail.  When ``False``, invalid values from
   environment variables will be ignored (and a warning message will be logged).
+:use_env_value: If ``True``, when an :ref:`parameters:Options:env_var` is used as the source of a value for this
+  TriFlag, the parsed value will be stored as this TriFlag's value (it must match the primary or alternate constant,
+  or the default value).  If ``False`` (the default), then the parsed value will be used to determine whether this
+  TriFlag's normal action should be taken as if it was specified via a CLI argument.
 
 
 Example::

--- a/lib/cli_command_parser/annotations.py
+++ b/lib/cli_command_parser/annotations.py
@@ -8,12 +8,7 @@ from __future__ import annotations
 
 from collections.abc import Collection, Iterable
 from inspect import isclass
-from typing import Union, Optional, get_type_hints
-
-try:
-    from typing import get_origin, get_args as _get_args  # pylint: disable=C0412
-except ImportError:  # Added in 3.8; the versions from 3.8 are copied here
-    from .compat import get_origin, _get_args
+from typing import Union, Optional, get_type_hints, get_origin, get_args as _get_args  # pylint: disable=C0412
 
 try:
     from types import NoneType

--- a/lib/cli_command_parser/command_parameters.py
+++ b/lib/cli_command_parser/command_parameters.py
@@ -11,12 +11,8 @@ It has some involvement in the parsing process for :class:`.BaseOption` paramete
 from __future__ import annotations
 
 from collections import defaultdict
+from functools import cached_property
 from typing import TYPE_CHECKING, Optional, Collection, Iterator, List, Dict, Set, Tuple
-
-try:
-    from functools import cached_property
-except ImportError:
-    from .compat import cached_property
 
 from .actions import help_action
 from .config import CommandConfig, AmbiguousComboMode

--- a/lib/cli_command_parser/compat.py
+++ b/lib/cli_command_parser/compat.py
@@ -8,135 +8,15 @@ The :class:`WCTextWrapper` in this module extends the stdlib :class:`python:text
 characters.
 """
 
-from collections.abc import Callable
 from textwrap import TextWrapper
-from threading import RLock
-from typing import List, Generic, _GenericAlias, _SpecialForm  # noqa
+from typing import List
 
 try:
     from wcwidth import wcswidth
 except ImportError:
     wcswidth = len
 
-__all__ = ['get_origin', 'cached_property', 'WCTextWrapper', 'Literal']
-
-
-# region typing
-
-
-def get_origin(tp):  # pylint: disable=C0103
-    # Copied from 3.8
-    if isinstance(tp, _GenericAlias):
-        return tp.__origin__
-    if tp is Generic:
-        return Generic
-    return None
-
-
-def _get_args(tp):  # pylint: disable=C0103
-    # Copied from 3.8
-    if isinstance(tp, _GenericAlias):
-        res = tp.__args__
-        if get_origin(tp) is Callable and res[0] is not Ellipsis:
-            res = (list(res[:-1]), res[-1])
-        return res
-    return ()
-
-
-try:
-    from typing import Literal
-except ImportError:  # Python 3.7
-
-    class _LiteralSpecialForm(_SpecialForm, _root=True):
-        def __repr__(self) -> str:
-            return f'compat.{self._name}'
-
-        def __getitem__(self, parameters):
-            if not isinstance(parameters, tuple):
-                parameters = (parameters,)
-            return _GenericAlias(self, parameters)
-
-    _LITERAL_DOCSTRING = """
-    Special typing form to define literal types (a.k.a. value types).
-
-    This form can be used to indicate to type checkers that the corresponding
-    variable or function parameter has a value equivalent to the provided
-    literal (or one of several literals):
-
-      def validate_simple(data: Any) -> Literal[True]:  # always returns True
-          ...
-
-      MODE = Literal['r', 'rb', 'w', 'wb']
-      def open_helper(file: str, mode: MODE) -> str:
-          ...
-
-      open_helper('/some/path', 'r')  # Passes type check
-      open_helper('/other/path', 'typo')  # Error in type checker
-
-    Literal[...] cannot be subclassed. At runtime, an arbitrary value
-    is allowed as type argument to Literal[...], but type checkers may
-    impose restrictions.
-    """
-    Literal = _LiteralSpecialForm('Literal', doc=_LITERAL_DOCSTRING)
-
-
-# endregion
-
-# region functools
-
-
-_NOT_FOUND = object()
-
-
-class cached_property:  # pylint: disable=C0103,R0903
-    # Copied from 3.10
-    def __init__(self, func):
-        self.func = func
-        self.attrname = None
-        self.__doc__ = func.__doc__
-        self.lock = RLock()
-
-    def __set_name__(self, owner, name):
-        if self.attrname is None:
-            self.attrname = name
-        elif name != self.attrname:
-            raise TypeError(
-                f'Cannot assign the same cached_property to two different names ({self.attrname!r} and {name!r}).'
-            )
-
-    def __get__(self, instance, owner=None):
-        if instance is None:
-            return self
-        if self.attrname is None:
-            raise TypeError('Cannot use cached_property instance without calling __set_name__ on it.')
-        try:
-            cache = instance.__dict__
-        except AttributeError:  # not all objects have __dict__ (e.g. class defines slots)
-            msg = (
-                f"No '__dict__' attribute on {type(instance).__name__!r} "
-                f'instance to cache {self.attrname!r} property.'
-            )
-            raise TypeError(msg) from None
-        val = cache.get(self.attrname, _NOT_FOUND)
-        if val is _NOT_FOUND:
-            with self.lock:
-                # check if another thread filled cache while we awaited lock
-                val = cache.get(self.attrname, _NOT_FOUND)
-                if val is _NOT_FOUND:
-                    val = self.func(instance)
-                    try:
-                        cache[self.attrname] = val
-                    except TypeError:
-                        msg = (
-                            f"The '__dict__' attribute on {type(instance).__name__!r} instance "
-                            f'does not support item assignment for caching {self.attrname!r} property.'
-                        )
-                        raise TypeError(msg) from None
-        return val
-
-
-# endregion
-
+__all__ = ['WCTextWrapper']
 
 # region textwrap
 

--- a/lib/cli_command_parser/context.py
+++ b/lib/cli_command_parser/context.py
@@ -12,14 +12,10 @@ from collections import defaultdict
 from contextlib import AbstractContextManager
 from contextvars import ContextVar
 from enum import Enum
+from functools import cached_property
 from inspect import Signature, Parameter as _Parameter
 from typing import TYPE_CHECKING, Any, Callable, Union, Sequence, Optional, Iterator, Collection, cast
 from typing import Dict, Tuple, List
-
-try:
-    from functools import cached_property
-except ImportError:
-    from .compat import cached_property
 
 from .config import CommandConfig, DEFAULT_CONFIG
 from .error_handling import ErrorHandler, NullErrorHandler, extended_error_handler

--- a/lib/cli_command_parser/conversion/argparse_ast.py
+++ b/lib/cli_command_parser/conversion/argparse_ast.py
@@ -5,13 +5,12 @@ import logging
 import sys
 from argparse import ArgumentParser
 from ast import AST, Assign, Call, withitem
-from functools import partial
+from functools import partial, cached_property
 from inspect import Signature, BoundArguments
 from pathlib import Path
 from typing import TYPE_CHECKING, Union, Optional, Callable, Collection, TypeVar, Generic, Type, Iterator
 from typing import List, Tuple, Dict, Set
 
-from cli_command_parser.compat import cached_property
 from .argparse_utils import ArgumentParser as _ArgumentParser, SubParsersAction as _SubParsersAction
 from .utils import get_name_repr, iter_module_parents, unparse
 

--- a/lib/cli_command_parser/conversion/command_builder.py
+++ b/lib/cli_command_parser/conversion/command_builder.py
@@ -5,10 +5,10 @@ import logging
 from abc import ABC, abstractmethod
 from ast import literal_eval, Attribute, Name, GeneratorExp, Subscript, DictComp, ListComp, SetComp, Constant, Str
 from dataclasses import dataclass, fields
+from functools import cached_property
 from itertools import count
 from typing import TYPE_CHECKING, Union, Optional, Iterator, Iterable, Type, TypeVar, Generic, List, Tuple
 
-from cli_command_parser.compat import cached_property
 from cli_command_parser.nargs import Nargs
 from .argparse_ast import AC, ParserArg, ArgGroup, MutuallyExclusiveGroup, AstArgumentParser, Script
 from .utils import collection_contents, unparse
@@ -23,6 +23,7 @@ log = logging.getLogger(__name__)
 C = TypeVar('C', bound='Converter')
 
 RESERVED = set(keyword.kwlist) | set(getattr(keyword, 'softkwlist', ('_', 'case', 'match')))  # soft was added in 3.9
+# TODO: Handle argparse.SUPPRESS ('==SUPPRESS==')
 
 
 def convert_script(script: Script, add_methods: bool = False) -> str:
@@ -301,6 +302,7 @@ class GroupConverter(CollectionConverter[ArgGroup], converts=ArgGroup, newline_b
     def _get_args(self) -> str:
         # log.debug(f'Processing args for {self.ast_obj._init_func_bound}')
         description = self.ast_obj.init_func_kwargs.get('description')
+        # TODO: Missing required=True
         title = self.ast_obj.init_func_kwargs.get('title')
         if title:
             title_str = literal_eval(title)

--- a/lib/cli_command_parser/exceptions.py
+++ b/lib/cli_command_parser/exceptions.py
@@ -213,7 +213,7 @@ class InvalidChoice(BadArgument):
 
     def __init__(self, param: Optional[Parameter], invalid: Any, choices: Collection[Any]):
         if isinstance(invalid, Collection) and not isinstance(invalid, str):
-            bad_str = 'choices: {}'.format(', '.join(map(repr, invalid)))
+            bad_str = f'choices: {", ".join(map(repr, invalid))}'
         else:
             bad_str = f'choice: {invalid!r}'
         choices_str = ', '.join(map(repr, choices))

--- a/lib/cli_command_parser/formatting/params.py
+++ b/lib/cli_command_parser/formatting/params.py
@@ -7,12 +7,8 @@ Parameter usage / help text formatters
 
 from __future__ import annotations
 
+from functools import cached_property
 from typing import TYPE_CHECKING, Type, Callable, Iterator, Iterable, Tuple, Dict
-
-try:
-    from functools import cached_property
-except ImportError:
-    from ..compat import cached_property
 
 from ..config import SubcommandAliasHelpMode
 from ..context import ctx

--- a/lib/cli_command_parser/inputs/time.py
+++ b/lib/cli_command_parser/inputs/time.py
@@ -22,13 +22,8 @@ from datetime import datetime, date, time, timedelta
 from enum import Enum
 from locale import LC_ALL, setlocale
 from threading import RLock
-from typing import Union, Iterator, Collection, Sequence, Optional, TypeVar, Type, overload
+from typing import Union, Iterator, Collection, Sequence, Optional, TypeVar, Type, Literal, overload
 from typing import Tuple, Dict
-
-try:
-    from typing import Literal
-except ImportError:
-    from ..compat import Literal
 
 from ..typing import T, Bool, Locale, TimeBound
 from ..utils import MissingMixin

--- a/lib/cli_command_parser/parameters/base.py
+++ b/lib/cli_command_parser/parameters/base.py
@@ -10,15 +10,10 @@ from __future__ import annotations
 import re
 from abc import ABC, abstractmethod
 from contextvars import ContextVar
-from functools import partial, update_wrapper
+from functools import partial, update_wrapper, cached_property
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Type, Generic, Optional, Callable, Collection, Union, Iterator, overload
 from typing import List, Tuple, FrozenSet
-
-try:
-    from functools import cached_property  # pylint: disable=C0412
-except ImportError:
-    from ..compat import cached_property
 
 from ..annotations import get_descriptor_value_type
 from ..config import CommandConfig, OptionNameMode, AllowLeadingDash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.blue]
 line-length = 120
 include = '\.pyi?$'
-target-version = ['py37', 'py38', 'py39', 'py310']
+target-version = ['py38', 'py39', 'py310']
 exclude = '''
 /(
     \.git

--- a/readme.rst
+++ b/readme.rst
@@ -3,7 +3,7 @@ CLI Command Parser
 
 |downloads| |py_version| |coverage_badge| |build_status| |Blue|
 
-.. |py_version| image:: https://img.shields.io/badge/python-3.7%20%7C%203.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20-blue
+.. |py_version| image:: https://img.shields.io/badge/python-3.8%20%7C%203.9%20%7C%203.10%20%7C%203.11%20-blue
     :target: https://pypi.org/project/cli-command-parser/
 
 .. |coverage_badge| image:: https://codecov.io/gh/dskrypa/cli_command_parser/branch/main/graph/badge.svg
@@ -85,13 +85,13 @@ with optional dependencies::
 Python Version Compatibility
 ============================
 
-Python versions 3.7 and above are currently supported.  CLI Command Parser will no longer support 3.7 after 2023-04-30,
-ahead of the `official end of support for 3.7 on 2023-06-27 <https://devguide.python.org/versions/>`__.
+Python versions 3.8 and above are currently supported.  The last release of CLI Command Parser that supported 3.7 was
+2023-04-30.  Support for Python 3.7 `officially ends on 2023-06-27 <https://devguide.python.org/versions/>`__.
 
-When using 3.7 or 3.8, some additional packages that backport functionality that was added in later Python versions
+When using Python 3.8, some additional packages that backport functionality that was added in later Python versions
 are required for compatibility.
 
-To use the argparse to cli-command-parser conversion script with Python 3.7 or 3.8, there is a dependency on
+To use the argparse to cli-command-parser conversion script with Python 3.8, there is a dependency on
 `astunparse <https://astunparse.readthedocs.io>`__.  If you are using Python 3.9 or above, then ``astunparse`` is not
 necessary because the relevant code was added to the stdlib ``ast`` module.  If you're unsure, you can install
 cli-command-parser with the following command to automatically handle whether that extra dependency is needed or not::

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
     Operating System :: OS Independent
     Programming Language :: Python
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
@@ -32,10 +31,8 @@ classifiers =
 include_package_data = True
 packages = find:
 package_dir = = lib
-python_requires = >=3.7
+python_requires = >=3.8
 tests_require = testtools; coverage
-install_requires =
-    importlib_metadata; python_version<"3.8"
 
 [options.packages.find]
 where = lib

--- a/tests/test_conversion/test_convert_argparse.py
+++ b/tests/test_conversion/test_convert_argparse.py
@@ -3,12 +3,12 @@
 from __future__ import annotations
 
 import ast
+from functools import cached_property
 from itertools import count
 from typing import TYPE_CHECKING
 from unittest import main
 from unittest.mock import Mock, patch
 
-from cli_command_parser.compat import cached_property
 from cli_command_parser.conversion.argparse_ast import Script, AstArgumentParser, AstCallable
 from cli_command_parser.conversion.argparse_ast import AddVisitedChild, visit_func
 from cli_command_parser.conversion.argparse_utils import ArgumentParser, SubParsersAction


### PR DESCRIPTION
- Added `use_env_value` option to make env var handling for Flag/TriFlag more flexible
- Removed Python 3.7 support and related compatibility code