### PR TITLE
Fixed the ability to use main with a top-level Command that extends an ABC Command

### DIFF
--- a/lib/cli_command_parser/parameters/choice_map.py
+++ b/lib/cli_command_parser/parameters/choice_map.py
@@ -270,6 +270,7 @@ class SubCommand(ChoiceMap[CommandCls], title='Subcommands', choice_validation_e
             msg = f'Invalid {choice=} for {command} with {parent=} - already assigned to {self.choices[choice].target}'
             raise CommandDefinitionError(msg) from None
 
+        command._is_subcommand_ = True
         return command
 
     def register(

--- a/tests/test_core/test_main.py
+++ b/tests/test_core/test_main.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from abc import ABC
 from unittest import TestCase, main
 from unittest.mock import Mock
 
@@ -38,10 +39,21 @@ class MainTest(TestCase):
             parse_and_run = Mock()
 
         class Bar(Foo):
-            pass
+            parse_and_run = Mock()
 
         cmd_main([])
         self.assertTrue(Foo.parse_and_run.called)
+        self.assertFalse(Bar.parse_and_run.called)
+
+    def test_main_ignores_abc(self):
+        class Foo(Command, ABC):
+            pass
+
+        class Bar(Foo):
+            main = Mock()
+
+        cmd_main([])
+        self.assertTrue(Bar.main.called)
 
     def test_main_returns_none(self):
         class Foo(Command):
@@ -58,6 +70,6 @@ class MainTest(TestCase):
 
 if __name__ == '__main__':
     try:
-        main(warnings='ignore', verbosity=2, exit=False)
+        main(verbosity=2, exit=False)
     except KeyboardInterrupt:
         print()


### PR DESCRIPTION
- Moved injected attributes into `CommandMeta.__prepare__`
- Added `_is_subcommand_`, which is set at the one point that is common to all possible ways of registering a command as a subcommand, and refactored `get_top_level_commands` to look at that attribute instead of the number of bases that are `CommandMeta` instances