### PR TITLE
Improved default Option nargs when action=append

### DIFF
--- a/docs/_src/parameters.rst
+++ b/docs/_src/parameters.rst
@@ -94,8 +94,9 @@ Options support two additional initialization parameters:
       ``-`` characters.
     - Long forms must begin with a ``--`` prefix, and may be one or more characters.  If provided, the automatically
       generated long form based on the Parameter's name will not be added.
-:name_mode: Override the configured :ref:`configuration:Parsing Options:option_name_mode` for this
-  Option/Flag/Counter/etc.
+:name_mode: Override the :ref:`configuration:Parsing Options:option_name_mode` that was configured for all options in
+  the Command for this specific Option/Flag/Counter/etc.  To only include a short form option string, ``name_mode=None``
+  may be used to prevent a long form from being automatically added.  See :class:`.OptionNameMode` for more info.
 :env_var: A string or sequence (tuple, list, etc) of strings representing environment variables that should
   be searched for a value when no value was provided via CLI.  If a value was provided via CLI, then these variables
   will not be checked.  If multiple env variable names/keys were provided, then they will be checked in the order

--- a/docs/_src/parameters.rst
+++ b/docs/_src/parameters.rst
@@ -125,6 +125,12 @@ The generic :class:`.Option` parameter that accepts arbitrary values or lists of
 **Unique Option initialization parameters:**
 
 :choices: A container that holds the specific values that users must pick from.  By default, any value is allowed.
+:nargs: The number of values that are expected/required when this parameter is specified.  Defaults to ``+``
+  when ``action='append'``, and to ``1`` otherwise. See :ref:`parameters:Parameters:nargs` for more info.
+:action: The action to take on individual parsed values.  Supported actions include ``store`` and ``append``.
+  Defaults to ``store`` when ``nargs=1`` (the default if neither action nor nargs are specified), and to ``append``
+  otherwise.  A single value will be stored when ``action='store'``, and a list of values will be stored when
+  ``action='append'``.
 :allow_leading_dash: Whether string values may begin with a dash (``-``).  By default, if a value begins with a dash,
   it is only accepted if it appears to be a negative numeric value.  Use ``True`` / ``always`` /
   ``AllowLeadingDash.ALWAYS`` to allow any value that begins with a dash (as long as it is not an option string for an

--- a/lib/cli_command_parser/config.py
+++ b/lib/cli_command_parser/config.py
@@ -78,26 +78,30 @@ class OptionNameMode(FixedFlag):
     Given a Parameter defined as ``foo_bar = Option(...)``, the default long form handling based on this setting would
     be:
 
-    :UNDERSCORE: ``--foo_bar``
-    :DASH: ``--foo-bar``
-    :BOTH: Both ``--foo-bar`` and ``--foo_bar`` will be accepted
+    :UNDERSCORE: ``--foo_bar`` - the attribute name is used verbatim.
+    :DASH: ``--foo-bar`` - any underscores present in the attribute name will be replaced with dashes (this is
+      the default behavior).
+    :BOTH: Both ``--foo-bar`` and ``--foo_bar`` will be accepted, and both will be displayed in help text.
     :BOTH_UNDERSCORE: Both ``--foo-bar`` and ``--foo_bar`` will be accepted, but only ``--foo_bar`` with be displayed
-      in help text
+      in help text.  This may be useful for compatibility purposes, and helps prevent help text from being too
+      cluttered.
     :BOTH_DASH: Both ``--foo-bar`` and ``--foo_bar`` will be accepted, but only ``--foo-bar`` with be displayed
-      in help text
+      in help text.  This may be useful for compatibility purposes, and helps prevent help text from being too
+      cluttered.
     :NONE: No long form option string will be added.  At least one short form option string must be defined.  Note that
-      it is NOT necessary to use ``name_mode=None`` to prevent the automatic creation of long form option strings - if
-      any long form option strings are explicitly provided for a given Parameter, then no automatic ones will be added.
+      it is NOT necessary to use ``name_mode=None`` to prevent the automatic creation of long form option strings in
+      general.  If any long form option strings are explicitly provided for a given Parameter, then an automatic one
+      will not be added, regardless of value for this configuration option.
 
     If a long form is provided explicitly for a given optional Parameter, then this setting will be ignored.
 
     The value may be specified to Commands as ``option_name_mode=<mode>`` or to Parameters as ``name_mode=<mode>``,
     where ``<mode>`` is one of:
 
+        - ``'_'`` or ``'-'`` or ``'*'`` or ``'*_'`` or ``'*-'`` or ``'_*'`` or ``'-*'`` or ``None``
         - ``OptionNameMode.UNDERSCORE`` or ``OptionNameMode.DASH`` or ``OptionNameMode.BOTH``
-          or ``OptionNameMode.BOTH_UNDERSCORE`` or ``OptionNameMode.BOTH_DASH``
-        - ``'underscore'`` or ``'dash'`` or ``'both'`` or ``'both_underscore'`` or ``'both_dash'``
-        - ``'_'`` or ``'-'`` or ``'*'`` or ``'*_'`` or ``'*-'``
+          or ``OptionNameMode.BOTH_UNDERSCORE`` or ``OptionNameMode.BOTH_DASH`` or ``OptionNameMode.NONE``
+        - ``'underscore'`` or ``'dash'`` or ``'both'`` or ``'both_underscore'`` or ``'both_dash'`` or ``'none'``
     """
 
     UNDERSCORE = 1

--- a/lib/cli_command_parser/formatting/commands.py
+++ b/lib/cli_command_parser/formatting/commands.py
@@ -160,6 +160,8 @@ class CommandHelpFormatter:
         # TODO: The subcommand names in the group containing subcommand targets should link to their respective
         #  subcommand sections
         for group in self.groups:
+            # TODO: Nested subcommands' local choices should not repeat the `subcommands` positional arguments section
+            #  that includes the nested subcommand choice being documented
             if group.show_in_help:
                 table: RstTable = group.formatter.rst_table()  # noqa
                 yield from table.iter_build()
@@ -182,6 +184,9 @@ class CommandHelpFormatter:
             yield from spaced_rst_header('Subcommands', level - 1)
 
         for cmd_name, choice in sub_command.choices.items():
+            # TODO: There are some cases where multiple aliases for the same command (possibly local choices, possibly
+            #  multiple choices all handled by a single class) would be better documented without separate sections for
+            #  each choice value (should probably be configurable to explode or condense)
             choice_str = f'{choice_base} {cmd_name}' if choice_base else cmd_name
             yield from spaced_rst_header(f'Subcommand: {choice_str}', level)
             if choice_help := choice.help:

--- a/lib/cli_command_parser/inputs/base.py
+++ b/lib/cli_command_parser/inputs/base.py
@@ -7,13 +7,16 @@ Custom input handlers for Parameters
 from abc import ABC, abstractmethod
 from typing import Any, Generic, Optional
 
-from ..typing import T
+from ..typing import T, Bool
 
 __all__ = ['InputType']
 
 
 class InputType(Generic[T], ABC):
-    __slots__ = ()
+    __slots__ = ('_fix_default',)
+
+    def __init__(self, fix_default: Bool = True):
+        self._fix_default = fix_default
 
     @abstractmethod
     def __call__(self, value: str) -> T:

--- a/lib/cli_command_parser/inputs/choices.py
+++ b/lib/cli_command_parser/inputs/choices.py
@@ -94,7 +94,7 @@ class Choices(_ChoicesBase[T]):
             raise TypeError(f'Cannot combine case_sensitive=False with non-str {choices=}')
         elif isinstance(type, EnumChoices) and not any(isinstance(c, type.type) for c in choices):
             raise TypeError(f'Invalid {choices=} for {type=}')
-
+        super().__init__()  # fix_default is not implemented here, so it's not necessary to expose
         self.choices = choices
         self.type = type
         self.case_sensitive = case_sensitive
@@ -159,6 +159,7 @@ class EnumChoices(_ChoicesBase[EnumT]):
     type: Type[EnumT]
 
     def __init__(self, enum: Type[EnumT], case_sensitive: Bool = False):
+        super().__init__()  # fix_default is not implemented here, so it's not necessary to expose
         self.type = enum
         self.case_sensitive = case_sensitive
         self.choices = enum._member_map_

--- a/lib/cli_command_parser/inputs/files.py
+++ b/lib/cli_command_parser/inputs/files.py
@@ -40,7 +40,9 @@ class FileInput(InputType[T], ABC):
         writable: Bool = False,
         allow_dash: Bool = False,
         use_windows_fix: Bool = True,
+        fix_default: Bool = True,
     ):
+        super().__init__(fix_default)
         self.exists = exists
         self.expand = expand
         self.resolve = resolve
@@ -59,7 +61,7 @@ class FileInput(InputType[T], ABC):
         Fixes the default value to conform to the expected return type for this input.  Allows the default value for a
         path to be provided as a string, for example.
         """
-        if value is None:
+        if value is None or not self._fix_default:
             return value
         return self(value)
 
@@ -96,6 +98,7 @@ class FileInput(InputType[T], ABC):
 
 
 class Path(FileInput[_Path]):
+    # noinspection PyUnresolvedReferences
     """
     :param exists: If set, then the provided path must already exist if True, or must not already exist if False.
       Default: existence is not checked.
@@ -109,6 +112,7 @@ class Path(FileInput[_Path]):
     :param allow_dash: Allow a dash (``-``) to be provided to indicate stdin/stdout (default: False).
     :param use_windows_fix: If True (the default) and the program is running on Windows, then :func:`.fix_windows_path`
       will be called to fix issues caused by auto-completion via Git Bash.
+    :param fix_default: Whether default values should be normalized using :meth:`.fix_default`.
     """
 
     def __call__(self, value: PathLike) -> _Path:

--- a/lib/cli_command_parser/inputs/files.py
+++ b/lib/cli_command_parser/inputs/files.py
@@ -112,7 +112,7 @@ class Path(FileInput[_Path]):
     :param allow_dash: Allow a dash (``-``) to be provided to indicate stdin/stdout (default: False).
     :param use_windows_fix: If True (the default) and the program is running on Windows, then :func:`.fix_windows_path`
       will be called to fix issues caused by auto-completion via Git Bash.
-    :param fix_default: Whether default values should be normalized using :meth:`.fix_default`.
+    :param fix_default: Whether default values should be normalized using :meth:`~FileInput.fix_default`.
     """
 
     def __call__(self, value: PathLike) -> _Path:

--- a/lib/cli_command_parser/inputs/numeric.py
+++ b/lib/cli_command_parser/inputs/numeric.py
@@ -62,7 +62,7 @@ class Range(NumericInput[NT]):
       value is closer to.
     :param type: Callable that returns a numeric type, to be used on parsed values before validating whether they are
       in the allowed range.  Defaults to :class:`python:int`.
-    :param fix_default: Whether default values should be normalized using :meth:`.fix_default`.
+    :param fix_default: Whether default values should be normalized using :meth:`~NumericInput.fix_default`.
     """
 
     type: NumType = int
@@ -117,7 +117,7 @@ class NumRange(NumericInput[NT]):
     :param max: The maximum allowed value, or None to have no upper bound
     :param include_min: Whether the minimum is inclusive (default: True)
     :param include_max: Whether the maximum is inclusive (default: False)
-    :param fix_default: Whether default values should be normalized using :meth:`.fix_default`.
+    :param fix_default: Whether default values should be normalized using :meth:`~NumericInput.fix_default`.
     """
 
     __slots__ = ('type', 'snap', 'min', 'max', 'include_min', 'include_max')

--- a/lib/cli_command_parser/inputs/numeric.py
+++ b/lib/cli_command_parser/inputs/numeric.py
@@ -46,7 +46,7 @@ class NumericInput(InputType[NT], ABC):
         return f'{{{self._range_str()}}}'
 
     def fix_default(self, value: Union[str, NT, None]) -> Optional[NT]:
-        if value is None or not isinstance(value, str):
+        if value is None or not isinstance(value, str) or not self._fix_default:
             return value
         return self(value)
 
@@ -60,13 +60,17 @@ class Range(NumericInput[NT]):
     :param snap: If True and a provided value is outside the allowed range, snap to the nearest bound.  The min or max
       of the provided range (not necessarily the start/stop values) will be used, depending on which one the provided
       value is closer to.
+    :param type: Callable that returns a numeric type, to be used on parsed values before validating whether they are
+      in the allowed range.  Defaults to :class:`python:int`.
+    :param fix_default: Whether default values should be normalized using :meth:`.fix_default`.
     """
 
     type: NumType = int
     range: Optional[_range]
     snap: bool
 
-    def __init__(self, range: RngType, snap: Bool = False, type: NumType = None):  # noqa
+    def __init__(self, range: RngType, snap: Bool = False, type: NumType = None, fix_default: Bool = True):  # noqa
+        super().__init__(fix_default)
         self.snap = snap
         if isinstance(range, int):
             self.range = _range(range)
@@ -113,6 +117,7 @@ class NumRange(NumericInput[NT]):
     :param max: The maximum allowed value, or None to have no upper bound
     :param include_min: Whether the minimum is inclusive (default: True)
     :param include_max: Whether the maximum is inclusive (default: False)
+    :param fix_default: Whether default values should be normalized using :meth:`.fix_default`.
     """
 
     __slots__ = ('type', 'snap', 'min', 'max', 'include_min', 'include_max')
@@ -131,12 +136,14 @@ class NumRange(NumericInput[NT]):
         max: Number = None,  # noqa
         include_min: Bool = True,
         include_max: Bool = False,
+        fix_default: Bool = True,
     ):
         if min is None and max is None:
             raise ValueError('NumRange inputs must be initialized with at least one of min and/or max values')
         elif min is not None and max is not None and min >= max:
             raise ValueError(f'Invalid {min=} >= {max=} - min must be less than max')
 
+        super().__init__(fix_default)
         if type is None:
             self.type = float if isinstance(min, float) or isinstance(max, float) else int
         else:

--- a/lib/cli_command_parser/inputs/patterns.py
+++ b/lib/cli_command_parser/inputs/patterns.py
@@ -103,6 +103,7 @@ class Regex(PatternInput[RegexResult]):
             raise TypeError('At least one regex pattern is required')
         elif group is not None and groups is not None:
             raise TypeError(f'Invalid combination of {group=} with {groups=} - only one may be provided')
+        super().__init__()  # fix_default is not implemented here, so it's not necessary to expose
         self.mode = mode = RegexMode.normalize(mode, group, groups)
         self.patterns = tuple(re.compile(p) if isinstance(p, str) else p for p in patterns)
         self.group = 0 if group is None and mode == RegexMode.GROUP else group
@@ -144,6 +145,7 @@ class Glob(PatternInput[str]):
     def __init__(self, *patterns: str, match_case: bool = False, normcase: bool = False):
         if not patterns:
             raise TypeError('At least one glob/fnmatch pattern is required')
+        super().__init__()  # fix_default is not implemented here, so it's not necessary to expose
         if normcase:
             patterns = tuple(os.path.normcase(p) for p in patterns)
         self._original_patterns = patterns

--- a/lib/cli_command_parser/inputs/time.py
+++ b/lib/cli_command_parser/inputs/time.py
@@ -138,7 +138,7 @@ class CalendarUnitInput(DTInput[Union[str, int]], ABC):
         :param locale: An alternate locale to use when parsing input
         :param out_format: A :class:`DTFormatMode` or str that matches a format mode.  Defaults to full weekday name.
         :param out_locale: Alternate locale to use for output.  Defaults to the same value as ``locale``.
-        :param fix_default: Whether default values should be normalized using :meth:`.fix_default`.
+        :param fix_default: Whether default values should be normalized using :meth:`~DTInput.fix_default`.
         """
         if not (full or abbreviation or numeric):
             raise ValueError('At least one of full, abbreviation, or numeric must be True')
@@ -254,7 +254,7 @@ class Day(CalendarUnitInput, dt_type='day of the week'):
         :param locale: An alternate locale to use when parsing input
         :param out_format: A :class:`DTFormatMode` or str that matches a format mode.  Defaults to full weekday name.
         :param out_locale: Alternate locale to use for output.  Defaults to the same value as ``locale``.
-        :param fix_default: Whether default values should be normalized using :meth:`.fix_default`.
+        :param fix_default: Whether default values should be normalized using :meth:`~DTInput.fix_default`.
         """
         ...
 
@@ -309,7 +309,7 @@ class Month(CalendarUnitInput, dt_type='month', min_index=1):
         :param locale: An alternate locale to use when parsing input
         :param out_format: A :class:`DTFormatMode` or str that matches a format mode.  Defaults to full month name.
         :param out_locale: Alternate locale to use for output.  Defaults to the same value as ``locale``.
-        :param fix_default: Whether default values should be normalized using :meth:`.fix_default`.
+        :param fix_default: Whether default values should be normalized using :meth:`~DTInput.fix_default`.
         """
         ...
 
@@ -489,7 +489,7 @@ class DateTime(DateTimeInput[datetime], type=datetime):
         :param locale: An alternate locale to use when parsing input
         :param earliest: If specified, the parsed value must be later than or equal to this
         :param latest: If specified, the parsed value must be earlier than or equal to this
-        :param fix_default: Whether default values should be normalized using :meth:`.fix_default`.
+        :param fix_default: Whether default values should be normalized using :meth:`~DTInput.fix_default`.
         """
         super().__init__(
             formats or (DEFAULT_DT_FMT,), locale=locale, earliest=earliest, latest=latest, fix_default=fix_default
@@ -514,7 +514,7 @@ class Date(DateTimeInput[date], type=date):
         :param locale: An alternate locale to use when parsing input
         :param earliest: If specified, the parsed value must be later than or equal to this
         :param latest: If specified, the parsed value must be earlier than or equal to this
-        :param fix_default: Whether default values should be normalized using :meth:`.fix_default`.
+        :param fix_default: Whether default values should be normalized using :meth:`~DTInput.fix_default`.
         """
         super().__init__(
             formats or (DEFAULT_DATE_FMT,), locale=locale, earliest=earliest, latest=latest, fix_default=fix_default
@@ -539,7 +539,7 @@ class Time(DateTimeInput[time], type=time):
         :param locale: An alternate locale to use when parsing input
         :param earliest: If specified, the parsed value must be later than or equal to this
         :param latest: If specified, the parsed value must be earlier than or equal to this
-        :param fix_default: Whether default values should be normalized using :meth:`.fix_default`.
+        :param fix_default: Whether default values should be normalized using :meth:`~DTInput.fix_default`.
         """
         super().__init__(
             formats or (DEFAULT_TIME_FMT,), locale=locale, earliest=earliest, latest=latest, fix_default=fix_default

--- a/lib/cli_command_parser/inputs/utils.py
+++ b/lib/cli_command_parser/inputs/utils.py
@@ -33,10 +33,10 @@ class InputParam:
         self.name = name
 
     def __get__(self, instance, owner) -> Any:
-        if instance is None:
-            return self
         try:
             return instance.__dict__[self.name]
+        except AttributeError:  # instance is None
+            return self
         except KeyError:
             return self.default
 
@@ -108,7 +108,7 @@ class FileWrapper:
         self._finalizer = None
 
     def __eq__(self, other: FileWrapper) -> bool:
-        attrs = ('path', 'mode', 'binary', 'encoding', 'errors', 'converter', 'pass_file')
+        attrs = ('path', 'mode', 'binary', 'encoding', 'errors', 'converter', 'pass_file', 'parents')
         try:
             return all(getattr(self, a) == getattr(other, a) for a in attrs)
         except AttributeError:

--- a/lib/cli_command_parser/parameters/base.py
+++ b/lib/cli_command_parser/parameters/base.py
@@ -421,8 +421,7 @@ class Parameter(ParamBase, Generic[T_co], ABC):
                 raise MissingArgument(self)
             else:
                 return self._fix_default(self.default)
-
-        if self.action == 'store':
+        elif self.action == 'store':
             return value
 
         # Implied: action == 'append' or 'store_all'

--- a/lib/cli_command_parser/parameters/base.py
+++ b/lib/cli_command_parser/parameters/base.py
@@ -256,34 +256,41 @@ class Parameter(ParamBase, Generic[T_co], ABC):
                 f'Invalid {action=} for {self.__class__.__name__} - valid actions: {sorted(self._actions)}'
             )
         if required and default is not _NotSet:
+            # TODO: For required mutually dependent groups, or a required group with all params having a default,
+            #  is another check needed, or does this check make sense, or should this check be removed?
             raise ParameterDefinitionError(
                 f'Invalid combination of required=True with {default=} for {self.__class__.__name__} -'
                 ' required Parameters cannot have a default value'
             )
         super().__init__(name=name, required=required, help=help, hide=hide)
         self.action = action
-        self.default = None if default is _NotSet and not required and self.nargs.max == 1 else default
+        self.default = self._init_default() if default is _NotSet else default
         self.metavar = metavar
         if show_default is not None:
             self.show_default = show_default
+
+    def _init_default(self):
+        if not self.required and self.nargs.max == 1:
+            return None
+        return _NotSet
 
     def _init_value_factory(self):
         return _NotSet
 
     def __set_name__(self, command: CommandCls, name: str):
         super().__set_name__(command, name)
-        type_attr = self.type
-        choices = isinstance(type_attr, (ChoiceMapInput, Choices)) and type_attr.type is None
-        if (
-            not (choices or type_attr is None)
-            or not self._config(command).allow_annotation_type
-            or self.nargs.max is REMAINDER
-        ):
+        # If self.type is None, a type may still be inferred from an annotation, which happens in this method.
+        if untyped_choices := (type_attr := self.type) is not None:
+            if not isinstance(type_attr, _ChoicesBase) or type_attr.type is not None:
+                return  # An explicit type was provided to either stand alone or be used for Choices values
+            # self.type is therefore a Choices object with no explicit type provided, so from here on, the var
+            # name `untyped_choices` is accurate.  The type for its values may still be inferred from an annotation.
+        elif self.nargs.max is REMAINDER or not self._config(command).allow_annotation_type:
             return
 
         if (annotated_type := get_descriptor_value_type(command, name)) is None:
             return
-        elif choices:
+        elif untyped_choices:
             type_attr.type = annotated_type
         else:  # self.type must be None
             # Choices present earlier would have already been converted
@@ -291,8 +298,9 @@ class Parameter(ParamBase, Generic[T_co], ABC):
 
     @property
     def has_choices(self) -> bool:
-        type_attr = self.type
-        return isinstance(type_attr, _ChoicesBase) and type_attr.choices
+        if type_attr := self.type:
+            return isinstance(type_attr, _ChoicesBase) and type_attr.choices
+        return False
 
     # endregion
 
@@ -305,26 +313,7 @@ class Parameter(ParamBase, Generic[T_co], ABC):
         kwargs = ', '.join(f'{a}={v!r}' for a, v in attrs if v not in (None, _NotSet) and not (a == 'hide' and not v))
         return f'{self.__class__.__name__}({self.name!r}, {kwargs})'
 
-    # region Argument Handling
-
-    @overload
-    def __get__(self: Param, command: None, owner: CommandCls) -> Param:
-        ...
-
-    @overload
-    def __get__(self, command: CommandObj, owner: CommandCls) -> Optional[T_co]:
-        ...
-
-    def __get__(self, command, owner):
-        if command is None:
-            return self
-
-        with self._ctx(command):
-            value = self.result()
-
-        if (name := self._attr_name) is not None:
-            command.__dict__[name] = value  # Skip __get__ on subsequent accesses
-        return value
+    # region Parsing / Argument Handling
 
     def _get_parsed_and_max_reached(self) -> Tuple[List[T_co], bool]:
         parsed = ctx.get_parsed_value(self)
@@ -397,17 +386,34 @@ class Parameter(ParamBase, Generic[T_co], ABC):
         else:
             return True
 
-    def _fix_default(self, value) -> Optional[T_co]:
-        type_func = self.type
-        if type_func is not None and isinstance(type_func, InputType):
-            return type_func.fix_default(value)
-        return value
+    def can_pop_counts(self) -> List[int]:  # noqa
+        return []
 
-    def _fix_default_collection(self, values) -> Optional[T_co]:
-        type_func = self.type
-        if type_func is None or not isinstance(type_func, InputType) or not isinstance(values, (list, tuple, set)):
-            return values
-        return values.__class__(map(type_func.fix_default, values))
+    def pop_last(self, count: int = 1) -> List[str]:
+        raise UnsupportedAction
+
+    # endregion
+
+    # region Parse Results / Argument Value Handling
+
+    @overload
+    def __get__(self: Param, command: None, owner: CommandCls) -> Param:
+        ...
+
+    @overload
+    def __get__(self, command: CommandObj, owner: CommandCls) -> Optional[T_co]:
+        ...
+
+    def __get__(self, command, owner):
+        if command is None:
+            return self
+
+        with self._ctx(command):
+            value = self.result()
+
+        if (name := self._attr_name) is not None:
+            command.__dict__[name] = value  # Skip __get__ on subsequent accesses
+        return value
 
     def result_value(self) -> Optional[T_co]:
         if (value := ctx.get_parsed_value(self)) is _NotSet:
@@ -419,13 +425,12 @@ class Parameter(ParamBase, Generic[T_co], ABC):
         if self.action == 'store':
             return value
 
-        # action == 'append' or 'store_all'
-        if not value:
-            if (default := self.default) is not _NotSet:
-                if isinstance(default, Collection) and not isinstance(default, str):
-                    value = self._fix_default_collection(default)
-                else:
-                    value.append(self._fix_default(default))
+        # Implied: action == 'append' or 'store_all'
+        if not value and (default := self.default) is not _NotSet:
+            if isinstance(default, Collection) and not isinstance(default, str):
+                value = self._fix_default_collection(default)
+            else:
+                value.append(self._fix_default(default))
 
         nargs = self.nargs
         if (val_count := len(value)) == 0 and 0 not in nargs:
@@ -438,11 +443,15 @@ class Parameter(ParamBase, Generic[T_co], ABC):
 
     result = result_value
 
-    def can_pop_counts(self) -> List[int]:  # noqa
-        return []
+    def _fix_default(self, value) -> Optional[T_co]:
+        if (type_func := self.type) and isinstance(type_func, InputType):
+            return type_func.fix_default(value)
+        return value
 
-    def pop_last(self, count: int = 1) -> List[str]:
-        raise UnsupportedAction
+    def _fix_default_collection(self, values) -> Optional[T_co]:
+        if (type_func := self.type) and isinstance(type_func, InputType) and isinstance(values, (list, tuple, set)):
+            return values.__class__(map(type_func.fix_default, values))
+        return values
 
     # endregion
 
@@ -462,12 +471,41 @@ class Parameter(ParamBase, Generic[T_co], ABC):
 class BasicActionMixin:
     action: str
     nargs: Nargs
+    required: bool
     type: Optional[Callable]
+
+    # region Initialization
+
+    def _validate_nargs_and_allow_leading_dash(self, allow_leading_dash: LeadingDash):
+        if allow_leading_dash is not None:
+            allow_leading_dash = AllowLeadingDash(allow_leading_dash)
+
+        if self.nargs.max is REMAINDER:
+            if self.type is not None:
+                raise ParameterDefinitionError(f'Type casting and choices are not supported with nargs={self.nargs!r}')
+            elif allow_leading_dash not in (None, AllowLeadingDash.ALWAYS):
+                raise ParameterDefinitionError(
+                    f'With nargs={self.nargs!r}, only allow_leading_dash=AllowLeadingDash.ALWAYS is supported - found:'
+                    f' {allow_leading_dash!r}'
+                )
+            allow_leading_dash = AllowLeadingDash.ALWAYS
+
+        if allow_leading_dash is not None:
+            self.allow_leading_dash = allow_leading_dash
+
+    def _init_default(self):
+        if not self.required and self.nargs.max == 1 and self.action != 'append':
+            return None
+        return _NotSet
 
     def _init_value_factory(self):
         if self.action == 'append':
             return []
         return super()._init_value_factory()  # noqa
+
+    # endregion
+
+    # region Actions
 
     @parameter_action
     def store(self: Parameter, value: T_co):
@@ -483,6 +521,10 @@ class BasicActionMixin:
                 self, f'cannot accept any additional args with nargs={self.nargs} - already found {len(parsed)} values'
             )
         parsed.append(value)
+
+    # endregion
+
+    # region Parsing - Backtracking Methods
 
     def _pre_pop_values(self: Parameter):
         if self.action != 'append' or not self.nargs.variable or self.type not in (None, str):
@@ -517,22 +559,7 @@ class BasicActionMixin:
         ctx.record_action(self, -count)
         return values[-count:]
 
-    def _validate_nargs_and_allow_leading_dash(self, allow_leading_dash: LeadingDash):
-        if allow_leading_dash is not None:
-            allow_leading_dash = AllowLeadingDash(allow_leading_dash)
-
-        if self.nargs.max is REMAINDER:
-            if self.type is not None:
-                raise ParameterDefinitionError(f'Type casting and choices are not supported with nargs={self.nargs!r}')
-            elif allow_leading_dash not in (None, AllowLeadingDash.ALWAYS):
-                raise ParameterDefinitionError(
-                    f'With nargs={self.nargs!r}, only allow_leading_dash=AllowLeadingDash.ALWAYS is supported - found:'
-                    f' {allow_leading_dash!r}'
-                )
-            allow_leading_dash = AllowLeadingDash.ALWAYS
-
-        if allow_leading_dash is not None:
-            self.allow_leading_dash = allow_leading_dash
+    # endregion
 
 
 class BasePositional(Parameter[T_co], ABC):

--- a/lib/cli_command_parser/parameters/choice_map.py
+++ b/lib/cli_command_parser/parameters/choice_map.py
@@ -270,7 +270,7 @@ class SubCommand(ChoiceMap[CommandCls], title='Subcommands', choice_validation_e
             msg = f'Invalid {choice=} for {command} with {parent=} - already assigned to {self.choices[choice].target}'
             raise CommandDefinitionError(msg) from None
 
-        command._is_subcommand_ = True
+        command._is_subcommand_ = True  # This is used indirectly by ``main()`` to filter out non-top-level Commands
         return command
 
     def register(

--- a/lib/cli_command_parser/parameters/option_strings.py
+++ b/lib/cli_command_parser/parameters/option_strings.py
@@ -19,6 +19,8 @@ __all__ = ['OptionStrings', 'TriFlagOptionStrings']
 
 
 class OptionStrings:
+    """Container for the option strings registered for a given BaseOption (or subclass thereof)."""
+
     __slots__ = ('name_mode', '_long', '_short', 'combinable', '_display_long')
     name_mode: Optional[OptionNameMode]
     combinable: Set[str]
@@ -90,6 +92,8 @@ class OptionStrings:
 
 
 class TriFlagOptionStrings(OptionStrings):
+    """Container for the option strings registered for a given TriFlag."""
+
     __slots__ = ('_alt_prefix', '_alt_long', '_alt_short')
     _alt_prefix: Optional[str]
     _alt_short: Optional[str]
@@ -184,14 +188,16 @@ class TriFlagOptionStrings(OptionStrings):
 
 
 def _sort_options(options: Collection[str]):
+    """Sort option strings in descending length order (alphanumeric order for options with the same length)"""
     return sorted(options, key=lambda opt: (-len(opt), opt))
 
 
 def _split_options(opt_strs: Collection[str]) -> Tuple[Set[str], Set[str]]:
+    """Split long and short option strings and ensure that all of the provided option strings are valid."""
     long_opts, short_opts, bad_opts, bad_short = set(), set(), [], []
     for opt in opt_strs:
-        if not opt:
-            continue
+        if not opt:     # Ignore None / empty strings / etc
+            continue    # Only raise an exception if invalid values that were intended to be used were provided
         elif not 0 < opt.count('-', 0, 3) < 3 or opt.endswith('-') or '=' in opt:
             bad_opts.append(opt)
         elif opt.startswith('--'):
@@ -202,11 +208,13 @@ def _split_options(opt_strs: Collection[str]) -> Tuple[Set[str], Set[str]]:
             short_opts.add(opt)
 
     if bad_opts:
-        bad = ', '.join(bad_opts)
+        bad = ', '.join(map(repr, bad_opts))
         raise ParameterDefinitionError(
             f"Bad option(s) - they must start with '--' or '-', may not end with '-', and may not contain '=': {bad}"
         )
     elif bad_short:
-        raise ParameterDefinitionError(f"Bad short option(s) - they may not contain '-': {', '.join(bad_short)}")
+        raise ParameterDefinitionError(
+            f"Bad short option(s) - they may not contain '-': {', '.join(map(repr, bad_short))}"
+        )
 
     return long_opts, short_opts

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -37,8 +37,8 @@ class Option(BasicActionMixin, BaseOption[T_co]):
 
     :param option_strs: The long and/or short option prefixes for this option.  If no long prefixes are specified,
       then one will automatically be added based on the name assigned to this parameter.
-    :param nargs: The number of values that are expected/required when this parameter is specified.  Defaults to 1.
-      See :class:`.Nargs` for more info.
+    :param nargs: The number of values that are expected/required when this parameter is specified.  Defaults to ``+``
+      when ``action='append'``, and to ``1`` otherwise. See :class:`.Nargs` for more info.
     :param action: The action to take on individual parsed values.  Actions must be defined as methods in classes
       that extend Parameter, and must be registered via :class:`.parameter_action`.  Defaults to ``store`` when
       ``nargs=1``, and to ``append`` otherwise.  A single value will be stored when ``action='store'``, and a list

--- a/lib/cli_command_parser/parameters/pass_thru.py
+++ b/lib/cli_command_parser/parameters/pass_thru.py
@@ -15,7 +15,7 @@ from ..utils import _NotSet, ValueSource
 from .base import Parameter, parameter_action
 
 if TYPE_CHECKING:
-    from ..typing import Bool, Strings, ValSrc
+    from ..typing import Strings, ValSrc
 
 __all__ = ['PassThru']
 
@@ -32,10 +32,11 @@ class PassThru(Parameter):
     nargs = Nargs('REMAINDER')
     missing_hint: str = "missing pass thru args separated from others with '--'"
 
-    def __init__(self, action: str = 'store_all', default: Any = _NotSet, required: Bool = False, **kwargs):
-        if not required and default is _NotSet:
-            default = None
-        super().__init__(action=action, required=required, default=default, **kwargs)
+    def __init__(self, action: str = 'store_all', **kwargs):
+        super().__init__(action=action, **kwargs)
+
+    def _init_default(self):
+        return _NotSet if self.required else None
 
     @parameter_action
     def store_all(self, values: Strings):

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -4,9 +4,9 @@ from itertools import product, starmap
 from operator import or_
 from unittest import TestCase, main
 
-from cli_command_parser import Command, SubCommand
+from cli_command_parser import Command, SubCommand, CommandConfig, ShowDefaults, AllowLeadingDash, OptionNameMode
 from cli_command_parser.core import get_config
-from cli_command_parser.config import CommandConfig, ShowDefaults, ConfigItem, DEFAULT_CONFIG, AllowLeadingDash
+from cli_command_parser.config import ConfigItem, DEFAULT_CONFIG
 
 
 class ConfigItemTest(TestCase):
@@ -41,6 +41,8 @@ class ConfigItemTest(TestCase):
 
 
 class ConfigEnumTest(TestCase):
+    # region Show Default
+
     def test_invalid_show_defaults(self):
         with self.assertRaisesRegex(ValueError, 'Invalid.*- expected one of'):
             ShowDefaults('foo')
@@ -61,11 +63,34 @@ class ConfigEnumTest(TestCase):
         config.show_defaults = 'never'  # noqa
         self.assertIs(ShowDefaults.NEVER, config.show_defaults)
 
+    # endregion
+
     def test_invalid_allow_leading_dash(self):
         with self.assertRaises(ValueError):
             AllowLeadingDash('foo')
         with self.assertRaises(ValueError):
             AllowLeadingDash(1)
+
+    def test_name_mode_aliases(self):
+        cases = {
+            'underscore': OptionNameMode.UNDERSCORE,
+            'dash': OptionNameMode.DASH,
+            'both': OptionNameMode.BOTH,
+            'both_dash': OptionNameMode.BOTH_DASH,
+            'both_underscore': OptionNameMode.BOTH_UNDERSCORE,
+            'none': OptionNameMode.NONE,
+            None: OptionNameMode.NONE,
+            '-': OptionNameMode.DASH,
+            '_': OptionNameMode.UNDERSCORE,
+            '*': OptionNameMode.BOTH,
+            '-*': OptionNameMode.BOTH_DASH,
+            '*-': OptionNameMode.BOTH_DASH,
+            '*_': OptionNameMode.BOTH_UNDERSCORE,
+            '_*': OptionNameMode.BOTH_UNDERSCORE,
+        }
+        for alias, expected in cases.items():
+            with self.subTest(alias=alias):
+                self.assertEqual(expected, OptionNameMode(alias))
 
 
 class ConfigTest(TestCase):

--- a/tests/test_core/test_metadata.py
+++ b/tests/test_core/test_metadata.py
@@ -32,8 +32,8 @@ class MetadataTest(TestCase):
     def test_metadata_self(self):
         self.assertIsInstance(ProgramMetadata.url, Metadata)
         self.assertIsInstance(ProgramMetadata.prog, DynamicMetadata)
-        self.assertEqual('Metadata(default=None)', repr(ProgramMetadata.url))
-        self.assertEqual('DynamicMetadata(func=ProgramMetadata.prog)', repr(ProgramMetadata.prog))
+        self.assertEqual('Metadata(default=None, inheritable=True)', repr(ProgramMetadata.url))
+        self.assertEqual('DynamicMetadata(func=ProgramMetadata.prog, inheritable=True)', repr(ProgramMetadata.prog))
 
     def test_bad_arg(self):
         with self.assertRaisesRegex(TypeError, 'Invalid arguments for ProgramMetadata: bar, foo'):

--- a/tests/test_inputs/test_choice_inputs.py
+++ b/tests/test_inputs/test_choice_inputs.py
@@ -33,7 +33,7 @@ class ChoiceInputTest(ParserTest):
 
         self.assertIsInstance(Foo.bar.type, Choices)
         self.assertIsInstance(Foo.bar.type.type, EnumChoices)
-        self.assertIs(Foo.bar.type.type.enum, EnumExample)
+        self.assertIs(Foo.bar.type.type.type, EnumExample)
 
     def test_enum_repr(self):
         expected = '<EnumChoices[type=EnumExample, case_sensitive=False, choices=(FOO,Bar,baz)]>'

--- a/tests/test_inputs/test_numeric_inputs.py
+++ b/tests/test_inputs/test_numeric_inputs.py
@@ -4,7 +4,7 @@ from unittest import main, TestCase
 
 from cli_command_parser import Command, Option
 from cli_command_parser.exceptions import ParameterDefinitionError
-from cli_command_parser.inputs import Range, NumRange
+from cli_command_parser.inputs import Range, NumRange, InputValidationError
 from cli_command_parser.testing import ParserTest
 
 
@@ -155,6 +155,16 @@ class ParseInputTest(ParserTest):
         ]
         self.assert_parse_results_cases(Foo, success_cases)
         self.assert_argv_parse_fails_cases(Foo, [['-ba'], ['-b', '-1'], ['-b', '11']])
+
+    def test_fix_default(self):
+        class Foo(Command):
+            bar = Option(type=Range(range(10), fix_default=True), default='-10')
+            baz = Option(type=Range(range(10), fix_default=False), default='-10')
+
+        with self.assertRaisesRegex(InputValidationError, 'expected a value in the range'):
+            _ = Foo().bar
+
+        self.assertEqual('-10', Foo().baz)
 
 
 if __name__ == '__main__':

--- a/tests/test_parsing/test_parse_options.py
+++ b/tests/test_parsing/test_parse_options.py
@@ -262,6 +262,19 @@ class OptionTest(ParserTest):
         fail_cases = [['bar', '-fby'], ['bar', '-fbx'], ['bar', '-fbar']]
         self.assert_parse_fails_cases(Foo, fail_cases, AmbiguousCombo)
 
+    def test_action_append_default_nargs(self):
+        class Foo(Command):
+            bar = Option('-b', action='append')
+
+        success_cases = [
+            ([], {'bar': []}),
+            (['-b', 'a'], {'bar': ['a']}),
+            # (['-b', 'a', '-b', 'b'], {'bar': ['a', 'b']}),  # TODO
+        ]
+        self.assert_parse_results_cases(Foo, success_cases)
+        fail_cases = [['-b'], ['-b', 'a', 'b']]
+        self.assert_argv_parse_fails_cases(Foo, fail_cases)
+
 
 if __name__ == '__main__':
     # import logging

--- a/tests/test_parsing/test_parse_options.py
+++ b/tests/test_parsing/test_parse_options.py
@@ -269,10 +269,11 @@ class OptionTest(ParserTest):
         success_cases = [
             ([], {'bar': []}),
             (['-b', 'a'], {'bar': ['a']}),
-            # (['-b', 'a', '-b', 'b'], {'bar': ['a', 'b']}),  # TODO
+            (['-b', 'a', '-b', 'b'], {'bar': ['a', 'b']}),
+            (['-b', 'a', 'b'], {'bar': ['a', 'b']}),
         ]
         self.assert_parse_results_cases(Foo, success_cases)
-        fail_cases = [['-b'], ['-b', 'a', 'b']]
+        fail_cases = [['-b']]
         self.assert_argv_parse_fails_cases(Foo, fail_cases)
 
 


### PR DESCRIPTION
- Added check during `Option` init to set a more appropriate `nargs` default when `action='append'`
- Added a `fix_default` param for custom input validation helpers to be able to disable automatic casting of default values used with them for cases where that behavior may not be desirable and the value would not have been handled correctly