### PR TITLE
Parameter Action Implementation Overhaul

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 init:
-	pip install -r requirements-dev.txt
+	pip install -r requirements-dev.txt --require-virtualenv
 	pre-commit install --install-hooks
 
 .PHONY: docs
@@ -7,7 +7,7 @@ docs:
 	bin/build_docs.py -uco
 
 publish:
-	pip install twine build -U
+	pip install twine build -U --require-virtualenv
 	python -m build
 	twine upload dist/*
 	rm -rf dist lib/cli_command_parser.egg-info

--- a/docs/_src/inputs.rst
+++ b/docs/_src/inputs.rst
@@ -12,7 +12,7 @@ Path
 ----
 
 To automatically handle common normalization steps / checks that are done for paths, the :class:`.Path` class is
-available.
+available.  When this input type is used, the parsed value will be provided as a :class:`python:pathlib.Path` object.
 
 .. _path_init_params:
 
@@ -25,7 +25,7 @@ available.
   False.
 :type: To restrict the acceptable types of files/directories that are accepted, specify the :class:`.StatMode` that
   matches the desired type.  By default, any type is accepted.  To accept specifically only regular files or
-  directories, for example, use ``type=StatMode.DIR | StatMode.FILE``.
+  directories, for example, use ``type=StatMode.DIR | StatMode.FILE`` or ``'dir|file'``.
 :readable: If True, the path must be readable.
 :writable: If True, the path must be writable.
 :allow_dash: Allow a dash (``-``) to be provided to indicate stdin/stdout (default: False).

--- a/lib/cli_command_parser/__init__.py
+++ b/lib/cli_command_parser/__init__.py
@@ -23,6 +23,7 @@ from .exceptions import (
     BadArgument,
     InvalidChoice,
     MissingArgument,
+    TooManyArguments,
     NoSuchOption,
     ParserExit,
     ParamConflict,

--- a/lib/cli_command_parser/command_parameters.py
+++ b/lib/cli_command_parser/command_parameters.py
@@ -407,7 +407,7 @@ class CommandParameters:
         # value will never be empty if key is a valid option because by this point, option is not a short option
         combo_option_map = self.combo_option_map
         param = combo_option_map[key]
-        if param.would_accept(value, short_combo=True):
+        if param.action.would_accept(value, combo=True):
             return [(key, param, value)]
         else:
             # Multi-char short options can never be combined with each other, but single-char ones can

--- a/lib/cli_command_parser/command_parameters.py
+++ b/lib/cli_command_parser/command_parameters.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from functools import cached_property
-from typing import TYPE_CHECKING, Optional, Iterator, List, Dict, Set, Tuple
+from typing import TYPE_CHECKING, Optional, Collection, Iterator, List, Dict, Set, Tuple
 
 from .actions import help_action
 from .config import CommandConfig, AmbiguousComboMode
@@ -467,6 +467,16 @@ class CommandParameters:
         for param in self.options:
             if param.env_var and ctx.num_provided(param) == 0:
                 yield param
+
+    def iter_params(self, exclude: Collection[Parameter] = ()) -> Iterator[Parameter]:
+        if exclude:
+            yield from (p for p in self.all_positionals if p not in exclude)
+            yield from (p for p in self.options if p not in exclude)
+        else:
+            yield from self.all_positionals
+            yield from self.options
+        if (pass_thru := self.pass_thru) and pass_thru not in exclude:
+            yield pass_thru
 
     def required_check_params(self) -> Iterator[Parameter]:
         ignore = SubCommand

--- a/lib/cli_command_parser/command_parameters.py
+++ b/lib/cli_command_parser/command_parameters.py
@@ -416,11 +416,11 @@ class CommandParameters:
     def find_option_that_accepts_values(self, option: str) -> Optional[BaseOption]:
         if option.startswith('--'):
             param = self.long_option_to_param_value_pair(option)[1]
-            if param.accepts_values:
+            if param.action.accepts_values:
                 return param
         elif option.startswith('-'):
             for _, param, _ in self.short_option_to_param_value_pairs(option):
-                if param.accepts_values:
+                if param.action.accepts_values:
                     return param
         else:
             raise ValueError(f'Invalid {option=}')

--- a/lib/cli_command_parser/context.py
+++ b/lib/cli_command_parser/context.py
@@ -203,6 +203,13 @@ class Context(AbstractContextManager):  # Extending AbstractContextManager to ma
         self._provided[param] = 0
         return self._parsed.pop(param)
 
+    def roll_back_parsed_values(self, param: Parameter, count: int):
+        """Not intended to be called by users.  Used during parsing as part of backtracking."""
+        values = self._parsed[param]
+        self._parsed[param] = values[:-count]
+        self._provided[param] -= count
+        return values[-count:]
+
     def record_action(self, param: ParamOrGroup, val_count: int = 1):
         """
         Not intended to be called by users.  Used by Parameters during parsing to indicate that they were provided.

--- a/lib/cli_command_parser/core.py
+++ b/lib/cli_command_parser/core.py
@@ -109,8 +109,8 @@ class CommandMeta(ABCMeta, type):
         If the given class does not directly extend ABC, and it extends a Command subclass with a :class:`.SubCommand`
         parameter, then this method will register the class as a subcommand choice for that parameter.
 
-        If no explicit ``choice`` or ``choices`` values are provided, then the name of the class (converted to camel
-        case) will be used as the subcommand choice.
+        If no explicit ``choice`` or ``choices`` values are provided, then the name of the class (converted from camel
+        case to snake case) will be used as the subcommand choice.
 
         :param cls: A Command (sub)class.
         :param choice: SubCommand value to map to this command.  If specified, this single choice value will override

--- a/lib/cli_command_parser/exceptions.py
+++ b/lib/cli_command_parser/exceptions.py
@@ -33,6 +33,7 @@ __all__ = [
     'BadArgument',
     'InvalidChoice',
     'MissingArgument',
+    'TooManyArguments',
     'NoSuchOption',
     'NoActiveContext',
 ]
@@ -223,6 +224,14 @@ class MissingArgument(BadArgument):
     """Error raised when a value for a Parameter was not provided"""
 
     message = 'missing required argument value'
+
+
+class TooManyArguments(BadArgument):
+    """Error raised when too many values were provided for a Parameter"""
+
+    def __str__(self) -> str:
+        nargs = self.param.nargs
+        return f'argument {self.usage_str}: cannot accept any additional args with {nargs=} - {self.message}'
 
 
 class NoSuchOption(UsageError):

--- a/lib/cli_command_parser/exceptions.py
+++ b/lib/cli_command_parser/exceptions.py
@@ -229,9 +229,9 @@ class MissingArgument(BadArgument):
 class TooManyArguments(BadArgument):
     """Error raised when too many values were provided for a Parameter"""
 
-    def __str__(self) -> str:
-        nargs = self.param.nargs
-        return f'argument {self.usage_str}: cannot accept any additional args with {nargs=} - {self.message}'
+    def __init__(self, param: ParamOrGroup, message: str = None):
+        msg = f'expected {param.nargs} args - cannot accept any additional args'
+        super().__init__(param, f'{msg} - {message}' if message else msg)
 
 
 class NoSuchOption(UsageError):

--- a/lib/cli_command_parser/exceptions.py
+++ b/lib/cli_command_parser/exceptions.py
@@ -247,10 +247,6 @@ class NoActiveContext(CommandParserException, RuntimeError):
 # region Internal Exceptions
 
 
-class UnsupportedAction(CommandParserException):
-    """Indicates that an attempted action cannot be completed.  Only used internally."""
-
-
 class Backtrack(CommandParserException):
     """Raised when backtracking took place.  Only used internally."""
 

--- a/lib/cli_command_parser/formatting/commands.py
+++ b/lib/cli_command_parser/formatting/commands.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING, Union, Type, Callable, Iterator, Iterable, Opt
 from ..context import ctx, NoActiveContext
 from ..core import get_params, get_metadata
 from ..parameters.groups import ParamGroup
-from ..utils import camel_to_snake_case
+from ..utils import camel_to_snake_case, _NotSet
 from .restructured_text import RstTable, spaced_rst_header
 from .utils import combine_and_wrap
 
@@ -232,7 +232,7 @@ def get_usage_sub_cmds(command: CommandCls):
     except NoActiveContext:
         parsed = []
 
-    if parsed:  # May have been called directly on the subcommand without parsing
+    if parsed and parsed is not _NotSet:  # May have been called directly on the subcommand without parsing
         yield from parsed
     elif chosen := next((name for name, choice in sub_cmd_param.choices.items() if choice.target is command), None):
         yield chosen

--- a/lib/cli_command_parser/formatting/params.py
+++ b/lib/cli_command_parser/formatting/params.py
@@ -68,7 +68,7 @@ class ParamHelpFormatter:
 
     def format_metavar(self) -> str:
         param = self.param
-        if param.metavar:
+        if param.metavar and param.action.accepts_values:
             return param.metavar
         if (t := param.type) is not None:
             try:

--- a/lib/cli_command_parser/nargs.py
+++ b/lib/cli_command_parser/nargs.py
@@ -160,17 +160,14 @@ class Nargs:
         else:
             return count >= self.min
 
-    def max_reached(self, parsed_values: Any) -> bool:
+    def max_reached(self, parsed_values: Collection[Any]) -> bool:
         """
         :param parsed_values: The value(s) parsed so far for a Parameter.
         :return: True if ``parsed_values`` has a length and that length meets or exceeds the maximum count allowed,
           False otherwise.
         """
         if self._has_upper_bound:
-            try:
-                return len(parsed_values) >= self.max
-            except TypeError:
-                pass
+            return len(parsed_values) >= self.max
         return False
 
     @property

--- a/lib/cli_command_parser/nargs.py
+++ b/lib/cli_command_parser/nargs.py
@@ -6,7 +6,7 @@ Helpers for handling ``nargs=...`` for Parameters.
 
 from __future__ import annotations
 
-from typing import Union, Optional, Sequence, Collection, Iterable, Tuple, Set, FrozenSet
+from typing import Any, Union, Optional, Sequence, Collection, Iterable, Tuple, Set, FrozenSet
 
 __all__ = ['Nargs', 'NargsValue', 'REMAINDER', 'nargs_min_and_max_sums']
 
@@ -159,6 +159,19 @@ class Nargs:
             return count in self.allowed
         else:
             return count >= self.min
+
+    def max_reached(self, parsed_values: Any) -> bool:
+        """
+        :param parsed_values: The value(s) parsed so far for a Parameter.
+        :return: True if ``parsed_values`` has a length and that length meets or exceeds the maximum count allowed,
+          False otherwise.
+        """
+        if self._has_upper_bound:
+            try:
+                return len(parsed_values) >= self.max
+            except TypeError:
+                pass
+        return False
 
     @property
     def has_upper_bound(self) -> bool:

--- a/lib/cli_command_parser/parameters/actions.py
+++ b/lib/cli_command_parser/parameters/actions.py
@@ -1,0 +1,442 @@
+"""
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Iterator, Iterable, Callable, Union, Sequence, TypeVar, NoReturn, List
+
+from ..context import ctx
+from ..exceptions import BadArgument, MissingArgument, InvalidChoice, TooManyArguments, ParamUsageError, ParamConflict
+from ..inputs import InputType
+from ..nargs import Nargs
+from ..utils import _NotSet, camel_to_snake_case
+
+if TYPE_CHECKING:
+    from ..typing import OptStr, Param, T_co
+
+__all__ = [
+    'ParamAction',
+    'Store',
+    'Append',
+    'StoreConst',
+    'AppendConst',
+    # 'StoreValueOrConst', 'AppendValueOrConst',
+    'Count',
+    'Concatenate',
+    'StoreAll',
+]
+
+_PANotSet = object()
+
+TD = TypeVar('TD')
+Found = Union[int, NoReturn]
+
+
+class ParamAction(ABC):
+    __slots__ = ('param',)
+    name: str
+    default: TD = _NotSet
+
+    def __init_subclass__(cls, default: TD = _PANotSet, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls.name = camel_to_snake_case(cls.__name__)
+        if default is not _PANotSet:
+            cls.default = default
+
+    def __init__(self, param: Param):
+        self.param = param
+
+    @property
+    @abstractmethod
+    def default_nargs(self) -> Nargs:
+        raise NotImplementedError
+
+    @abstractmethod
+    def add_value(self, value: str, *, opt: str = None, combo: bool = False) -> Found:
+        """
+        Execute this action for the given Parameter and value.
+
+        :param value: The value that was provided, if any.
+        :param opt: The option string that preceded the given value in the case of optional params, or that
+          represents a flag so a constant value can be stored, if any.
+        :param combo: Only True when a short option was provided, where the option string was combined with
+          either a real value or a sequence of 1-char combinable versions of short option strings.
+        :return: The number of new values discovered
+        """
+        raise NotImplementedError
+
+    def add_values(self, values: Sequence[str], *, opt: str = None, combo: bool = False) -> Found:
+        added = 0
+        for value in values:
+            added += self.add_value(value, opt=opt, combo=combo)
+        return added
+
+    def add_const(self, *, opt: str = None, combo: bool = False) -> Found:  # noqa
+        ctx.record_action(self.param)
+        raise MissingArgument(self.param)
+
+    def add_env_value(self, value: str, env_var: str):
+        return self.add_value(value)
+
+    def get_default(self, missing_default=_NotSet):
+        if (default := self.param.default) is not _NotSet:
+            return self.finalize_default(default)
+        return self.default
+
+    def finalize_default(self, value):
+        if (type_func := self.param.type) and isinstance(type_func, InputType):
+            return type_func.fix_default(value)
+        return value
+
+    def finalize_value(self, value):
+        return value
+
+    def can_reset(self) -> bool:
+        return False
+
+    def prep_and_validate(self, values: Sequence[str], combo: bool) -> Iterator[T_co]:
+        param = self.param
+        prepare_value, validate = param.prepare_value, param.validate
+        for value in values:
+            value = prepare_value(value, combo)
+            validate(value)
+            yield value
+
+    def would_accept(self, value: str, combo: bool = False) -> bool:
+        param = self.param
+        try:
+            normalized = param.prepare_value(value, combo, True)
+        except BadArgument:
+            return False
+        return param.is_valid_arg(normalized)
+
+
+class ValueMixin:
+    __slots__ = ()
+    param: Param
+    get_default: Callable
+
+    def set_value(self, value):
+        param = self.param
+        if (prev := ctx.get_parsed_value(param)) is not _NotSet:
+            raise ParamUsageError(param, f'can only be specified once - found multiple values: {prev!r}, {value!r}')
+
+        ctx.set_parsed_value(param, value)
+
+    def append_value(self, value):
+        param = self.param
+        parsed = ctx.get_parsed_value(param)
+        if parsed is _NotSet:
+            parsed = self.get_default()
+            ctx.set_parsed_value(param, parsed)
+        elif param.nargs.max_reached(parsed):
+            raise TooManyArguments(param, f'already found {len(parsed)} values')
+
+        parsed.append(value)
+
+    def extend_values(self, values: Iterable[T_co]):
+        param = self.param
+        parsed = ctx.get_parsed_value(param)
+        if parsed is _NotSet:
+            parsed = self.get_default()
+            ctx.set_parsed_value(param, parsed)
+
+        parsed.extend(values)
+
+
+class ConstMixin:
+    __slots__ = ()
+    param: Param
+    get_default: Callable
+    add_const: Callable
+    add_value: Callable
+
+    def __init_subclass__(cls, append: bool = False, **kwargs):
+        super().__init_subclass__(**kwargs)
+        cls._append = append
+
+    def get_const(self, value: OptStr, opt: str = None):
+        if value is None:
+            return self.param.get_const(opt)
+        raise BadArgument(self.param, f'does not accept values, but {value=} was provided')
+
+    def set_const(self, const):
+        param = self.param
+        parsed = ctx.get_parsed_value(param)
+        if parsed is not _NotSet and parsed != const:
+            raise ParamConflict([param])
+
+        ctx.set_parsed_value(param, const)
+
+    def append_const(self, const):
+        param = self.param
+        parsed = ctx.get_parsed_value(param)
+        if parsed is _NotSet:
+            parsed = self.get_default()
+            ctx.set_parsed_value(param, parsed)
+
+        parsed.append(const)
+
+    # def extend_consts(self, consts):
+    #     param = self.param
+    #     parsed = ctx.get_parsed_value(param)
+    #     if parsed is _NotSet:
+    #         parsed = self.get_default()
+    #         ctx.set_parsed_value(param, parsed)
+    #
+    #     parsed.extend(consts)
+
+    def add_env_value(self, value: str, env_var: str):
+        param = self.param
+        const, use_value = param.get_env_const(value, env_var)
+        if const is _NotSet:
+            return self.add_value(value)
+        elif use_value:
+            ctx.record_action(param)
+            if self._append:
+                self.append_const(const)
+            else:
+                self.set_const(const)
+            return 1
+        elif const:
+            return self.add_const()
+
+
+class Store(ValueMixin, ParamAction, default=None):
+    __slots__ = ()
+    default_nargs = Nargs(1)
+
+    def add_value(self, value: str, *, opt: str = None, combo: bool = False) -> Found:
+        param = self.param
+        ctx.record_action(param)
+        value = param.prepare_value(value, combo)
+        param.validate(value)
+        self.set_value(value)
+        return 1
+
+    def add_values(self, values: Sequence[str], *, opt: str = None, combo: bool = False) -> Found:
+        param = self.param
+        ctx.record_action(param)
+        if not values:
+            raise MissingArgument(param)
+        elif (val_count := len(values)) not in (nargs := param.nargs):
+            raise BadArgument(param, f'expected {nargs=} values but found {val_count}')
+
+        self.set_value([value for value in self.prep_and_validate(values, combo)])
+        return val_count
+
+    def would_accept(self, value: str, combo: bool = False) -> bool:
+        if ctx.get_parsed_value(self.param) is not _NotSet:
+            return False
+        return super().would_accept(value, combo)
+
+
+class Append(ValueMixin, ParamAction):
+    __slots__ = ()
+    default_nargs = Nargs('+')
+
+    def add_value(self, value: str, *, opt: str = None, combo: bool = False) -> Found:
+        param = self.param
+        ctx.record_action(param)
+        value = param.prepare_value(value, combo)
+        param.validate(value)
+        self.append_value(value)
+        return 1
+
+    def add_values(self, values: Sequence[str], *, opt: str = None, combo: bool = False) -> Found:
+        param = self.param
+        ctx.record_action(param)
+        if not values:
+            raise MissingArgument(param)
+        elif (val_count := len(values)) not in (nargs := param.nargs):
+            raise BadArgument(param, f'expected {nargs=} values but found {val_count}')
+
+        self.extend_values(value for value in self.prep_and_validate(values, combo))
+        return val_count
+
+    def get_default(self, missing_default=_NotSet):
+        if (default := self.param.default) is not _NotSet:
+            return self.finalize_default(default)
+        return []
+
+    def finalize_default(self, value):
+        param = self.param
+        if param.strict_default:
+            return value
+
+        if (type_func := param.type) and isinstance(type_func, InputType):
+            fix_default = type_func.fix_default
+        else:
+            fix_default = None
+
+        if not isinstance(value, str):
+            try:
+                next(iter(value), None)
+            except TypeError:
+                pass
+            else:
+                if fix_default:
+                    return [fix_default(v) for v in value]
+                elif isinstance(value, list):
+                    return value[:]
+                return list(value)
+
+        return [fix_default(value)] if fix_default else [value]
+
+    def finalize_value(self, value):
+        if (val_count := len(value)) not in (nargs := self.param.nargs):
+            raise BadArgument(self.param, f'expected {nargs=} values but found {val_count}')
+        return value
+
+    def can_reset(self) -> bool:
+        if self.param.type not in (None, str):
+            return False
+        return ctx.has_parsed_value(self.param)
+
+    def would_accept(self, value: str, combo: bool = False) -> bool:
+        param = self.param
+        parsed = ctx.get_parsed_value(param)
+        if parsed is not _NotSet and param.nargs.max_reached(parsed):
+            return False
+        return super().would_accept(value, combo)
+
+
+class StoreConst(ConstMixin, ParamAction, default=None):
+    __slots__ = ()
+    default_nargs = Nargs(0)
+
+    def add_const(self, *, opt: str = None, combo: bool = False) -> Found:
+        param = self.param
+        ctx.record_action(param)
+        self.set_const(param.get_const(opt))
+        return 1
+
+    def add_value(self, value: str, *, opt: str = None, combo: bool = False) -> Found:
+        ctx.record_action(self.param)
+        self.set_const(self.get_const(value, opt))
+        return 1
+
+    def would_accept(self, value: str, combo: bool = False) -> bool:
+        return False
+
+
+class AppendConst(ConstMixin, ParamAction, append=True):
+    __slots__ = ()
+    default_nargs = Nargs(0)
+
+    def add_const(self, *, opt: str = None, combo: bool = False) -> Found:
+        param = self.param
+        ctx.record_action(param)
+        # TODO: Fix nargs consistency for overall vs per-arg
+        self.append_const(param.get_const(opt))
+        return 1
+
+    def add_value(self, value: str, *, opt: str = None, combo: bool = False) -> Found:
+        ctx.record_action(self.param)
+        # TODO: Fix nargs consistency for overall vs per-arg
+        self.append_const(self.get_const(value, opt))
+        return 1
+
+    def get_default(self, missing_default=_NotSet):
+        return []
+
+    def would_accept(self, value: str, combo: bool = False) -> bool:
+        return False
+
+
+# class StoreValueOrConst(ConstMixin, Store):
+#     __slots__ = ()
+#     default_nargs = Nargs('?')
+#
+#     def add_const(self, *, opt: str = None, combo: bool = False) -> Found:
+#         param = self.param
+#         ctx.record_action(param)
+#         self.set_const(param.get_const(opt))
+#         return 1
+#
+#
+# class AppendValueOrConst(ConstMixin, Append, append=True):
+#     __slots__ = ()
+#     default_nargs = Nargs('?')
+#
+#     def add_const(self, *, opt: str = None, combo: bool = False) -> Found:
+#         param = self.param
+#         ctx.record_action(param)
+#         self.append_const(param.get_const(opt))
+#         return 1
+
+
+class Count(ParamAction):
+    __slots__ = ()
+    default_nargs = Nargs('?')
+
+    def _add(self, value: int):
+        param = self.param
+        parsed = ctx.get_parsed_value(param)
+        if parsed is _NotSet:
+            parsed = param.init
+
+        ctx.set_parsed_value(param, parsed + value)
+
+    def add_const(self, *, opt: str = None, combo: bool = False) -> Found:
+        param = self.param
+        ctx.record_action(param)
+        self._add(param.get_const(opt))
+        return 1
+
+    def add_value(self, value: str, *, opt: str = None, combo: bool = False) -> Found:
+        param = self.param
+        ctx.record_action(param)
+        value = param.prepare_value(value, combo)
+        param.validate(value)
+        self._add(value)
+        return 1
+
+
+class Concatenate(Append):
+    __slots__ = ()
+
+    def add_value(self, value: str, *, opt: str = None, combo: bool = False) -> Found:
+        param = self.param
+        values = value.split()
+        if not param.is_valid_arg(' '.join(values)):
+            ctx.record_action(param)
+            raise InvalidChoice(param, value, param.choices)
+
+        parsed = ctx.get_parsed_value(param)
+        if parsed is _NotSet:
+            ctx.set_parsed_value(param, values)
+        else:
+            parsed.extend(values)
+
+        n_values = len(values)
+        ctx.record_action(param, n_values)
+        return n_values
+
+    def finalize_default(self, value):
+        return value
+
+    def finalize_value(self, value):
+        choice = ' '.join(super().finalize_value(value))
+        if choice not in self.param.choices:
+            raise InvalidChoice(self.param, choice, self.param.choices)
+        return choice
+
+
+class StoreAll(Store):
+    __slots__ = ()
+    default_nargs = Nargs('REMAINDER')
+
+    def add_values(self, values: List[str], *, opt: str = None, combo: bool = False) -> Found:
+        param = self.param
+        ctx.record_action(param)
+
+        if (value := ctx.get_parsed_value(param)) is not _NotSet:
+            raise ParamUsageError(
+                param, f'can only be specified once - found {values=} but a stored {value=} already exists'
+            )
+
+        values = [param.prepare_value(v) for v in values]
+        ctx.set_parsed_value(param, values)
+        return len(values)

--- a/lib/cli_command_parser/parameters/actions.py
+++ b/lib/cli_command_parser/parameters/actions.py
@@ -224,9 +224,9 @@ class ConstMixin:
 
     def add_env_value(self, value: str, env_var: str):
         const, use_value = self.param.get_env_const(value, env_var)
-        if const is _NotSet:
+        if const is _NotSet:  # It does not support storing constants
             return self.add_value(value)
-        elif use_value:
+        elif use_value:  # Due to config or Param type (TriFlag needs this even when invoking the positive action)
             ctx.record_action(self.param)
             if self._append:
                 self.append_const(const)

--- a/lib/cli_command_parser/parameters/actions.py
+++ b/lib/cli_command_parser/parameters/actions.py
@@ -1,4 +1,6 @@
 """
+Parameter actions define how Parameters behave when processing values that were provided via CLI or environment
+variables.
 """
 
 from __future__ import annotations
@@ -83,11 +85,12 @@ class ParamAction(ABC):
         """
         raise NotImplementedError
 
-    def add_values(self, values: Sequence[str], *, opt: str = None, combo: bool = False) -> Found:
-        added = 0
-        for value in values:
-            added += self.add_value(value, opt=opt, combo=combo)
-        return added
+    # Note: Not used yet
+    # def add_values(self, values: Sequence[str], *, opt: str = None, combo: bool = False) -> Found:
+    #     added = 0
+    #     for value in values:
+    #         added += self.add_value(value, opt=opt, combo=combo)
+    #     return added
 
     def add_const(self, *, opt: str = None, combo: bool = False) -> Found:  # noqa
         ctx.record_action(self.param)
@@ -107,12 +110,13 @@ class ParamAction(ABC):
             return False
         return self.param.is_valid_arg(normalized)
 
-    def _prep_and_validate(self, values: Sequence[str], combo: bool) -> Iterator[T_co]:
-        prepare_value, validate = self.param.prepare_value, self.param.validate
-        for value in values:
-            value = prepare_value(value, combo)
-            validate(value)
-            yield value
+    # Note: Not used yet
+    # def _prep_and_validate(self, values: Sequence[str], combo: bool) -> Iterator[T_co]:
+    #     prepare_value, validate = self.param.prepare_value, self.param.validate
+    #     for value in values:
+    #         value = prepare_value(value, combo)
+    #         validate(value)
+    #         yield value
 
     # endregion
 
@@ -174,13 +178,14 @@ class ValueMixin:
 
         parsed.append(value)
 
-    def extend_values(self, values: Iterable[T_co]):
-        parsed = ctx.get_parsed_value(self.param)
-        if parsed is _NotSet:
-            parsed = self.get_default()
-            ctx.set_parsed_value(self.param, parsed)
-
-        parsed.extend(values)
+    # Note: Not used yet
+    # def extend_values(self, values: Iterable[T_co]):
+    #     parsed = ctx.get_parsed_value(self.param)
+    #     if parsed is _NotSet:
+    #         parsed = self.get_default()
+    #         ctx.set_parsed_value(self.param, parsed)
+    #
+    #     parsed.extend(values)
 
 
 class ConstMixin:
@@ -248,15 +253,16 @@ class Store(ValueMixin, ParamAction, default=None, accepts_values=True):
         self.set_value(value)
         return 1
 
-    def add_values(self, values: Sequence[str], *, opt: str = None, combo: bool = False) -> Found:
-        ctx.record_action(self.param)
-        if not values:
-            raise MissingArgument(self.param)
-        elif (val_count := len(values)) not in (nargs := self.param.nargs):
-            raise BadArgument(self.param, f'expected {nargs=} values but found {val_count}')
-
-        self.set_value([value for value in self._prep_and_validate(values, combo)])
-        return val_count
+    # Note: Not used yet
+    # def add_values(self, values: Sequence[str], *, opt: str = None, combo: bool = False) -> Found:
+    #     ctx.record_action(self.param)
+    #     if not values:
+    #         raise MissingArgument(self.param)
+    #     elif (val_count := len(values)) not in (nargs := self.param.nargs):
+    #         raise BadArgument(self.param, f'expected {nargs=} values but found {val_count}')
+    #
+    #     self.set_value([value for value in self._prep_and_validate(values, combo)])
+    #     return val_count
 
     # endregion
 
@@ -283,15 +289,16 @@ class Append(ValueMixin, ParamAction, accepts_values=True):
         self.append_value(value)
         return 1
 
-    def add_values(self, values: Sequence[str], *, opt: str = None, combo: bool = False) -> Found:
-        ctx.record_action(self.param)
-        if not values:
-            raise MissingArgument(self.param)
-        elif (val_count := len(values)) not in (nargs := self.param.nargs):
-            raise BadArgument(self.param, f'expected {nargs=} values but found {val_count}')
-
-        self.extend_values(value for value in self._prep_and_validate(values, combo))
-        return val_count
+    # Note: Not used yet
+    # def add_values(self, values: Sequence[str], *, opt: str = None, combo: bool = False) -> Found:
+    #     ctx.record_action(self.param)
+    #     if not values:
+    #         raise MissingArgument(self.param)
+    #     elif (val_count := len(values)) not in (nargs := self.param.nargs):
+    #         raise BadArgument(self.param, f'expected {nargs=} values but found {val_count}')
+    #
+    #     self.extend_values(value for value in self._prep_and_validate(values, combo))
+    #     return val_count
 
     # endregion
 

--- a/lib/cli_command_parser/parameters/actions.py
+++ b/lib/cli_command_parser/parameters/actions.py
@@ -224,9 +224,10 @@ class ConstMixin:
 
     def add_env_value(self, value: str, env_var: str):
         const, use_value = self.param.get_env_const(value, env_var)
-        if const is _NotSet:  # It does not support storing constants
-            return self.add_value(value)
-        elif use_value:  # Due to config or Param type (TriFlag needs this even when invoking the positive action)
+        # The const may only be _NotSet once StoreValueOrConst / AppendValueOrConst are put into use
+        # if const is _NotSet:  # It does not support storing constants
+        #     return self.add_value(value)
+        if use_value:  # Due to config or Param type (TriFlag needs this even when invoking the positive action)
             ctx.record_action(self.param)
             if self._append:
                 self.append_const(const)
@@ -321,7 +322,7 @@ class Append(ValueMixin, ParamAction, accepts_values=True):
         """
         if not self.param.nargs.variable or self.param.type not in (None, str):
             return []
-        elif values := ctx.get_parsed_value(self.param):
+        elif (values := ctx.get_parsed_value(self.param)) is not _NotSet:
             n_values = len(values)
             satisfied = self.param.nargs.satisfied
             return [i for i in range(1, n_values) if satisfied(n_values - i)]

--- a/lib/cli_command_parser/parameters/actions.py
+++ b/lib/cli_command_parser/parameters/actions.py
@@ -67,6 +67,8 @@ class ParamAction(ABC):
     def default_nargs(self) -> Nargs:
         raise NotImplementedError
 
+    # region Add Parsed Value / Constant Methods
+
     @abstractmethod
     def add_value(self, value: str, *, opt: str = None, combo: bool = False) -> Found:
         """
@@ -93,6 +95,8 @@ class ParamAction(ABC):
 
     def add_env_value(self, value: str, env_var: str):
         return self.add_value(value)
+
+    # endregion
 
     def get_default(self, missing_default=_NotSet):
         if (default := self.param.default) is not _NotSet:
@@ -232,6 +236,8 @@ class Store(ValueMixin, ParamAction, default=None, accepts_values=True):
     __slots__ = ()
     default_nargs = Nargs(1)
 
+    # region Add Parsed Value / Constant Methods
+
     def add_value(self, value: str, *, opt: str = None, combo: bool = False) -> Found:
         ctx.record_action(self.param)
         value = self.param.prepare_value(value, combo)
@@ -249,6 +255,8 @@ class Store(ValueMixin, ParamAction, default=None, accepts_values=True):
         self.set_value([value for value in self.prep_and_validate(values, combo)])
         return val_count
 
+    # endregion
+
     def would_accept(self, value: str, combo: bool = False) -> bool:
         if ctx.get_parsed_value(self.param) is not _NotSet:
             return False
@@ -258,6 +266,8 @@ class Store(ValueMixin, ParamAction, default=None, accepts_values=True):
 class Append(ValueMixin, ParamAction, accepts_values=True):
     __slots__ = ()
     default_nargs = Nargs('+')
+
+    # region Add Parsed Value / Constant Methods
 
     def add_value(self, value: str, *, opt: str = None, combo: bool = False) -> Found:
         ctx.record_action(self.param)
@@ -275,6 +285,8 @@ class Append(ValueMixin, ParamAction, accepts_values=True):
 
         self.extend_values(value for value in self.prep_and_validate(values, combo))
         return val_count
+
+    # endregion
 
     def get_default(self, missing_default=_NotSet):
         if (default := self.param.default) is not _NotSet:
@@ -330,6 +342,8 @@ class StoreConst(ConstMixin, ParamAction, default=None, accepts_consts=True):
     __slots__ = ()
     default_nargs = Nargs(0)
 
+    # region Add Parsed Value / Constant Methods
+
     def add_const(self, *, opt: str = None, combo: bool = False) -> Found:
         ctx.record_action(self.param)
         self.set_const(self.param.get_const(opt))
@@ -340,6 +354,8 @@ class StoreConst(ConstMixin, ParamAction, default=None, accepts_consts=True):
         self.set_const(self.get_const(value, opt))
         return 1
 
+    # endregion
+
     def would_accept(self, value: str, combo: bool = False) -> bool:
         return False
 
@@ -347,6 +363,8 @@ class StoreConst(ConstMixin, ParamAction, default=None, accepts_consts=True):
 class AppendConst(ConstMixin, ParamAction, append=True, accepts_consts=True):
     __slots__ = ()
     default_nargs = Nargs(0)
+
+    # region Add Parsed Value / Constant Methods
 
     def add_const(self, *, opt: str = None, combo: bool = False) -> Found:
         ctx.record_action(self.param)
@@ -359,6 +377,8 @@ class AppendConst(ConstMixin, ParamAction, append=True, accepts_consts=True):
         # TODO: Fix nargs consistency for overall vs per-arg
         self.append_const(self.get_const(value, opt))
         return 1
+
+    # endregion
 
     def get_default(self, missing_default=_NotSet):
         return []
@@ -398,6 +418,8 @@ class Count(ParamAction, accepts_values=True, accepts_consts=True):
 
         ctx.set_parsed_value(self.param, parsed + value)
 
+    # region Add Parsed Value / Constant Methods
+
     def add_const(self, *, opt: str = None, combo: bool = False) -> Found:
         ctx.record_action(self.param)
         self._add(self.param.get_const(opt))
@@ -410,9 +432,13 @@ class Count(ParamAction, accepts_values=True, accepts_consts=True):
         self._add(value)
         return 1
 
+    # endregion
+
 
 class Concatenate(Append):
     __slots__ = ()
+
+    # region Add Parsed Value / Constant Methods
 
     def add_value(self, value: str, *, opt: str = None, combo: bool = False) -> Found:
         param = self.param
@@ -431,6 +457,8 @@ class Concatenate(Append):
         ctx.record_action(param, n_values)
         return n_values
 
+    # endregion
+
     def finalize_default(self, value):
         return value
 
@@ -445,6 +473,8 @@ class StoreAll(Store):
     __slots__ = ()
     default_nargs = Nargs('REMAINDER')
 
+    # region Add Parsed Value / Constant Methods
+
     def add_values(self, values: List[str], *, opt: str = None, combo: bool = False) -> Found:
         param = self.param
         ctx.record_action(param)
@@ -457,3 +487,5 @@ class StoreAll(Store):
         values = [param.prepare_value(v) for v in values]
         ctx.set_parsed_value(param, values)
         return len(values)
+
+    # endregion

--- a/lib/cli_command_parser/parameters/actions.py
+++ b/lib/cli_command_parser/parameters/actions.py
@@ -118,16 +118,12 @@ class ParamAction(ABC):
 
     # region Backtracking
 
-    def get_maybe_poppable_values(self):
+    def get_maybe_poppable_counts(self) -> List[int]:
+        """
+        :return: The indexes on which the parsed values may be split such that the remaining number of values will
+          still be acceptable for the Parameter's nargs.
+        """
         return []
-
-    def get_maybe_poppable_values_and_counts(self):
-        values = self.get_maybe_poppable_values()
-        if not values:
-            return [], []
-        n_values = len(values)
-        satisfied = self.param.nargs.satisfied
-        return values, [i for i in range(1, n_values) if satisfied(n_values - i)]
 
     def can_reset(self) -> bool:
         return False
@@ -316,10 +312,19 @@ class Append(ValueMixin, ParamAction, accepts_values=True):
 
     # region Backtracking
 
-    def get_maybe_poppable_values(self):
+    def get_maybe_poppable_counts(self) -> List[int]:
+        """
+        :return: The indexes on which the parsed values may be split such that the remaining number of values will
+          still be acceptable for the Parameter's nargs.
+        """
         if not self.param.nargs.variable or self.param.type not in (None, str):
             return []
-        return ctx.get_parsed_value(self.param)
+        elif values := ctx.get_parsed_value(self.param):
+            n_values = len(values)
+            satisfied = self.param.nargs.satisfied
+            return [i for i in range(1, n_values) if satisfied(n_values - i)]
+        else:
+            return []
 
     def can_reset(self) -> bool:
         if self.param.type not in (None, str):

--- a/lib/cli_command_parser/parameters/base.py
+++ b/lib/cli_command_parser/parameters/base.py
@@ -10,28 +10,27 @@ from __future__ import annotations
 import re
 from abc import ABC, abstractmethod
 from contextvars import ContextVar
-from functools import partial, update_wrapper, cached_property
+from functools import cached_property
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Type, Generic, Optional, Callable, Collection, Union, Iterator, TypeVar, overload
-from typing import List, FrozenSet
+from typing import List, Dict, Tuple
 
 from ..annotations import get_descriptor_value_type
 from ..config import CommandConfig, OptionNameMode, AllowLeadingDash, DEFAULT_CONFIG
 from ..context import Context, ctx, get_current_context
-from ..exceptions import ParameterDefinitionError, BadArgument, MissingArgument, InvalidChoice, TooManyArguments
-from ..exceptions import ParamUsageError, UnsupportedAction
+from ..exceptions import ParameterDefinitionError, BadArgument, MissingArgument, InvalidChoice, UnsupportedAction
 from ..inputs import InputType, normalize_input_type
 from ..inputs.choices import _ChoicesBase
 from ..inputs.exceptions import InputValidationError, InvalidChoiceError
 from ..nargs import Nargs, REMAINDER
 from ..typing import T_co
-from ..utils import _NotSet, ValueSource
+from ..utils import _NotSet
 from .option_strings import OptionStrings
 
 if TYPE_CHECKING:
-    from types import MethodType
     from ..formatting.params import ParamHelpFormatter
-    from ..typing import OptStr, OptStrs, Bool, ValSrc, CommandCls, CommandObj, CommandAny, Param, LeadingDash
+    from ..typing import OptStr, OptStrs, Strings, Bool, CommandCls, CommandObj, CommandAny, Param, LeadingDash
+    from .actions import ParamAction
     from .groups import ParamGroup
 
 __all__ = ['Parameter', 'BasePositional', 'BaseOption']
@@ -39,47 +38,6 @@ __all__ = ['Parameter', 'BasePositional', 'BaseOption']
 _group_stack = ContextVar('cli_command_parser.parameters.base.group_stack')
 _is_numeric = re.compile(r'^-\d+$|^-\d*\.\d+?$').match
 TD = TypeVar('TD')
-
-
-class parameter_action:  # pylint: disable=C0103
-    """
-    Decorator that is used to register :paramref:`Parameter.__init__.action` handler methods to store values that are
-    provided for that type of :class:`Parameter`.  The name of the decorated method is used as the ``action`` name.
-
-    :param method: The method that should be used to handle storing values
-    """
-
-    def __init__(self, method: MethodType):
-        self.method = method
-        update_wrapper(self, method)
-
-    def __set_name__(self, parameter_cls: Type[Parameter], name: str):
-        """
-        Registers the decorated method in the Parameter subclass's _actions dict, then replaces the action decorator
-        with the original method.
-
-        Since `__set_name__` is called on descriptors before their containing class's parent's `__init_subclass__` is
-        called, name action/method name conflicts are handled by imitating a name mangled dunder attribute that will be
-        unique to each subclass.  The mangled name is replaced with the friendlier `_actions` in
-        :meth:`Parameter.__init_subclass__`.
-        """
-        attr = f'_{parameter_cls.__name__}__actions'
-        try:
-            actions = getattr(parameter_cls, attr)
-        except AttributeError:
-            actions = set()
-            setattr(parameter_cls, attr, actions)
-
-        actions.add(name)
-
-    def __call__(self, *args, **kwargs) -> int:
-        result = self.method(*args, **kwargs)
-        return 1 if result is None else result
-
-    def __get__(self, instance: Optional[Parameter], owner: Type[Parameter]):
-        if instance is None:
-            return self
-        return partial(self.__call__, instance)
 
 
 class ParamBase(ABC):
@@ -93,23 +51,27 @@ class ParamBase(ABC):
     :param hide: If ``True``, this parameter will not be included in usage / help messages.  Defaults to ``False``.
     """
 
+    # Class Attributes
+    missing_hint: str = None        #: Hint to provide if this param/group is missing
+    # Instance Attributes
     _attr_name: str = None          #: Always the name of the attr that points to this object
     _name: str = None               #: An explicitly provided name, or the name of the attr that points to this object
     group: ParamGroup = None        #: The group this object is a member of, if any
     command: CommandCls = None      #: The :class:`.Command` this object is a member of
-    required: Bool = False          #: Whether this param/group is required
-    help: str = None                #: The description for this param/group that will appear in ``--help`` text
-    hide: Bool = False              #: Whether this param/group should be hidden in ``--help`` text
-    missing_hint: str = None        #: Hint to provide if this param/group is missing
+    required: Bool                  #: Whether this param/group is required
+    help: str                       #: The description for this param/group that will appear in ``--help`` text
+    hide: Bool                      #: Whether this param/group should be hidden in ``--help`` text
 
     def __init__(self, name: str = None, required: Bool = False, help: str = None, hide: Bool = False):  # noqa
         self.__doc__ = help  # Prevent this class's docstring from showing up for params in generated documentation
         self.required = required
-        self.name = name
         self.help = help
         self.hide = hide
+        self.name = name
         if param_groups := _group_stack.get(None):  # If truthy, there's at least 1 active ParamGroup
             param_groups[-1].register(self)  # This sets self.group = group
+
+    # region Name
 
     @property
     def name(self) -> str:
@@ -130,6 +92,8 @@ class ParamBase(ABC):
         if self._name is None:
             self._name = name
         self._attr_name = name
+
+    # endregion
 
     def __hash__(self) -> int:
         return hash(self.__class__) ^ hash(self._attr_name) ^ hash(self._name) ^ hash(self.command)
@@ -204,19 +168,26 @@ class Parameter(ParamBase, Generic[T_co], ABC):
     # region Attributes & Initialization
 
     # Class attributes
-    _actions: FrozenSet[str] = frozenset()          #: The actions supported by this Parameter
-    _repr_attrs: Optional[Collection[str]] = None   #: Attributes to include in ``repr()`` output
-    accepts_values: bool = True                     #: Whether this Parameter can be provided with at least 1 value
+    _action_map: Dict[str, Type[ParamAction]] = {}
+    _repr_attrs: Optional[Strings] = None           #: Attributes to include in ``repr()`` output
+    accepts_values: Bool = True                     #: Whether this Parameter can be provided with at least 1 value
     # Instance attributes with class defaults
-    accepts_none: bool = False                      #: Whether this Parameter can be provided without a value
+    accepts_none: Bool = False                      #: Whether this Parameter can be provided without a value
     metavar: str = None
     nargs: Nargs = Nargs(1)                         # Set in subclasses
+    # nargs: Nargs  # TODO
     type: Optional[Callable[[str], T_co]] = None    # Only set here if not set by __init__ in Option/Positional
-    show_default: bool = None
+    show_default: Bool = None
     allow_leading_dash: AllowLeadingDash = AllowLeadingDash.NUMERIC  # Set in some subclasses
+    strict_default: Bool = False
 
     def __init_subclass__(
-        cls, accepts_values: bool = None, accepts_none: bool = None, repr_attrs: Collection[str] = None, **kwargs
+        cls,
+        accepts_values: bool = None,
+        accepts_none: bool = None,
+        repr_attrs: Strings = None,
+        actions: Collection[Type[ParamAction]] = None,
+        **kwargs,
     ):
         """
         :param accepts_values: Indicates whether a given subclass of Parameter accepts values, or not.  :class:`.Flag`
@@ -226,15 +197,9 @@ class Parameter(ParamBase, Generic[T_co], ABC):
         :param repr_attrs: Additional attributes to include in the repr.
         """
         super().__init_subclass__(**kwargs)
-        actions = set(cls._actions)  # Inherit actions from parent
-        actions.update(getattr(cls, '_BasicActionMixin__actions', ()))  # Inherit from mixin, if present
-        try:
-            actions.update(getattr(cls, f'_{cls.__name__}__actions'))
-        except AttributeError:
-            pass
-        else:
-            delattr(cls, f'_{cls.__name__}__actions')
-        cls._actions = frozenset(actions)
+        if actions:
+            cls._action_map = action_map = cls._action_map.copy()
+            action_map.update((action.name, action) for action in actions)
         if accepts_values is not None:
             cls.accepts_values = accepts_values
         if accepts_none is not None:
@@ -252,10 +217,11 @@ class Parameter(ParamBase, Generic[T_co], ABC):
         help: str = None,  # noqa
         hide: Bool = False,
         show_default: Bool = None,
+        strict_default: Bool = False,
     ):
-        if action not in self._actions:
+        if not (param_action := self._action_map.get(action)):
             raise ParameterDefinitionError(
-                f'Invalid {action=} for {self.__class__.__name__} - valid actions: {sorted(self._actions)}'
+                f'Invalid {action=} for {self.__class__.__name__} - valid actions: {sorted(self._action_map)}'
             )
         if required and default is not _NotSet:
             # TODO: For required mutually dependent groups, or a required group with all params having a default,
@@ -265,19 +231,13 @@ class Parameter(ParamBase, Generic[T_co], ABC):
                 ' required Parameters cannot have a default value'
             )
         super().__init__(name=name, required=required, help=help, hide=hide)
+        self.action = param_action(self)
         self._action_name = action
-        self.default = self._init_default() if default is _NotSet else default
+        self.default = default
         self.metavar = metavar
+        self.strict_default = strict_default
         if show_default is not None:
             self.show_default = show_default
-
-    def _init_default(self):
-        if not self.required and self.nargs.max == 1:
-            return None
-        return _NotSet
-
-    def _init_value_factory(self):
-        return _NotSet
 
     def __set_name__(self, command: CommandCls, name: str):
         super().__set_name__(command, name)
@@ -320,48 +280,12 @@ class Parameter(ParamBase, Generic[T_co], ABC):
     # region Parsing / Argument Handling
 
     def get_const(self, opt_str: OptStr = None):
-        return NotImplemented
+        return _NotSet
 
-    def normalize_env_var_value(self, value: str, env_var: str) -> T_co:
-        return value
+    def get_env_const(self, value: str, env_var: str) -> Tuple[T_co, bool]:
+        return _NotSet, False
 
-    def take_action(
-        self, value: OptStr, short_combo: Bool = False, opt_str: OptStr = None, src: ValSrc = ValueSource.CLI
-    ) -> int:
-        """
-        :param value: The parsed value or None
-        :param short_combo: Only True when a short option was provided, where the option string was combined with
-          either a real value or a sequence of 1-char combinable versions of short option strings.
-        :param opt_str: The option string that preceded the given value, or a single char that was combined with
-          other 1-char combinable versions of short option strings.
-        :param src: The source for the value - either CLI or env var
-        :return: The number of new values discovered
-        """
-        ctx.record_action(self)
-        return getattr(self, self._action_name)(self.prepare_and_validate(value, short_combo))
-
-    def would_accept(self, value: str, short_combo: Bool = False) -> bool:
-        action = self._action_name
-        if action in {'store', 'store_all'} and ctx.get_parsed_value(self) is not _NotSet:
-            return False
-        elif action == 'append' and self.nargs.max_reached(ctx.get_parsed_value(self)):
-            return False
-        try:
-            normalized = self.prepare_value(value, short_combo, True)
-        except BadArgument:
-            return False
-        return self.is_valid_arg(normalized)
-
-    def prepare_and_validate(self, value: OptStr, short_combo: Bool = False) -> T_co:
-        """Called by :meth:`.take_action` to prepare/validate the value before it is passed to the action method."""
-        if value is not None:
-            value = self.prepare_value(value, short_combo)
-        self.validate(value)
-        return value
-
-    def prepare_value(  # pylint: disable=W0613
-        self, value: str, short_combo: Bool = False, pre_action: Bool = False
-    ) -> T_co:
+    def prepare_value(self, value: str, short_combo: Bool = False, pre_action: Bool = False) -> T_co:
         type_func = self.type
         if type_func is None or (pre_action and isinstance(type_func, InputType) and type_func.is_valid_type(value)):
             return value
@@ -377,17 +301,13 @@ class Parameter(ParamBase, Generic[T_co], ABC):
             raise BadArgument(self, f'unable to cast {value=} to type={type_func!r}') from e
 
     def validate(self, value: Optional[T_co]):
-        if isinstance(value, str) and value.startswith('-'):
-            if self.allow_leading_dash == AllowLeadingDash.NUMERIC:
-                if len(value) > 1 and not _is_numeric(value):
-                    raise BadArgument(self, f'invalid {value=}')
-            elif self.allow_leading_dash == AllowLeadingDash.NEVER:
+        if not isinstance(value, str) or not value or not value[0] == '-':
+            return
+        elif self.allow_leading_dash == AllowLeadingDash.NUMERIC:
+            if len(value) > 1 and not _is_numeric(value):
                 raise BadArgument(self, f'invalid {value=}')
-        elif value is None:
-            if not self.accepts_none:
-                raise MissingArgument(self)
-        elif not self.accepts_values:
-            raise BadArgument(self, f'does not accept values, but {value=} was provided')
+        elif self.allow_leading_dash == AllowLeadingDash.NEVER:
+            raise BadArgument(self, f'invalid {value=}')
 
     def is_valid_arg(self, value: Any) -> bool:
         try:
@@ -431,45 +351,18 @@ class Parameter(ParamBase, Generic[T_co], ABC):
         return value
 
     def result_value(self, missing_default: TD = _NotSet) -> Union[T_co, TD, None]:
-        if (value := ctx.get_parsed_value(self)) is _NotSet:
+        value = ctx.get_parsed_value(self)
+        if value is _NotSet:
             if self.required:
                 if missing_default is _NotSet:
                     raise MissingArgument(self)
                 return missing_default
             else:
-                return self._fix_default(self.default)
-        elif self._action_name == 'store':
-            return value
+                return self.action.get_default(missing_default)
 
-        # Implied: action == 'append' or 'store_all'
-        if not value and (default := self.default) is not _NotSet:
-            if isinstance(default, Collection) and not isinstance(default, str):
-                value = self._fix_default_collection(default)
-            else:
-                value.append(self._fix_default(default))
-
-        nargs = self.nargs
-        if (val_count := len(value)) == 0 and 0 not in nargs:
-            if self.required:
-                if missing_default is _NotSet:
-                    raise MissingArgument(self)
-                return missing_default
-        elif val_count not in nargs:
-            raise BadArgument(self, f'expected {nargs=} values but found {val_count}')
-
-        return value
+        return self.action.finalize_value(value)
 
     result = result_value
-
-    def _fix_default(self, value) -> Optional[T_co]:
-        if (type_func := self.type) and isinstance(type_func, InputType):
-            return type_func.fix_default(value)
-        return value
-
-    def _fix_default_collection(self, values) -> Optional[T_co]:
-        if (type_func := self.type) and isinstance(type_func, InputType) and isinstance(values, (list, tuple, set)):
-            return values.__class__(map(type_func.fix_default, values))
-        return values
 
     # endregion
 
@@ -511,33 +404,6 @@ class BasicActionMixin:
         if allow_leading_dash is not None:
             self.allow_leading_dash = allow_leading_dash
 
-    def _init_default(self):
-        if not self.required and self.nargs.max == 1 and self._action_name != 'append':
-            return None
-        return _NotSet
-
-    def _init_value_factory(self):
-        if self._action_name == 'append':
-            return []
-        return super()._init_value_factory()  # noqa
-
-    # endregion
-
-    # region Actions
-
-    @parameter_action
-    def store(self: Parameter, value: T_co):
-        if (prev := ctx.get_parsed_value(self)) is not _NotSet:
-            raise ParamUsageError(self, f'can only be specified once - found multiple values: {prev!r}, {value!r}')
-        ctx.set_parsed_value(self, value)
-
-    @parameter_action
-    def append(self: Parameter, value: T_co):
-        parsed = ctx.get_parsed_value(self)
-        if self.nargs.max_reached(parsed):
-            raise TooManyArguments(self, f'already found {len(parsed)} values')
-        parsed.append(value)
-
     # endregion
 
     # region Parsing - Backtracking Methods
@@ -554,17 +420,6 @@ class BasicActionMixin:
 
         n_values = len(values)
         return [i for i in range(1, n_values) if self.nargs.satisfied(n_values - i)]
-
-    def _reset(self: Union[Parameter, BasicActionMixin]) -> List[str]:
-        if self._action_name != 'append' or self.type not in (None, str):
-            raise UnsupportedAction
-
-        if not (values := ctx.get_parsed_value(self)):
-            return values
-
-        ctx.set_parsed_value(self, self._init_value_factory())
-        ctx._provided[self] = 0
-        return values
 
     def pop_last(self: Union[Parameter, BasicActionMixin], count: int = 1) -> List[str]:
         values = self._pre_pop_values()
@@ -636,12 +491,23 @@ class BaseOption(Parameter[T_co], ABC):
       will not be checked.  If multiple env variable names/keys were provided, then they will be checked in the order
       that they were provided.  When enabled, values from env variables take precedence over the default value.  When
       enabled and the Parameter is required, then either a CLI value or an env var value must be provided.
+    :param strict_env: When ``True`` (the default), if an :paramref:`.BaseOption.env_var` is used as the source of a
+      value for this Parameter and that value is invalid, then parsing will fail.  When ``False``, invalid values from
+      environment variables will be ignored (and a warning message will be logged).
+    :param use_env_value: For optional Parameters that support storing a constant (such as Flag), this option controls
+      behavior when an :paramref:`.BaseOption.env_var` is used as the source of a value for this Parameter.
+      If ``True``, the parsed value will be stored as this Parameter's value (it must be a valid value).  If ``False``
+      (the default), then the parsed value will be used to determine whether the store/append const action should be
+      taken as if it was specified as a CLI flag (e.g., ``--foo`` with no value).
     :param kwargs: Additional keyword arguments to pass to :class:`Parameter`.
     """
 
     _opt_str_cls: Type[OptionStrings] = OptionStrings
     option_strs: OptionStrings
     env_var: OptStrs = None
+    strict_env: Bool
+    use_env_value: Bool
+    const = _NotSet
 
     def __init__(
         self,
@@ -649,12 +515,17 @@ class BaseOption(Parameter[T_co], ABC):
         action: str,
         name_mode: Union[OptionNameMode, str, None] = _NotSet,
         env_var: OptStrs = None,
+        strict_env: bool = True,
+        use_env_value: Bool = None,
         **kwargs,
     ):
         super().__init__(action, **kwargs)
         self.option_strs = self._opt_str_cls(option_strs, name_mode)
+        self.strict_env = strict_env
         if env_var:
             self.env_var = env_var
+        if use_env_value is not None:
+            self.use_env_value = use_env_value
 
     def __set_name__(self, command: CommandCls, name: str):
         super().__set_name__(command, name)
@@ -668,3 +539,6 @@ class BaseOption(Parameter[T_co], ABC):
                 yield env_var
             else:
                 yield from env_var
+
+    def get_const(self, opt_str: OptStr = None):
+        return self.const

--- a/lib/cli_command_parser/parameters/base.py
+++ b/lib/cli_command_parser/parameters/base.py
@@ -13,7 +13,7 @@ from contextvars import ContextVar
 from functools import partial, update_wrapper, cached_property
 from itertools import chain
 from typing import TYPE_CHECKING, Any, Type, Generic, Optional, Callable, Collection, Union, Iterator, overload
-from typing import Iterable, List, Tuple, FrozenSet
+from typing import List, Tuple, FrozenSet
 
 from ..annotations import get_descriptor_value_type
 from ..config import CommandConfig, OptionNameMode, AllowLeadingDash, DEFAULT_CONFIG
@@ -131,7 +131,7 @@ class ParamBase(ABC):
         self._attr_name = name
 
     def __hash__(self) -> int:
-        return hash(self.__class__) ^ hash(self._attr_name) ^ hash(self.name) ^ hash(self.command)
+        return hash(self.__class__) ^ hash(self._attr_name) ^ hash(self._name) ^ hash(self.command)
 
     def _ctx(self, command: CommandAny = None) -> Optional[Context]:
         if context := get_current_context(True):

--- a/lib/cli_command_parser/parameters/base.py
+++ b/lib/cli_command_parser/parameters/base.py
@@ -380,15 +380,6 @@ class BasicActionMixin:
 
     # endregion
 
-    # region Parsing - Backtracking Methods
-
-    def _pop_last(self: Union[Parameter, BasicActionMixin], values, count: int = 1) -> List[str]:
-        ctx.set_parsed_value(self, values[:-count])
-        ctx.record_action(self, -count)
-        return values[-count:]
-
-    # endregion
-
 
 class BasePositional(Parameter[T_co], ABC):
     """

--- a/lib/cli_command_parser/parameters/base.py
+++ b/lib/cli_command_parser/parameters/base.py
@@ -170,9 +170,7 @@ class Parameter(ParamBase, Generic[T_co], ABC):
     # Class attributes
     _action_map: Dict[str, Type[ParamAction]] = {}
     _repr_attrs: Optional[Strings] = None           #: Attributes to include in ``repr()`` output
-    accepts_values: Bool = True                     #: Whether this Parameter can be provided with at least 1 value
     # Instance attributes with class defaults
-    accepts_none: Bool = False                      #: Whether this Parameter can be provided without a value
     metavar: str = None
     nargs: Nargs = Nargs(1)                         # Set in subclasses
     # nargs: Nargs  # TODO
@@ -181,29 +179,15 @@ class Parameter(ParamBase, Generic[T_co], ABC):
     allow_leading_dash: AllowLeadingDash = AllowLeadingDash.NUMERIC  # Set in some subclasses
     strict_default: Bool = False
 
-    def __init_subclass__(
-        cls,
-        accepts_values: bool = None,
-        accepts_none: bool = None,
-        repr_attrs: Strings = None,
-        actions: Collection[Type[ParamAction]] = None,
-        **kwargs,
-    ):
+    def __init_subclass__(cls, repr_attrs: Strings = None, actions: Collection[Type[ParamAction]] = None, **kwargs):
         """
-        :param accepts_values: Indicates whether a given subclass of Parameter accepts values, or not.  :class:`.Flag`
-          is an example of a class that does not accept values.
-        :param accepts_none: Indicates whether a given subclass of Parameter accepts being specified without a value,
-          like :class:`.Flag` and :class:`.Counter`.
         :param repr_attrs: Additional attributes to include in the repr.
+        :param actions: Collection of ParamAction classes that this type of Parameter supports
         """
         super().__init_subclass__(**kwargs)
         if actions:
             cls._action_map = action_map = cls._action_map.copy()
             action_map.update((action.name, action) for action in actions)
-        if accepts_values is not None:
-            cls.accepts_values = accepts_values
-        if accepts_none is not None:
-            cls.accepts_none = accepts_none
         if repr_attrs is not None:
             cls._repr_attrs = repr_attrs
 

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -169,7 +169,7 @@ class _Flag(BaseOption[T_co], ABC):
     def would_accept(self, value: Optional[str], short_combo: bool = False) -> bool:  # noqa
         return value is None
 
-    def result_value(self) -> Any:
+    def result_value(self, missing_default=_NotSet) -> Any:
         return ctx.get_parsed_value(self)
 
     result = result_value
@@ -524,8 +524,7 @@ class Counter(BaseOption[int], accepts_values=True, accepts_none=True):
     def append(self, value: Optional[int]):
         if value is None:
             value = self.const
-        current = ctx.get_parsed_value(self)
-        ctx.set_parsed_value(self, current + value)
+        ctx.increment_parsed_value(self, value)
 
     def validate(self, value: Any):
         if value is None or isinstance(value, self.type):
@@ -537,7 +536,7 @@ class Counter(BaseOption[int], accepts_values=True, accepts_none=True):
         else:
             return
 
-    def result_value(self) -> int:
+    def result_value(self, missing_default=_NotSet) -> int:
         return ctx.get_parsed_value(self)
 
     result = result_value

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -126,6 +126,12 @@ class _Flag(BaseOption[T_co], ABC, actions=(StoreConst, AppendConst)):
         if type is not None:
             self.type = type
 
+    def _handle_bad_action(self, action: str) -> NoReturn:
+        if action in ('store', 'append'):
+            fixed = f'{action}_const'
+            raise ParameterDefinitionError(f'Invalid {action=} for {self.__class__.__name__} - did you mean {fixed!r}?')
+        super()._handle_bad_action(action)
+
     def get_env_const(self, value: str, env_var: str) -> Tuple[T_co, bool]:
         try:
             const = self.type(value)

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -128,7 +128,7 @@ class _Flag(BaseOption[T_co], ABC, actions=(StoreConst, AppendConst)):
         return const, self.use_env_value
 
 
-class Flag(_Flag[Union[TD, TC]], accepts_values=False, accepts_none=True):
+class Flag(_Flag[Union[TD, TC]]):
     """
     A (typically boolean) option that does not accept any values.
 
@@ -186,7 +186,7 @@ class Flag(_Flag[Union[TD, TC]], accepts_values=False, accepts_none=True):
         return parsed, use_env_value
 
 
-class TriFlag(_Flag[Union[TD, TC, TA]], accepts_values=False, accepts_none=True):
+class TriFlag(_Flag[Union[TD, TC, TA]]):
     """
     A trinary / ternary Flag.  While :class:`.Flag` only supports 1 constant when provided, with 1 default if not
     provided, this class accepts a pair of constants for the primary and alternate values to store, along with a
@@ -403,7 +403,7 @@ def after_main(*option_strs: str, order: Union[int, float] = 1, func: Callable =
 # endregion
 
 
-class Counter(BaseOption[int], accepts_values=True, accepts_none=True, actions=(Count,)):
+class Counter(BaseOption[int], actions=(Count,)):
     """
     A :class:`.Flag`-like option that counts the number of times it was specified.  Supports an optional integer value
     to explicitly increase the stored value by that amount.

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -131,7 +131,7 @@ class _Flag(BaseOption[T_co], ABC):
             self.type = type
 
     def _init_value_factory(self):
-        if self.action == 'store_const':
+        if self._action_name == 'store_const':
             return self.default
         else:
             return []
@@ -142,7 +142,7 @@ class _Flag(BaseOption[T_co], ABC):
         # log.debug(f'{self!r}.take_action({value!r})')
         ctx.record_action(self)
         if value is None:
-            action_method = getattr(self, self.action)
+            action_method = getattr(self, self._action_name)
             return action_method(opt_str) if self._use_opt_str else action_method()
         elif src != ValueSource.CLI:
             src, env_var = src
@@ -154,7 +154,7 @@ class _Flag(BaseOption[T_co], ABC):
                     return
                 raise
 
-        raise ParamUsageError(self, f'received {value=} but no values are accepted for action={self.action!r}')
+        raise ParamUsageError(self, f'received {value=} but no values are accepted for action={self._action_name!r}')
 
     def normalize_env_var_value(self, value: str, env_var: str) -> T_co:
         try:
@@ -230,11 +230,11 @@ class Flag(_Flag[Union[TD, TC]], accepts_values=False, accepts_none=True):
         parsed = self.normalize_env_var_value(value, env_var)
         if self.use_env_value:
             if parsed == self.const:
-                getattr(self, self.action)()
+                getattr(self, self._action_name)()
             elif parsed != self.default:
                 raise BadArgument(self, f'invalid value={parsed!r} from {env_var=}')
         elif parsed:
-            getattr(self, self.action)()
+            getattr(self, self._action_name)()
 
     def get_const(self, opt_str: OptStr = None) -> TC:
         return self.const

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -17,7 +17,7 @@ from ..nargs import Nargs, NargsValue
 from ..typing import T_co, TypeFunc
 from ..utils import _NotSet, str_to_bool
 from .actions import Store, StoreConst, Append, AppendConst, Count
-from .base import BasicActionMixin, BaseOption
+from .base import BaseOption, AllowLeadingDashProperty
 from .option_strings import TriFlagOptionStrings
 
 if TYPE_CHECKING:
@@ -31,7 +31,7 @@ TC = TypeVar('TC')
 TA = TypeVar('TA')
 
 
-class Option(BasicActionMixin, BaseOption[Union[T_co, TD]], actions=(Store, Append)):
+class Option(BaseOption[Union[T_co, TD]], actions=(Store, Append)):
     """
     A generic option that can be specified as ``--foo bar`` or by using other similar forms.
 
@@ -62,6 +62,7 @@ class Option(BasicActionMixin, BaseOption[Union[T_co, TD]], actions=(Store, Appe
     """
 
     default: TD
+    allow_leading_dash = AllowLeadingDashProperty()
 
     def __init__(
         self,
@@ -99,7 +100,7 @@ class Option(BasicActionMixin, BaseOption[Union[T_co, TD]], actions=(Store, Appe
 
         super().__init__(*option_strs, action=action, default=default, required=required, **kwargs)
         self.type = normalize_input_type(type, choices)
-        self._validate_nargs_and_allow_leading_dash(allow_leading_dash)
+        self.allow_leading_dash = allow_leading_dash
 
 
 class _Flag(BaseOption[T_co], ABC, actions=(StoreConst, AppendConst)):

--- a/lib/cli_command_parser/parameters/pass_thru.py
+++ b/lib/cli_command_parser/parameters/pass_thru.py
@@ -52,7 +52,7 @@ class PassThru(Parameter):
 
         ctx.record_action(self)
         normalized = list(map(self.prepare_value, values))
-        return getattr(self, self.action)(normalized)
+        return getattr(self, self._action_name)(normalized)
 
     def result_value(self, missing_default=_NotSet) -> Any:
         if (value := ctx.get_parsed_value(self)) is _NotSet:

--- a/lib/cli_command_parser/parameters/pass_thru.py
+++ b/lib/cli_command_parser/parameters/pass_thru.py
@@ -6,6 +6,8 @@ PassThru Parameters
 
 from __future__ import annotations
 
+from typing import Literal
+
 from ..nargs import Nargs
 from .actions import StoreAll
 from .base import Parameter
@@ -25,5 +27,5 @@ class PassThru(Parameter, actions=(StoreAll,)):
     nargs = Nargs('REMAINDER')
     missing_hint: str = " (missing pass thru args separated from others with '--')"  # leading space is intentional
 
-    def __init__(self, action: str = 'store_all', **kwargs):
+    def __init__(self, action: Literal['store_all'] = 'store_all', **kwargs):
         super().__init__(action=action, **kwargs)

--- a/lib/cli_command_parser/parameters/pass_thru.py
+++ b/lib/cli_command_parser/parameters/pass_thru.py
@@ -6,21 +6,14 @@ PassThru Parameters
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
-
-from ..context import ctx
-from ..exceptions import ParamUsageError, MissingArgument
 from ..nargs import Nargs
-from ..utils import _NotSet, ValueSource
-from .base import Parameter, parameter_action
-
-if TYPE_CHECKING:
-    from ..typing import Strings, ValSrc
+from .actions import StoreAll
+from .base import Parameter
 
 __all__ = ['PassThru']
 
 
-class PassThru(Parameter):
+class PassThru(Parameter, actions=(StoreAll,)):
     """
     Collects all remaining arguments, without processing them.  Must be preceded by ``--`` and a space.
 
@@ -34,33 +27,3 @@ class PassThru(Parameter):
 
     def __init__(self, action: str = 'store_all', **kwargs):
         super().__init__(action=action, **kwargs)
-
-    def _init_default(self):
-        return _NotSet if self.required else None
-
-    @parameter_action
-    def store_all(self, values: Strings):
-        ctx.set_parsed_value(self, values)
-
-    def take_action(  # pylint: disable=W0237
-        self, values: Strings, short_combo: bool = False, opt_str: str = None, src: ValSrc = ValueSource.CLI
-    ):
-        if (value := ctx.get_parsed_value(self)) is not _NotSet:
-            raise ParamUsageError(
-                self, f'can only be specified once - found {values=} but a stored {value=} already exists'
-            )
-
-        ctx.record_action(self)
-        normalized = list(map(self.prepare_value, values))
-        return getattr(self, self._action_name)(normalized)
-
-    def result_value(self, missing_default=_NotSet) -> Any:
-        if (value := ctx.get_parsed_value(self)) is _NotSet:
-            if self.required:
-                if missing_default is _NotSet:
-                    raise MissingArgument(self)
-                return missing_default
-            return self.default
-        return value
-
-    result = result_value

--- a/lib/cli_command_parser/parameters/pass_thru.py
+++ b/lib/cli_command_parser/parameters/pass_thru.py
@@ -30,7 +30,7 @@ class PassThru(Parameter):
     """
 
     nargs = Nargs('REMAINDER')
-    missing_hint: str = "missing pass thru args separated from others with '--'"
+    missing_hint: str = " (missing pass thru args separated from others with '--')"  # leading space is intentional
 
     def __init__(self, action: str = 'store_all', **kwargs):
         super().__init__(action=action, **kwargs)
@@ -54,10 +54,12 @@ class PassThru(Parameter):
         normalized = list(map(self.prepare_value, values))
         return getattr(self, self.action)(normalized)
 
-    def result_value(self) -> Any:
+    def result_value(self, missing_default=_NotSet) -> Any:
         if (value := ctx.get_parsed_value(self)) is _NotSet:
             if self.required:
-                raise MissingArgument(self)
+                if missing_default is _NotSet:
+                    raise MissingArgument(self)
+                return missing_default
             return self.default
         return value
 

--- a/lib/cli_command_parser/parameters/positionals.py
+++ b/lib/cli_command_parser/parameters/positionals.py
@@ -12,6 +12,7 @@ from ..exceptions import ParameterDefinitionError
 from ..inputs import normalize_input_type
 from ..nargs import Nargs, NargsValue
 from ..utils import _NotSet
+from .actions import Store, Append
 from .base import BasicActionMixin, BasePositional
 
 if TYPE_CHECKING:
@@ -20,7 +21,7 @@ if TYPE_CHECKING:
 __all__ = ['Positional']
 
 
-class Positional(BasicActionMixin, BasePositional, default_ok=True):
+class Positional(BasicActionMixin, BasePositional, default_ok=True, actions=(Store, Append)):
     """
     A parameter that must be provided positionally.
 
@@ -65,6 +66,7 @@ class Positional(BasicActionMixin, BasePositional, default_ok=True):
             if self.nargs == 0:
                 cls_name = self.__class__.__name__
                 raise ParameterDefinitionError(f'Invalid nargs={self.nargs} - {cls_name} must allow at least 1 value')
+
         if action is _NotSet:
             action = 'store' if self.nargs == 1 or self.nargs == Nargs('?') else 'append'
         elif action == 'store' and self.nargs.max != 1:

--- a/lib/cli_command_parser/parameters/positionals.py
+++ b/lib/cli_command_parser/parameters/positionals.py
@@ -13,7 +13,7 @@ from ..inputs import normalize_input_type
 from ..nargs import Nargs, NargsValue
 from ..utils import _NotSet
 from .actions import Store, Append
-from .base import BasicActionMixin, BasePositional
+from .base import BasePositional, AllowLeadingDashProperty
 
 if TYPE_CHECKING:
     from ..typing import InputTypeFunc, ChoicesType, LeadingDash
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 __all__ = ['Positional']
 
 
-class Positional(BasicActionMixin, BasePositional, default_ok=True, actions=(Store, Append)):
+class Positional(BasePositional, default_ok=True, actions=(Store, Append)):
     """
     A parameter that must be provided positionally.
 
@@ -49,6 +49,8 @@ class Positional(BasicActionMixin, BasePositional, default_ok=True, actions=(Sto
       ``AllowLeadingDash.NEVER``.
     :param kwargs: Additional keyword arguments to pass to :class:`.BasePositional`.
     """
+
+    allow_leading_dash = AllowLeadingDashProperty()
 
     def __init__(
         self,
@@ -79,4 +81,4 @@ class Positional(BasicActionMixin, BasePositional, default_ok=True, actions=(Sto
         kwargs.setdefault('required', required)
         super().__init__(action=action, default=default, **kwargs)
         self.type = normalize_input_type(type, choices)
-        self._validate_nargs_and_allow_leading_dash(allow_leading_dash)
+        self.allow_leading_dash = allow_leading_dash

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from collections import deque
 from os import environ
-from typing import TYPE_CHECKING, Optional, Union, Any, Iterable, Deque, List
+from typing import TYPE_CHECKING, Optional, Iterable, Deque, List
 
 from .core import get_parent
 from .context import ActionPhase, Context
@@ -279,6 +279,7 @@ class CommandParser:
             return
 
         can_pop = self._last.action.get_maybe_poppable_counts()
+        # It is extremely unlikely for this point to be reached without this resulting in triggering a backtrack
         if rollback_count := _to_pop((param, *self.positionals), can_pop, max(can_pop, default=0) + found, found):
             self.arg_deque.extendleft(reversed(self.ctx.pop_parsed_value(param)))
             self.arg_deque.extendleft(reversed(self.ctx.roll_back_parsed_values(self._last, rollback_count)))

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -17,7 +17,7 @@ from .exceptions import UsageError, ParamUsageError, NoSuchOption, MissingArgume
 from .exceptions import Backtrack, NextCommand
 from .nargs import REMAINDER, nargs_min_and_max_sums
 from .parse_tree import PosNode
-from .parameters.base import BasicActionMixin, Parameter, BasePositional, BaseOption
+from .parameters.base import Parameter, BasePositional, BaseOption
 
 if TYPE_CHECKING:
     from .command_parameters import CommandParameters
@@ -270,7 +270,7 @@ class CommandParser:
                 return found - rollback_count
         return found
 
-    def _maybe_backtrack_last(self, param: Union[BasePositional, BasicActionMixin], found: int):
+    def _maybe_backtrack_last(self, param: BasePositional, found: int):
         """
         Similar to :meth:`._maybe_backtrack`, but allows backtracking even after starting to process a Positional.
         """

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -274,9 +274,6 @@ class CommandParser:
         """
         Similar to :meth:`._maybe_backtrack`, but allows backtracking even after starting to process a Positional.
         """
-        if not self.config.allow_backtrack:
-            return
-
         values, can_pop = self._last.action.get_maybe_poppable_values_and_counts()
         if to_pop := _to_pop((param, *self.positionals), can_pop, max(can_pop, default=0) + found, found):
             reset = self.ctx.pop_parsed_value(param)
@@ -337,7 +334,12 @@ class CommandParser:
             return found
         elif exc:
             raise exc
-        elif self._last and isinstance(param, BasePositional) and param.action.can_reset():
+        elif (
+            self._last
+            and isinstance(param, BasePositional)
+            and param.action.can_reset()
+            and self.config.allow_backtrack
+        ):
             self._maybe_backtrack_last(param, found)
 
         s = '' if (n := nargs.min) == 1 else 's'

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -6,7 +6,7 @@ The class that handles parsing input.
 
 from __future__ import annotations
 
-# import logging
+import logging
 from collections import deque
 from os import environ
 from typing import TYPE_CHECKING, Optional, Union, Any, Iterable, Deque, List
@@ -14,11 +14,10 @@ from typing import TYPE_CHECKING, Optional, Union, Any, Iterable, Deque, List
 from .core import get_parent
 from .context import ActionPhase, Context
 from .exceptions import UsageError, ParamUsageError, NoSuchOption, MissingArgument, ParamsMissing
-from .exceptions import Backtrack, NextCommand, UnsupportedAction
+from .exceptions import Backtrack, NextCommand
 from .nargs import REMAINDER, nargs_min_and_max_sums
 from .parse_tree import PosNode
 from .parameters.base import BasicActionMixin, Parameter, BasePositional, BaseOption
-from .utils import ValueSource
 
 if TYPE_CHECKING:
     from .command_parameters import CommandParameters
@@ -26,7 +25,7 @@ if TYPE_CHECKING:
     from .typing import CommandType, OptStr
 
 __all__ = ['CommandParser', 'parse_args_and_get_next_cmd']
-# log = logging.getLogger(__name__)
+log = logging.getLogger(__name__)
 
 _PRE_INIT = ActionPhase.PRE_INIT
 
@@ -34,7 +33,7 @@ _PRE_INIT = ActionPhase.PRE_INIT
 class CommandParser:
     """Stateful parser used for a single pass of argument parsing"""
 
-    __slots__ = ('_last', 'arg_deque', 'config', 'deferred', 'params', 'positionals')
+    __slots__ = ('_last', 'arg_deque', 'ctx', 'config', 'deferred', 'params', 'positionals')
 
     arg_deque: Optional[Deque[str]]
     config: CommandConfig
@@ -45,6 +44,7 @@ class CommandParser:
 
     def __init__(self, ctx: Context, params: CommandParameters, config: CommandConfig):
         self._last = None
+        self.ctx = ctx
         self.params = params
         self.positionals = params.get_positionals_to_parse(ctx)
         self.config = config
@@ -95,7 +95,6 @@ class CommandParser:
     def _parse_env_vars(self, ctx: Context):
         # TODO: It would be helpful to store arg provenance for error messages, especially for a conflict between
         #  mutually exclusive params when they were provided via env
-        env = ValueSource.ENV
         for param in self.params.try_env_params(ctx):
             for env_var in param.env_vars():
                 try:
@@ -103,7 +102,12 @@ class CommandParser:
                 except KeyError:
                     pass
                 else:
-                    param.take_action(value, src=(env, env_var))
+                    try:
+                        param.action.add_env_value(value, env_var)
+                    except ParamUsageError as e:
+                        if param.strict_env:
+                            raise
+                        log.warning(e)
                     break
 
     def _handle_arg(self, arg: str):
@@ -141,7 +145,7 @@ class CommandParser:
                 pass  # If required, it's handled by the normal missing param handler
             else:
                 remainder_start = separator_pos + 1
-                pass_thru.take_action(remaining[remainder_start:])
+                pass_thru.action.add_values(remaining[remainder_start:])
                 return deque(remaining[:separator_pos])
         return deque(remaining)
 
@@ -154,10 +158,10 @@ class CommandParser:
         return False
 
     def handle_remainder(self, param: Parameter, value: str) -> int:
-        found = param.take_action(value)
+        found = param.action.add_value(value)
         arg_deque = self.arg_deque
         while arg_deque:
-            found += param.take_action(arg_deque.popleft())
+            found += param.action.add_value(arg_deque.popleft())
         return found
 
     # endregion
@@ -170,7 +174,7 @@ class CommandParser:
                 self.handle_remainder(param, arg)
             else:
                 try:
-                    found = param.take_action(arg)
+                    found = param.action.add_value(arg)
                 except UsageError:
                     positionals.insert(0, param)
                     raise
@@ -192,10 +196,11 @@ class CommandParser:
                 self._check_sub_command_options(arg)
                 self.deferred.append(arg)
         else:
+            # TODO: Split this for separate None/const vs value handling, and rely on action, not param
             if value is not None or (param.accepts_none and not param.accepts_values):
-                param.take_action(value, opt_str=opt)
+                param.action.add_value(value, opt=opt)
             elif not self.consume_values(param) and param.accepts_none:
-                param.take_action(None, opt_str=opt)
+                param.action.add_const(opt=opt)
             self._last = param
 
     # region Short Option Handling
@@ -211,8 +216,8 @@ class CommandParser:
             last = param_val_combos.pop()
             if param_val_combos:
                 # Note: This loop is only executed for single char combined flags, where the values will always be None
-                for opt, param, none_value in param_val_combos:
-                    param.take_action(none_value, short_combo=True, opt_str=opt)
+                for opt, param, _none_value in param_val_combos:
+                    param.action.add_const(opt=opt, combo=True)
             self._handle_short_value(*last)
 
     def _handle_short_not_found(self, arg: str):
@@ -230,9 +235,9 @@ class CommandParser:
     def _handle_short_value(self, opt: str, param: BaseOption, value: Any):
         # log.debug(f'Handling short {value=} for {param=}')
         if value is not None or (param.accepts_none and not param.accepts_values):
-            param.take_action(value, short_combo=True, opt_str=opt)
+            param.action.add_value(value, opt=opt, combo=True)
         elif not self.consume_values(param) and param.accepts_none:
-            param.take_action(None, short_combo=True, opt_str=opt)
+            param.action.add_const(opt=opt, combo=True)
         self._last = param
         # No need to raise MissingArgument if values were not consumed - consume_values handles checking nargs
 
@@ -274,16 +279,10 @@ class CommandParser:
 
         can_pop = self._last.can_pop_counts()
         if to_pop := _to_pop((param, *self.positionals), can_pop, max(can_pop, default=0) + found, found):
-            try:
-                reset = param._reset()
-            except UnsupportedAction:
-                return
-
+            reset = self.ctx.pop_parsed_value(param)
             self.arg_deque.extendleft(reversed(reset))
             self.arg_deque.extendleft(reversed(self._last.pop_last(to_pop)))
             raise Backtrack
-        else:
-            return
 
     # endregion
 
@@ -311,13 +310,13 @@ class CommandParser:
                 except (ParamUsageError, NextCommand) as e:
                     return self._finalize_consume(param, value, found, e)
 
-                if not param.would_accept(value):
+                if not param.action.would_accept(value):
                     # log.debug(f'{value=} will not be used with {param=} - it would not be accepted')
                     return self._finalize_consume(param, value, found, NoSuchOption(f'invalid argument: {value}'))
                 # log.debug(f'{value=} may be used with {param=} as a value')
 
             try:
-                found += param.take_action(value)
+                found += param.action.add_value(value)
             except UsageError as e:
                 # log.debug(f'{value=} was rejected by {param=}', exc_info=True)
                 return self._finalize_consume(param, value, found, e)
@@ -338,7 +337,7 @@ class CommandParser:
             return found
         elif exc:
             raise exc
-        elif self._last and isinstance(param, BasePositional) and hasattr(param, '_reset'):
+        elif self._last and isinstance(param, BasePositional) and param.action.can_reset():
             self._maybe_backtrack_last(param, found)
 
         s = '' if (n := nargs.min) == 1 else 's'

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from .config import CommandConfig
     from .typing import CommandType, OptStr
 
-__all__ = ['CommandParser']
+__all__ = ['CommandParser', 'parse_args_and_get_next_cmd']
 # log = logging.getLogger(__name__)
 
 _PRE_INIT = ActionPhase.PRE_INIT
@@ -56,7 +56,7 @@ class CommandParser:
         try:
             return cls(ctx, ctx.params, ctx.config).get_next_cmd(ctx)
         except UsageError:
-            if not ctx.categorized_action_flags[ActionPhase.PRE_INIT]:
+            if not ctx.categorized_action_flags[_PRE_INIT]:
                 raise
             return None
 
@@ -343,6 +343,9 @@ class CommandParser:
 
         s = '' if (n := nargs.min) == 1 else 's'
         raise MissingArgument(param, f'expected {n} value{s}, but only found {found}')
+
+
+parse_args_and_get_next_cmd = CommandParser.parse_args_and_get_next_cmd
 
 
 def _to_pop(positionals: Iterable[BasePositional], can_pop: List[int], available: int, req_mod: int = 0) -> int:

--- a/lib/cli_command_parser/typing.py
+++ b/lib/cli_command_parser/typing.py
@@ -18,7 +18,6 @@ if TYPE_CHECKING:
     from .core import CommandMeta
     from .inputs import InputType
     from .parameters import Parameter, ParamGroup
-    from .utils import ValueSource
 
 T = TypeVar('T')
 T_co = TypeVar('T_co', covariant=True)
@@ -31,7 +30,6 @@ RngType = Union[range, int, Sequence[int]]
 
 InputTypeFunc = Union[None, TypeFunc, 'InputType', range, Type['Enum'], Pattern]
 ChoicesType = Optional[Collection[Any]]
-ValSrc = Union['ValueSource', Tuple['ValueSource', str]]
 
 Bool = Union[bool, Any]
 Strs = Union[str, Sequence[str]]

--- a/lib/cli_command_parser/utils.py
+++ b/lib/cli_command_parser/utils.py
@@ -6,7 +6,7 @@ Utilities for working with terminals, strings, and Enums.
 
 from __future__ import annotations
 
-from enum import Flag, Enum, EnumMeta
+from enum import Flag, EnumMeta
 from shutil import get_terminal_size
 from time import monotonic
 from typing import Any, Callable, TypeVar, List
@@ -142,11 +142,6 @@ class Terminal:  # pylint: disable=R0903
             self._width = get_terminal_size()[0]
             self._last_time = monotonic()
         return self._width
-
-
-class ValueSource(Enum):
-    CLI = 'cli'
-    ENV = 'env'
 
 
 def str_to_bool(value: str) -> bool:

--- a/tests/test_commands/test_commands.py
+++ b/tests/test_commands/test_commands.py
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 
-from unittest import TestCase, main
+from unittest import main
 from unittest.mock import Mock
 
 from cli_command_parser import Command, Context
 from cli_command_parser.exceptions import ParamConflict
 from cli_command_parser.parameters import Action, ActionFlag
-from cli_command_parser.testing import sealed_mock
+from cli_command_parser.testing import ParserTest, sealed_mock
 
 
-class TestCommands(TestCase):
+class TestCommands(ParserTest):
     def test_true_on_action_handled(self):
         mock = sealed_mock(__name__='foo')
 
@@ -94,7 +94,7 @@ class TestCommands(TestCase):
             def main(self):
                 raise RuntimeError('test')
 
-        with self.assertRaisesRegex(RuntimeError, 'test'):
+        with self.assert_raises_contains_str(RuntimeError, 'test'):
             Foo.parse_and_run([])
 
         self.assertFalse(Foo._after_main_.called)
@@ -106,7 +106,7 @@ class TestCommands(TestCase):
             def main(self):
                 raise RuntimeError('test')
 
-        with self.assertRaisesRegex(RuntimeError, 'test'):
+        with self.assert_raises_contains_str(RuntimeError, 'test'):
             Foo.parse_and_run([])
 
         self.assertTrue(Foo._after_main_.called)
@@ -120,7 +120,7 @@ class TestCommands(TestCase):
             c = Action()
             c(action_mock)
 
-        with self.assertRaisesRegex(ParamConflict, 'combining an action with action flags is disabled'):
+        with self.assert_raises_contains_str(ParamConflict, 'combining an action with action flags is disabled'):
             Foo.parse_and_run(['b', '-a'])
 
         self.assertFalse(act_flag_mock.called)

--- a/tests/test_commands/test_param_registry.py
+++ b/tests/test_commands/test_param_registry.py
@@ -14,14 +14,14 @@ from cli_command_parser.parameters.base import Parameter
 from cli_command_parser.testing import RedirectStreams, ParserTest
 
 
-class TestParamRegistry(TestCase):
+class TestParamRegistry(ParserTest):
     def test_multiple_actions_rejected(self):
         class Foo(Command):
             a = Action()
             b = Action()
             a(Mock(__name__='baz'))
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'Only 1 Action xor SubCommand is allowed'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'Only 1 Action xor SubCommand is allowed'):
             Foo.parse([])
 
     def test_multiple_sub_cmds_rejected(self):
@@ -29,7 +29,7 @@ class TestParamRegistry(TestCase):
             a = SubCommand()
             b = SubCommand()
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'Only 1 Action xor SubCommand is allowed'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'Only 1 Action xor SubCommand is allowed'):
             Foo.parse([])
 
     def test_action_with_sub_cmd_rejected(self):
@@ -38,7 +38,7 @@ class TestParamRegistry(TestCase):
             bar = SubCommand()
             foo(Mock(__name__='baz'))
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'Only 1 Action xor SubCommand is allowed'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'Only 1 Action xor SubCommand is allowed'):
             Foo.parse([])
 
     def test_action_after_sub_cmd_rejected(self):
@@ -46,7 +46,7 @@ class TestParamRegistry(TestCase):
             a = SubCommand()
             b = Action()
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'Only 1 Action xor SubCommand is allowed'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'Only 1 Action xor SubCommand is allowed'):
             Foo.parse([])
 
     def test_no_help(self):
@@ -74,11 +74,11 @@ class TestParamRegistry(TestCase):
                     foo = Positional(nargs=a)
                     bar = Positional(nargs=b)
 
-                with self.assertRaisesRegex(CommandDefinitionError, 'it is a positional that is not required'):
+                with self.assert_raises_contains_str(CommandDefinitionError, 'it is a positional that is not required'):
                     CommandMeta.params(Foo)
 
 
-class CommandParamsTest(TestCase):
+class CommandParamsTest(ParserTest):
     def test_reprs(self):
         class Foo(Command):
             bar = Positional()
@@ -114,7 +114,7 @@ class CommandParamsTest(TestCase):
         class Foo(Command):
             bar = TestParam('test')
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'custom parameters must extend'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'custom parameters must extend'):
             Foo.parse([])
 
     def test_redefined_param_rejected(self):
@@ -154,8 +154,8 @@ class ParamNameConflictHandlingTest(ParserTest):
         class Baz(Foo):
             bar = Option()
 
-        self.assert_parse_fails(Baz, [], CommandDefinitionError, 'conflict for command=.* between')
-        self.assert_parse_fails(Foo, ['baz'], CommandDefinitionError, 'conflict for command=.* between')
+        self.assert_parse_fails(Baz, [], CommandDefinitionError, 'conflict for command=.* between', regex=True)
+        self.assert_parse_fails(Foo, ['baz'], CommandDefinitionError, 'conflict for command=.* between', regex=True)
 
     def test_sub_cmd_param_name_override_ok(self):
         class Foo(Command):

--- a/tests/test_commands/test_param_registry.py
+++ b/tests/test_commands/test_param_registry.py
@@ -7,6 +7,7 @@ from unittest.mock import Mock
 from cli_command_parser import Command
 from cli_command_parser.core import CommandMeta, get_params
 from cli_command_parser.exceptions import CommandDefinitionError, NoSuchOption
+from cli_command_parser.nargs import Nargs
 from cli_command_parser.parameters import Action, SubCommand, Positional, Counter, Flag, Option
 from cli_command_parser.parameters.actions import Store
 from cli_command_parser.parameters.base import Parameter
@@ -108,7 +109,7 @@ class CommandParamsTest(TestCase):
             pass
 
         class TestParam(Parameter, actions=(Test,)):
-            pass
+            nargs = Nargs(1)
 
         class Foo(Command):
             bar = TestParam('test')

--- a/tests/test_commands/test_param_registry.py
+++ b/tests/test_commands/test_param_registry.py
@@ -8,7 +8,8 @@ from cli_command_parser import Command
 from cli_command_parser.core import CommandMeta, get_params
 from cli_command_parser.exceptions import CommandDefinitionError, NoSuchOption
 from cli_command_parser.parameters import Action, SubCommand, Positional, Counter, Flag, Option
-from cli_command_parser.parameters.base import parameter_action, Parameter
+from cli_command_parser.parameters.actions import Store
+from cli_command_parser.parameters.base import Parameter
 from cli_command_parser.testing import RedirectStreams, ParserTest
 
 
@@ -103,8 +104,11 @@ class CommandParamsTest(TestCase):
             get_params(Foo).find_option_that_accepts_values('bar')
 
     def test_bad_custom_param_rejected(self):
-        class TestParam(Parameter):
-            test = parameter_action(Mock())
+        class Test(Store):
+            pass
+
+        class TestParam(Parameter, actions=(Test,)):
+            pass
 
         class Foo(Command):
             bar = TestParam('test')

--- a/tests/test_commands/test_sub_commands.py
+++ b/tests/test_commands/test_sub_commands.py
@@ -77,7 +77,7 @@ class SubCommandTest(ParserTest):
             sub_cmd = SubCommand()
 
         for args in ([], ['foo']):
-            with self.assertRaisesRegex(CommandDefinitionError, 'has no sub Commands'):
+            with self.assert_raises_contains_str(CommandDefinitionError, 'has no sub Commands'):
                 Foo.parse(args)
 
     def test_choice_none_not_registered(self):

--- a/tests/test_conversion/test_convert_argparse.py
+++ b/tests/test_conversion/test_convert_argparse.py
@@ -211,11 +211,11 @@ class Command9(Command1, choice='123 456'):\n    pass\n\n
     # region Actions
 
     def test_bad_positional_action(self):
-        with self.assertRaisesRegex(ConversionError, 'is not supported for Positional parameters'):
+        with self.assert_raises_contains_str(ConversionError, 'is not supported for Positional parameters'):
             prep_and_convert("'foo', action='store_true'")
 
     def test_bad_option_action(self):
-        with self.assertRaisesRegex(ConversionError, 'is not supported for Option parameters'):
+        with self.assert_raises_contains_str(ConversionError, 'is not supported for Option parameters'):
             prep_and_convert("'--foo', action='extend'")
 
     def test_explicit_option_action(self):
@@ -266,7 +266,7 @@ group.add_argument('--foo')"""
         self.assertEqual(expected, prep_and_convert("'--foo', help='The foo (default: %(default)s)'"))
 
     def test_bad_param_type(self):
-        with self.assertRaisesRegex(ConversionError, 'Unable to determine a suitable Parameter type'):
+        with self.assert_raises_contains_str(ConversionError, 'Unable to determine a suitable Parameter type'):
             prep_and_convert('')
 
     def test_param_order(self):

--- a/tests/test_core/test_config.py
+++ b/tests/test_core/test_config.py
@@ -7,6 +7,7 @@ from unittest import TestCase, main
 from cli_command_parser import Command, SubCommand, CommandConfig, ShowDefaults, AllowLeadingDash, OptionNameMode
 from cli_command_parser.core import get_config
 from cli_command_parser.config import ConfigItem, DEFAULT_CONFIG
+from cli_command_parser.testing import ParserTest
 
 
 class ConfigItemTest(TestCase):
@@ -93,12 +94,12 @@ class ConfigEnumTest(TestCase):
                 self.assertEqual(expected, OptionNameMode(alias))
 
 
-class ConfigTest(TestCase):
+class ConfigTest(ParserTest):
     def test_config_no_overrides_empty(self):
         self.assertDictEqual({}, CommandConfig().as_dict(False))
 
     def test_config_invalid_key(self):
-        with self.assertRaisesRegex(TypeError, 'unsupported options: bar, foo'):
+        with self.assert_raises_contains_str(TypeError, 'unsupported options: bar, foo'):
             CommandConfig(foo=1, bar=2)
 
     # region Inheritance

--- a/tests/test_core/test_context.py
+++ b/tests/test_core/test_context.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from unittest import TestCase, main
+from unittest import main
 
 from cli_command_parser import Command, CommandConfig
 from cli_command_parser.core import CommandMeta
@@ -8,9 +8,10 @@ from cli_command_parser.context import Context, ActionPhase, ctx, get_current_co
 from cli_command_parser.context import get_context, get_parsed, get_raw_arg
 from cli_command_parser.error_handling import extended_error_handler
 from cli_command_parser.parameters import Flag, SubCommand, Positional
+from cli_command_parser.testing import ParserTest
 
 
-class ContextTest(TestCase):
+class ContextTest(ParserTest):
     # region Config
 
     def test_no_command_results_in_config_default(self):
@@ -33,7 +34,7 @@ class ContextTest(TestCase):
         self.assertNotEqual(default, c.config.ignore_unknown)
 
     def test_double_config_rejected(self):
-        with self.assertRaisesRegex(TypeError, 'Cannot combine config='):
+        with self.assert_raises_contains_str(TypeError, 'Cannot combine config='):
             Context(config=CommandConfig(), add_help=False)
 
     def test_explicitly_provided_config_used(self):

--- a/tests/test_core/test_main.py
+++ b/tests/test_core/test_main.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python
 
 from abc import ABC
-from unittest import TestCase, main
+from unittest import main
 from unittest.mock import Mock
 
 from cli_command_parser import Command, main as cmd_main, SubCommand
 from cli_command_parser.core import CommandMeta
+from cli_command_parser.testing import ParserTest
 
 
-class MainTest(TestCase):
+class MainTest(ParserTest):
     def setUp(self):
         CommandMeta._commands.clear()
 
@@ -20,7 +21,7 @@ class MainTest(TestCase):
         self.assertTrue(Foo.main.called)
 
     def test_main_raises_error_on_0_cmds(self):
-        with self.assertRaisesRegex(RuntimeError, 'no commands were found'):
+        with self.assert_raises_contains_str(RuntimeError, 'no commands were found'):
             cmd_main([])
 
     def test_main_raises_error_on_2_cmds(self):
@@ -30,7 +31,7 @@ class MainTest(TestCase):
         class Bar(Command):
             pass
 
-        with self.assertRaisesRegex(RuntimeError, 'found 2 commands:'):
+        with self.assert_raises_contains_str(RuntimeError, 'found 2 commands:'):
             cmd_main([])
 
     def test_main_ignores_sub_cmd(self):

--- a/tests/test_core/test_metadata.py
+++ b/tests/test_core/test_metadata.py
@@ -9,6 +9,7 @@ from cli_command_parser import Command, Context, main as ccp_main
 from cli_command_parser.core import CommandMeta
 from cli_command_parser.metadata import ProgramMetadata, Metadata, DynamicMetadata, ProgFinder, dynamic_metadata
 from cli_command_parser.metadata import _path_and_globals, _description, _prog_finder, EntryPoint
+from cli_command_parser.testing import ParserTest
 
 MODULE = 'cli_command_parser.metadata'
 THIS_FILE = Path(__file__)
@@ -23,7 +24,7 @@ def ep_scripts(*name_val_tuples):
     return tuple(EntryPoint(name, val, cs) for name, val in name_val_tuples)  # noqa
 
 
-class MetadataTest(TestCase):
+class MetadataTest(ParserTest):
     def test_repr(self):
         meta_repr = repr(CommandMeta.meta(Foo))
         self.assertRegex(meta_repr, r'\s{8}path=.*?/commands.py')
@@ -36,7 +37,7 @@ class MetadataTest(TestCase):
         self.assertEqual('DynamicMetadata(func=ProgramMetadata.prog, inheritable=True)', repr(ProgramMetadata.prog))
 
     def test_bad_arg(self):
-        with self.assertRaisesRegex(TypeError, 'Invalid arguments for ProgramMetadata: bar, foo'):
+        with self.assert_raises_contains_str(TypeError, 'Invalid arguments for ProgramMetadata: bar, foo'):
             ProgramMetadata(foo=123, bar=456)
 
     def test_dynamic_metadata_no_args(self):

--- a/tests/test_core/test_misc.py
+++ b/tests/test_core/test_misc.py
@@ -33,6 +33,23 @@ class MiscTest(ParserTest):
         with self.assertRaises(AssertionError):
             self.assert_dict_equal({'a': 1}, {'b': 1})
 
+    def test_assert_raises_contains_str(self):
+        with self.assertRaises(AssertionError) as exc_ctx:
+            with self.assert_raises_contains_str(ValueError, 'foo'):
+                raise ValueError('bar')
+
+        self.assertEqual("'foo' not found in 'bar'", str(exc_ctx.exception))
+
+        with self.assertRaises(AssertionError) as exc_ctx:
+            with self.assert_raises_contains_str(ValueError, 'foo'):
+                pass
+
+        self.assertEqual('ValueError not raised', str(exc_ctx.exception))
+
+        with self.assertRaises(RuntimeError):  # The unexpected exception was allowed to propagate
+            with self.assert_raises_contains_str(ValueError, 'foo'):
+                raise RuntimeError('foo')
+
 
 if __name__ == '__main__':
     # import logging

--- a/tests/test_inputs/test_choice_inputs.py
+++ b/tests/test_inputs/test_choice_inputs.py
@@ -62,7 +62,7 @@ class ChoiceInputTest(ParserTest):
         for val in ('bar', 'test', 'foo', 'BAZ', '0', '4'):
             with self.subTest(val=val):
                 self.assertNotIn(val, ec)
-                with self.assertRaisesRegex(InvalidChoiceError, "choose from: 'FOO', 'Bar', 'baz'"):
+                with self.assert_raises_contains_str(InvalidChoiceError, "choose from: 'FOO', 'Bar', 'baz'"):
                     ec(val)
 
     def test_enum_case_insensitive(self):
@@ -81,15 +81,15 @@ class ChoiceInputTest(ParserTest):
         for val in ('test', 'BAT', '0', '4'):
             with self.subTest(val=val):
                 self.assertNotIn(val, ec)
-                with self.assertRaisesRegex(InvalidChoiceError, "choose from: 'FOO', 'Bar', 'baz'"):
+                with self.assert_raises_contains_str(InvalidChoiceError, "choose from: 'FOO', 'Bar', 'baz'"):
                     ec(val)
 
     def test_choices_rejects_typed_insensitive(self):
-        with self.assertRaisesRegex(TypeError, 'Cannot combine case_sensitive=False'):
+        with self.assert_raises_contains_str(TypeError, 'Cannot combine case_sensitive=False'):
             Choices((1, 2, 3), case_sensitive=False)
 
     def test_choices_rejects_bad_enum_choices(self):
-        with self.assertRaisesRegex(TypeError, 'Invalid choices='):
+        with self.assert_raises_contains_str(TypeError, 'Invalid choices='):
             Choices(EnumExample._member_map_, EnumChoices(EnumExample))
 
     def test_choices_typed_repr(self):
@@ -103,7 +103,7 @@ class ChoiceInputTest(ParserTest):
 
         for val in ('-1', '0', '4', '10', 'foo'):
             with self.subTest(val=val):
-                with self.assertRaisesRegex(InvalidChoiceError, 'choose from: 1, 2, 3'):
+                with self.assert_raises_contains_str(InvalidChoiceError, 'choose from: 1, 2, 3'):
                     choices(val)
 
     def test_choices_strs_sensitive(self):

--- a/tests/test_inputs/test_file_inputs.py
+++ b/tests/test_inputs/test_file_inputs.py
@@ -262,6 +262,17 @@ class FileInputTest(TestCase):
 
     # endregion
 
+    def test_fix_default_handling(self):
+        class Cmd(Command):
+            foo = Option(type=PathInput(), default='/var/tmp')
+            bar = Option(type=PathInput(fix_default=False), default='123')
+            baz = Option(type=PathInput(), default=None)
+
+        cmd = Cmd()
+        self.assertEqual(Path('/var/tmp'), cmd.foo)
+        self.assertEqual('123', cmd.bar)
+        self.assertIsNone(cmd.baz)
+
 
 class WriteFileTest(TestCase):
     def test_plain_write_with(self):

--- a/tests/test_inputs/test_file_inputs.py
+++ b/tests/test_inputs/test_file_inputs.py
@@ -328,7 +328,7 @@ class WriteFileTest(TestCase):
             self.assertEqual('{"a": 1}', a.read_text())
 
 
-class ReadFileTest(TestCase):
+class ReadFileTest(ParserTest):
     def test_plain_read_with(self):
         with temp_path('a') as a:
             a.write_text('{"a": 1}')
@@ -391,7 +391,7 @@ class ReadFileTest(TestCase):
         with temp_path() as tmp_path:
             b = tmp_path.joinpath('b')
             b.mkdir()
-            with self.assertRaisesRegex(BadArgument, 'Unable to open'):
+            with self.assert_raises_contains_str(BadArgument, 'Unable to open'):
                 Foo.parse_and_run(['-b', b.as_posix()])
 
 

--- a/tests/test_inputs/test_numeric_inputs.py
+++ b/tests/test_inputs/test_numeric_inputs.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from unittest import main, TestCase
+from unittest import main
 
 from cli_command_parser import Command, Option
 from cli_command_parser.exceptions import ParameterDefinitionError
@@ -8,7 +8,7 @@ from cli_command_parser.inputs import Range, NumRange, InputValidationError
 from cli_command_parser.testing import ParserTest
 
 
-class NumericInputTest(TestCase):
+class NumericInputTest(ParserTest):
     def test_range_replaced(self):
         class Foo(Command):
             bar: int = Option(type=range(10))
@@ -69,19 +69,19 @@ class NumericInputTest(TestCase):
         self.assertEqual("<NumRange(<class 'int'>, snap=False)[0 <= N]>", repr(NumRange(min=0)))
 
     def test_num_range_requires_min_max(self):
-        with self.assertRaisesRegex(ValueError, 'at least one of min and/or max values'):
+        with self.assert_raises_contains_str(ValueError, 'at least one of min and/or max values'):
             NumRange()
 
     def test_num_range_requires_min_lt_max(self):
-        with self.assertRaisesRegex(ValueError, 'min must be less than max'):
+        with self.assert_raises_contains_str(ValueError, 'min must be less than max'):
             NumRange(min=10, max=0)
 
     def test_num_range_snap_requires_strict_range(self):
-        with self.assertRaisesRegex(ValueError, 'snap would produce invalid values'):
+        with self.assert_raises_contains_str(ValueError, 'snap would produce invalid values'):
             NumRange(snap=True, min=1, max=2)
 
     def test_snap_rejects_float(self):
-        with self.assertRaisesRegex(TypeError, 'Unable to snap to extrema with type=float'):
+        with self.assert_raises_contains_str(TypeError, 'Unable to snap to extrema with type=float'):
             NumRange(snap=True, type=float, min=1)
 
     def test_num_range_auto_type(self):
@@ -161,8 +161,8 @@ class ParseInputTest(ParserTest):
             bar = Option(type=Range(range(10), fix_default=True), default='-10')
             baz = Option(type=Range(range(10), fix_default=False), default='-10')
 
-        with self.assertRaisesRegex(InputValidationError, 'expected a value in the range'):
-            _ = Foo().bar
+        with self.assert_raises_contains_str(InputValidationError, 'expected a value in the range'):
+            Foo().bar  # noqa
 
         self.assertEqual('-10', Foo().baz)
 

--- a/tests/test_inputs/test_pattern_inputs.py
+++ b/tests/test_inputs/test_pattern_inputs.py
@@ -2,7 +2,7 @@
 
 import re
 from typing import Match
-from unittest import main, TestCase
+from unittest import main
 
 from cli_command_parser import Command, Option
 from cli_command_parser.exceptions import ParameterDefinitionError
@@ -12,7 +12,7 @@ from cli_command_parser.testing import ParserTest
 PAT = re.compile('foo')
 
 
-class RegexInputTest(TestCase):
+class RegexInputTest(ParserTest):
     # region Inputs.__init__ Replacement / Validation
 
     def test_pattern_type_replaced(self):
@@ -38,7 +38,7 @@ class RegexInputTest(TestCase):
     # region Initialization
 
     def test_no_patterns(self):
-        with self.assertRaisesRegex(TypeError, 'At least one regex pattern is required'):
+        with self.assert_raises_contains_str(TypeError, 'At least one regex pattern is required'):
             Regex()
 
     def test_group_and_groups(self):
@@ -86,9 +86,9 @@ class RegexInputTest(TestCase):
     # endregion
 
     def test_non_match(self):
-        with self.assertRaisesRegex(InputValidationError, 'expected a value matching'):
+        with self.assert_raises_contains_str(InputValidationError, 'expected a value matching'):
             Regex(PAT)('barbaz')
-        with self.assertRaisesRegex(InputValidationError, 'expected a value matching'):
+        with self.assert_raises_contains_str(InputValidationError, 'expected a value matching'):
             Regex(PAT, 'foobar')('barbaz')
 
     def test_strings(self):
@@ -97,13 +97,13 @@ class RegexInputTest(TestCase):
         self.assertEqual('foo | bar', r.format_metavar())
 
 
-class GlobInputTest(TestCase):
+class GlobInputTest(ParserTest):
     def test_pattern_with_choices_rejected(self):
         with self.assertRaisesRegex(ParameterDefinitionError, 'Cannot combine type=.* with choices='):
             Option(type=Glob('foo'), choices=('a', 'b'))
 
     def test_no_patterns(self):
-        with self.assertRaisesRegex(TypeError, 'At least one glob/fnmatch pattern is required'):
+        with self.assert_raises_contains_str(TypeError, 'At least one glob/fnmatch pattern is required'):
             Glob()
 
     def test_strings(self):
@@ -112,11 +112,11 @@ class GlobInputTest(TestCase):
         self.assertEqual('foo | bar', g.format_metavar())
 
     def test_non_match(self):
-        with self.assertRaisesRegex(InputValidationError, 'expected a value matching'):
+        with self.assert_raises_contains_str(InputValidationError, 'expected a value matching'):
             Glob('foo')('barbaz')
-        with self.assertRaisesRegex(InputValidationError, 'expected a value matching'):
+        with self.assert_raises_contains_str(InputValidationError, 'expected a value matching'):
             Glob('foo', 'foobar')('barbaz')
-        with self.assertRaisesRegex(InputValidationError, 'expected a value matching'):
+        with self.assert_raises_contains_str(InputValidationError, 'expected a value matching'):
             Glob('FOO', match_case=True)('foo')
 
     def test_match(self):

--- a/tests/test_inputs/test_time_inputs.py
+++ b/tests/test_inputs/test_time_inputs.py
@@ -25,6 +25,10 @@ KO_KR = 'ko_KR.utf-8'
 FR_FR = 'fr_FR.utf-8'
 # fmt: on
 
+JAN_1_2022 = date(2022, 1, 1)
+FEB_2_2022 = date(2022, 2, 2)
+MAR_3_2022 = date(2022, 3, 3)
+
 
 class MiscDTInputTest(TestCase):
     def test_setlocale_not_called_without_locale(self):
@@ -340,9 +344,9 @@ class ParseInputTest(ParserTest):
     def test_date_default_type_fix(self):
         class Foo(Command):
             start = Option('-s', type=Date(), default='2022-01-01')
-            end = Option('-e', type=Date(), default=date(2022, 1, 1))
+            end = Option('-e', type=Date(), default=JAN_1_2022)
 
-        cases = {date(2022, 1, 1): [], date(2022, 2, 2): ['-s', '2022-02-02', '-e', '2022-02-02']}
+        cases = {JAN_1_2022: [], FEB_2_2022: ['-s', '2022-02-02', '-e', '2022-02-02']}
         for expected, argv in cases.items():
             with self.subTest(expected=expected, argv=argv):
                 foo = Foo.parse(argv)
@@ -351,11 +355,11 @@ class ParseInputTest(ParserTest):
 
     def test_date_default_collection_type_fix_tuple(self):
         class Foo(Command):
-            bar = Option('-b', type=Date(), nargs='+', default=('2022-01-01', date(2022, 1, 1)))
+            bar = Option('-b', type=Date(), nargs='+', default=('2022-01-01', JAN_1_2022))
 
         cases = [
-            ([], (date(2022, 1, 1), date(2022, 1, 1))),
-            (['-b', '2022-02-02', '2022-03-03'], [date(2022, 2, 2), date(2022, 3, 3)]),
+            ([], [JAN_1_2022, JAN_1_2022]),
+            (['-b', '2022-02-02', '2022-03-03'], [JAN_1_2022, JAN_1_2022, FEB_2_2022, MAR_3_2022]),
         ]
         for argv, expected in cases:
             with self.subTest(expected=expected, argv=argv):
@@ -364,11 +368,11 @@ class ParseInputTest(ParserTest):
 
     def test_date_default_collection_type_fix_single(self):
         class Foo(Command):
-            bar = Option('-b', type=Date(), nargs='+', default=date(2022, 1, 1))
+            bar = Option('-b', type=Date(), nargs='+', default=JAN_1_2022)
 
         cases = [
-            ([], [date(2022, 1, 1)]),
-            (['-b', '2022-02-02', '2022-03-03'], [date(2022, 2, 2), date(2022, 3, 3)]),
+            ([], [JAN_1_2022]),
+            (['-b', '2022-02-02', '2022-03-03'], [JAN_1_2022, FEB_2_2022, MAR_3_2022]),
         ]
         for argv, expected in cases:
             with self.subTest(expected=expected, argv=argv):
@@ -394,14 +398,14 @@ class ParseInputTest(ParserTest):
             def __contains__(self, item):
                 return item in self.data
 
-        default = Custom((date(2022, 1, 1),))
+        default = Custom((JAN_1_2022,))
 
         class Foo(Command):
             bar = Option('-b', type=Date(), nargs='+', default=default)
 
         cases = [
-            ([], default),
-            (['-b', '2022-02-02', '2022-03-03'], [date(2022, 2, 2), date(2022, 3, 3)]),
+            ([], [JAN_1_2022]),
+            (['-b', '2022-02-02', '2022-03-03'], [JAN_1_2022, FEB_2_2022, MAR_3_2022]),
         ]
         for argv, expected in cases:
             with self.subTest(expected=expected, argv=argv):

--- a/tests/test_parameters/test_action_flags.py
+++ b/tests/test_parameters/test_action_flags.py
@@ -264,14 +264,14 @@ class ActionFlagTest(ParserTest):
 
     def test_no_func(self):
         flag = ActionFlag()
-        with Context() as ctx:
-            flag.store_const()
+        with Context():
+            flag.action.add_const()
             with self.assertRaises(ParameterDefinitionError):
                 flag.result()
 
     def test_not_provided(self):
         flag = ActionFlag()
-        with Context() as ctx:
+        with Context():
             self.assertFalse(flag.result())
 
     def test_before_main_sorts_before_after_main(self):

--- a/tests/test_parameters/test_action_flags.py
+++ b/tests/test_parameters/test_action_flags.py
@@ -31,7 +31,7 @@ class ActionFlagTest(ParserTest):
         class Foo(Command):
             foo = ActionFlag()
 
-        with self.assertRaisesRegex(ParameterDefinitionError, 'No function was registered'):
+        with self.assert_raises_contains_str(ParameterDefinitionError, 'No function was registered'):
             Foo.parse([])
 
     def test_af_order_conflict(self):
@@ -39,7 +39,7 @@ class ActionFlagTest(ParserTest):
             foo = ActionFlag()(Mock())
             bar = ActionFlag()(Mock())
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'different order values'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'different order values'):
             Foo.parse([])
 
     def test_af_non_me_group_conflict(self):
@@ -48,7 +48,7 @@ class ActionFlagTest(ParserTest):
                 foo = ActionFlag()(Mock())
                 bar = ActionFlag()(Mock())
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'different order values'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'different order values'):
             Foo.parse([])
 
     def test_af_md_group_conflict(self):
@@ -57,7 +57,7 @@ class ActionFlagTest(ParserTest):
                 foo = ActionFlag()(Mock())
                 bar = ActionFlag()(Mock())
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'different order values'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'different order values'):
             Foo.parse([])
 
     def test_af_me_group_ok(self):
@@ -75,7 +75,7 @@ class ActionFlagTest(ParserTest):
                 bar = ActionFlag()(Mock())
             baz = ActionFlag()(Mock())
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'different order values'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'different order values'):
             Foo.parse([])
 
     def test_af_mixed_grouping_ordered_ok(self):
@@ -102,7 +102,8 @@ class ActionFlagTest(ParserTest):
                     self.assertFalse(parsed[a])
 
     def test_no_reassign(self):
-        with self.assertRaisesRegex(CommandDefinitionError, 'Cannot re-assign the func to call for ActionFlag'):
+        expected = 'Cannot re-assign the func to call for ActionFlag'
+        with self.assert_raises_contains_str(CommandDefinitionError, expected):
 
             class Foo(Command):
                 foo = ActionFlag()(Mock())
@@ -116,7 +117,7 @@ class ActionFlagTest(ParserTest):
             bar = ActionFlag('-b', order=1)(Mock())
             baz = ActionFlag('-b', order=2)(Mock())
 
-        with self.assertRaisesRegex(CommandDefinitionError, "short option='-b' conflict for command="):
+        with self.assert_raises_contains_str(CommandDefinitionError, "short option='-b' conflict for command="):
             Foo.parse([])
 
     def test_extra_flags_provided_cause_error(self):
@@ -126,11 +127,11 @@ class ActionFlagTest(ParserTest):
             foo = ActionFlag('-f', order=1)(mocks[0])
             bar = ActionFlag('-b', order=2)(mocks[1])
 
-        expected_error_text = r'--bar / -b, --foo / -f \(combining multiple action flags is disabled\)'
-        with self.assertRaisesRegex(ParamConflict, expected_error_text):
+        expected_error_text = '--bar / -b, --foo / -f (combining multiple action flags is disabled)'
+        with self.assert_raises_contains_str(ParamConflict, expected_error_text):
             Foo.parse_and_run(['-fb'])
 
-        with self.assertRaisesRegex(ParamConflict, expected_error_text):
+        with self.assert_raises_contains_str(ParamConflict, expected_error_text):
             Foo.parse_and_run(['--foo', '--bar'])
 
     def test_multi_flag_order_followed(self):
@@ -280,7 +281,7 @@ class ActionFlagTest(ParserTest):
         self.assertListEqual(expected, sorted([a, b]))
 
     def test_after_main_always_available(self):
-        with self.assertRaisesRegex(ParameterDefinitionError, 'cannot be combined with'):
+        with self.assert_raises_contains_str(ParameterDefinitionError, 'cannot be combined with'):
             ActionFlag(before_main=False, always_available=True)
 
     def test_nargs_not_allowed(self):
@@ -296,7 +297,8 @@ class ActionFlagTest(ParserTest):
             foo = before_main(order=1)(Mock(__doc__=''))
             bar = before_main(order=2, always_available=True)(Mock(__doc__=''))
 
-        with self.assertRaisesRegex(CommandDefinitionError, r"invalid parameters: \{\(True, 2\): ActionFlag\('bar',"):
+        expected = "invalid parameters: {(True, 2): ActionFlag('bar',"
+        with self.assert_raises_contains_str(CommandDefinitionError, expected):
             Foo.parse([])
 
 

--- a/tests/test_parameters/test_actions.py
+++ b/tests/test_parameters/test_actions.py
@@ -1,23 +1,23 @@
 #!/usr/bin/env python
 
-from unittest import TestCase, main
+from unittest import main
 from unittest.mock import Mock, PropertyMock, patch
 
 from cli_command_parser import Command, Action, Positional, action_flag, ParameterDefinitionError
 from cli_command_parser.exceptions import CommandDefinitionError, MissingArgument, InvalidChoice
-from cli_command_parser.testing import RedirectStreams, sealed_mock
+from cli_command_parser.testing import ParserTest, RedirectStreams, sealed_mock
 
 # TODO: Test multi-word actions; multi-word actions combined with subcommands (with multiple words)
 # TODO: Test space/-/_ switch for multi-word?
 
 
 @patch('cli_command_parser.config.CommandConfig.reject_ambiguous_pos_combos.default', True)
-class ActionTest(TestCase):
+class ActionTest(ParserTest):
     def test_action_requires_targets(self):
         class Foo(Command):
             a = Action()
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'No choices were registered for Action'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'No choices were registered for Action'):
             Foo.parse([])
 
     def test_action_called(self):
@@ -94,7 +94,7 @@ class ActionTest(TestCase):
         self.assertEqual(foo.text, ['bar'])
 
     def test_reject_double_choice(self):
-        with self.assertRaisesRegex(CommandDefinitionError, 'Cannot combine a positional method_or_choice='):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'Cannot combine a positional method_or_choice='):
 
             class Foo(Command):
                 action = Action()

--- a/tests/test_parameters/test_choice_maps.py
+++ b/tests/test_parameters/test_choice_maps.py
@@ -165,6 +165,15 @@ class ChoiceMapTest(ParserTest):
         choice = Choice('test', help='Example choice')
         self.assertEqual('    test                      Example choice', choice.format_help())
 
+    def test_default_when_missing(self):
+        class Foo(Command, add_help=False):
+            sub = SubCommand()
+
+        class Bar(Foo):
+            pass
+
+        self.assertEqual({'sub': 123}, Foo().ctx.get_parsed(default=123))
+
 
 if __name__ == '__main__':
     try:

--- a/tests/test_parameters/test_choice_maps.py
+++ b/tests/test_parameters/test_choice_maps.py
@@ -4,7 +4,7 @@ from unittest import main
 from unittest.mock import Mock
 
 from cli_command_parser import Command, Context
-from cli_command_parser.exceptions import CommandDefinitionError, BadArgument, InvalidChoice
+from cli_command_parser.exceptions import CommandDefinitionError, BadArgument, InvalidChoice, ParameterDefinitionError
 from cli_command_parser.parameters.choice_map import SubCommand, Action, Choice
 from cli_command_parser.testing import ParserTest
 
@@ -33,9 +33,9 @@ class ChoiceMapTest(ParserTest):
                 pass
 
         with Context():
-            Foo.action.take_action('foo')
+            Foo.action.action.add_value('foo')
             with self.assertRaises(InvalidChoice):
-                Foo.action.append('baz')
+                Foo.action.action.add_value('baz')
 
     def test_missing_action_target(self):
         class Foo(Command):
@@ -52,7 +52,7 @@ class ChoiceMapTest(ParserTest):
                 pass
 
         with Context():
-            Foo.action.take_action('foo')
+            Foo.action.action.add_value('foo')
             with self.assertRaises(BadArgument):
                 Foo.action.validate('bar')
 
@@ -78,7 +78,7 @@ class ChoiceMapTest(ParserTest):
                 pass
 
         with Context():
-            Foo.action.take_action('foo')
+            Foo.action.action.add_value('foo')
             with self.assertRaises(BadArgument):
                 Foo.action.result()
 
@@ -95,7 +95,7 @@ class ChoiceMapTest(ParserTest):
                 pass
 
         with Context():
-            Foo.action.take_action('foo bar')
+            Foo.action.action.add_value('foo bar')
             del Foo.action.choices['foo bar']
             with self.assertRaises(BadArgument):
                 Foo.action.result()
@@ -142,6 +142,10 @@ class ChoiceMapTest(ParserTest):
     def test_allow_leading_dash_not_allowed_sub_cmd(self):
         with self.assertRaises(TypeError):
             SubCommand(allow_leading_dash=True)
+
+    def test_default_not_allowed_sub_cmd(self):
+        with self.assertRaises(ParameterDefinitionError):
+            SubCommand(default='foo')
 
     def test_nargs_not_allowed_action(self):
         with self.assertRaises(TypeError):

--- a/tests/test_parameters/test_choice_maps.py
+++ b/tests/test_parameters/test_choice_maps.py
@@ -64,7 +64,7 @@ class ChoiceMapTest(ParserTest):
             def foo(self):
                 pass
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'No choices were registered for Action'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'No choices were registered for Action'):
             foo = Foo.parse([])
             del Foo.action.choices['foo']
             foo.action  # noqa
@@ -112,7 +112,7 @@ class ChoiceMapTest(ParserTest):
         class Foo(Command):
             sub = SubCommand()
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'Cannot combine a positional command_or_choice='):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'Cannot combine a positional command_or_choice='):
             Foo.sub.register('foo', choice='foo')
 
     def test_custom_action_choice(self):

--- a/tests/test_parameters/test_counters.py
+++ b/tests/test_parameters/test_counters.py
@@ -5,6 +5,7 @@ from unittest import main
 from cli_command_parser import Command, Counter, Flag
 from cli_command_parser.exceptions import NoSuchOption, ParameterDefinitionError, BadArgument
 from cli_command_parser.testing import ParserTest
+from cli_command_parser.utils import _NotSet
 
 
 class CounterTest(ParserTest):
@@ -104,8 +105,8 @@ class CounterTest(ParserTest):
         with self.assertRaises(ParameterDefinitionError):
             Counter(default=1.5)  # noqa
 
-    def test_prepare_value(self):
-        self.assertEqual(1, Counter().prepare_value(None))
+    def test_required_no_default(self):
+        self.assertIs(_NotSet, Counter(required=True).default)
 
     def test_validate(self):
         self.assertTrue(Counter().is_valid_arg('1'))

--- a/tests/test_parameters/test_counters.py
+++ b/tests/test_parameters/test_counters.py
@@ -149,7 +149,7 @@ class CounterTest(ParserTest):
 
         with self.env_vars('invalid value', BAR='foo'):
             # TODO: Improve this error so it indicates which env var had a bad value
-            with self.assertRaisesRegex(BadArgument, "bad counter value='foo'"):
+            with self.assert_raises_contains_str(BadArgument, "bad counter value='foo'"):
                 Foo.parse([])
 
     # endregion

--- a/tests/test_parameters/test_flags.py
+++ b/tests/test_parameters/test_flags.py
@@ -40,7 +40,7 @@ class FlagTest(ParserTest):
 
     def test_invalid_action_hint(self):
         with self.assertRaisesRegex(ParameterDefinitionError, r"Invalid action=.*- did you mean 'store_const'\?"):
-            Flag(action='store')
+            Flag(action='store')  # noqa
 
     # region Test Param Actions
 
@@ -77,10 +77,6 @@ class FlagTest(ParserTest):
     def test_nargs_not_allowed(self):
         with self.assertRaises(TypeError):
             Flag(nargs='+')
-
-    def test_metavar_not_allowed(self):
-        with self.assertRaisesRegex(TypeError, 'got an unexpected keyword argument:'):
-            Flag(metavar='foo')
 
     def test_choices_not_allowed(self):
         with self.assertRaises(TypeError):
@@ -201,10 +197,6 @@ class TriFlagTest(ParserTest):
     def test_choices_not_allowed(self):
         with self.assertRaises(TypeError):
             TriFlag(choices=(1, 2))
-
-    def test_metavar_not_allowed(self):
-        with self.assertRaises(TypeError):
-            TriFlag(metavar='foo')
 
     def test_allow_leading_dash_not_allowed(self):
         with self.assertRaises(TypeError):

--- a/tests/test_parameters/test_flags.py
+++ b/tests/test_parameters/test_flags.py
@@ -135,7 +135,7 @@ class FlagTest(ParserTest):
         class Foo(Command, option_name_mode=None):
             bar = Flag()
 
-        with self.assertRaisesRegex(ParameterDefinitionError, 'No option strings were registered'):
+        with self.assert_raises_contains_str(ParameterDefinitionError, 'No option strings were registered'):
             Foo().parse([])
 
     def test_name_none(self):
@@ -210,10 +210,11 @@ class TriFlagTest(ParserTest):
         self.assert_call_fails_cases(TriFlag, fail_cases)
 
     def test_default_in_consts_rejected(self):
+        expected = 'the default must not match either value'
         cases = [((None, 'foo'), None), (('foo', None), None), ((True, False), True), ((True, False), False)]
         for consts, default in cases:
             with self.subTest(consts=consts, default=default):
-                with self.assertRaisesRegex(ParameterDefinitionError, 'the default must not match either value'):
+                with self.assert_raises_contains_str(ParameterDefinitionError, expected):
                     TriFlag(consts=consts, default=default)
 
     # region Option Strings
@@ -350,7 +351,7 @@ class TriFlagTest(ParserTest):
                 class Foo(Command, option_name_mode=None):
                     bar = TriFlag(*args, **kwargs)
 
-                with self.assertRaisesRegex(ParameterDefinitionError, 'No option strings were registered'):
+                with self.assert_raises_contains_str(ParameterDefinitionError, 'No option strings were registered'):
                     Foo().parse([])
 
     def test_name_none(self):

--- a/tests/test_parameters/test_flags.py
+++ b/tests/test_parameters/test_flags.py
@@ -26,7 +26,7 @@ class FlagTest(ParserTest):
         cases = [(True, False), (False, True), (42, None)]
         for const, expected in cases:
             with self.subTest(const=const, expected=expected):
-                self.assertEqual(expected, Flag(const=const).default)
+                self.assertEqual(expected, Flag(const=const).action.get_default())
 
     def test_annotation_ignored(self):
         for annotation in (bool, int, str, None):

--- a/tests/test_parameters/test_flags.py
+++ b/tests/test_parameters/test_flags.py
@@ -38,6 +38,10 @@ class FlagTest(ParserTest):
                 self.assertNotEqual(Foo.bar.type, annotation)
                 self.assert_parse_results_cases(Foo, [(['--bar'], {'bar': True}), ([], {'bar': False})])
 
+    def test_invalid_action_hint(self):
+        with self.assertRaisesRegex(ParameterDefinitionError, r"Invalid action=.*- did you mean 'store_const'\?"):
+            Flag(action='store')
+
     # region Test Param Actions
 
     def test_store_false(self):

--- a/tests/test_parameters/test_misc.py
+++ b/tests/test_parameters/test_misc.py
@@ -185,7 +185,7 @@ class UnlikelyToBeReachedParameterTest(ParserTest):
 
     def test_flag_backtrack(self):
         flag_act = Flag().action
-        self.assertEqual([], flag_act.get_maybe_poppable_values())
+        self.assertEqual([], flag_act.get_maybe_poppable_counts())
         self.assertFalse(flag_act.can_reset())
 
     def test_flag_add_values(self):

--- a/tests/test_parameters/test_misc.py
+++ b/tests/test_parameters/test_misc.py
@@ -13,7 +13,6 @@ from cli_command_parser.exceptions import (
     ParamUsageError,
     MissingArgument,
     BadArgument,
-    UnsupportedAction,
     ParamsMissing,
 )
 from cli_command_parser.formatting.params import (
@@ -285,19 +284,20 @@ class UnlikelyToBeReachedParameterTest(ParserTest):
             with self.assertRaisesRegex(BadArgument, r'expected nargs=.* values but found \d+'):
                 foo.bar  # noqa
 
-    def test_flag_pop_last(self):
-        with self.assertRaises(UnsupportedAction):
-            Flag().pop_last()
+    def test_flag_backtrack(self):
+        flag_act = Flag().action
+        self.assertEqual([], flag_act.get_maybe_poppable_values())
+        self.assertFalse(flag_act.can_reset())
 
-    def test_empty_can_pop_counts(self):
-        self.assertEqual([], PassThru().can_pop_counts())
+    def test_flag_add_values(self):
+        flag_act = Flag().action
+        self.assertEqual(0, flag_act.add_values([]))
+        with Context():
+            self.assertEqual(1, flag_act.add_values([None]))
 
-    def test_unsupported_pop(self):
-        class Foo(Command):
-            bar = Positional()
-
-        with Context(), self.assertRaises(UnsupportedAction):
-            Foo.bar.pop_last()
+    def test_store_add_const(self):
+        with Context(), self.assertRaises(MissingArgument):
+            Positional().action.add_const()
 
 
 if __name__ == '__main__':

--- a/tests/test_parameters/test_misc.py
+++ b/tests/test_parameters/test_misc.py
@@ -139,10 +139,6 @@ class UnlikelyToBeReachedParameterTest(ParserTest):
             with self.assertRaises(ParamUsageError):
                 action.add_value('foo')
 
-    def test_non_none_rejected(self):
-        with self.assertRaises(ParamUsageError), Context():
-            Flag().action.add_value('foo')
-
     def test_sort_mixed_types(self):
         sort_cases = [
             (ParamGroup(), Flag(), ActionFlag()),
@@ -190,12 +186,6 @@ class UnlikelyToBeReachedParameterTest(ParserTest):
         flag_act = Flag().action
         self.assertEqual([], flag_act.get_maybe_poppable_counts())
         self.assertFalse(flag_act.can_reset())
-
-    def test_flag_add_values(self):
-        flag_act = Flag().action
-        self.assertEqual(0, flag_act.add_values([]))
-        with Context():
-            self.assertEqual(1, flag_act.add_values([None]))
 
     def test_store_add_const(self):
         with Context(), self.assertRaises(MissingArgument):

--- a/tests/test_parameters/test_misc.py
+++ b/tests/test_parameters/test_misc.py
@@ -14,7 +14,7 @@ from cli_command_parser.formatting.params import (
     GroupHelpFormatter,
 )
 from cli_command_parser.parameters import PassThru, Positional, ParamGroup, ActionFlag, Counter, Flag, Option
-from cli_command_parser.parameters.base import Parameter, BaseOption, BasePositional
+from cli_command_parser.parameters.base import Parameter, BaseOption, BasePositional, AllowLeadingDashProperty
 from cli_command_parser.parameters.choice_map import ChoiceMap, SubCommand, Action
 from cli_command_parser.parser import CommandParser
 from cli_command_parser.testing import ParserTest, sealed_mock
@@ -126,6 +126,9 @@ class MiscParameterTest(ParserTest):
         act = Flag().action
         self.assertEqual('store_const', str(act))
         self.assertIn('<StoreConst[values=False, consts=True]', repr(act))
+
+    def test_leading_dash_property(self):
+        self.assertIsInstance(Option.allow_leading_dash, AllowLeadingDashProperty)
 
 
 class UnlikelyToBeReachedParameterTest(ParserTest):

--- a/tests/test_parameters/test_misc.py
+++ b/tests/test_parameters/test_misc.py
@@ -29,7 +29,7 @@ class MiscParameterTest(ParserTest):
 
     def test_unregistered_action_rejected(self):
         with self.assertRaises(ParameterDefinitionError):
-            Flag(action='foo')
+            Flag(action='foo')  # noqa
 
     def test_empty_choices(self):
         with self.assertRaises(ParameterDefinitionError):
@@ -58,7 +58,7 @@ class MiscParameterTest(ParserTest):
         class Foo(Command):
             bar = Positional(type=sealed_mock(side_effect=OSError))
 
-        self.assert_parse_fails(Foo, ['a'], BadArgument, 'unable to cast value=.* to type=')
+        self.assert_parse_fails(Foo, ['a'], BadArgument, 'unable to cast value=.* to type=', regex=True)
 
     def test_formatter_class(self):
         param_fmt_cls_map = {
@@ -85,7 +85,7 @@ class MiscParameterTest(ParserTest):
             bar = Flag('-b')
             baz = Option('-b')
 
-        with self.assertRaisesRegex(CommandDefinitionError, "short option='-b' conflict for command="):
+        with self.assert_raises_contains_str(CommandDefinitionError, "short option='-b' conflict for command="):
             Foo.parse([])
 
     def test_config_no_context_explicit_command(self):

--- a/tests/test_parameters/test_misc.py
+++ b/tests/test_parameters/test_misc.py
@@ -275,14 +275,15 @@ class UnlikelyToBeReachedParameterTest(ParserTest):
             bar = Option(required=True)
 
         with self.assertRaises(MissingArgument):
-            Foo.parse([]).bar  # noqa
+            Foo().bar  # noqa
 
     def test_missing_required_value_multi(self):
-        class Foo(Command, allow_missing=True):
+        class Foo(Command, allow_missing=True, add_help=False):
             bar = Option(nargs='+', required=True)
 
+        self.assertEqual({'bar': 123}, Foo().ctx.get_parsed(default=123))
         with self.assertRaises(MissingArgument):
-            Foo.parse([]).bar  # noqa
+            Foo().bar  # noqa
 
     def test_too_few_values(self):
         class Foo(Command):

--- a/tests/test_parameters/test_options.py
+++ b/tests/test_parameters/test_options.py
@@ -64,7 +64,11 @@ class OptionTest(ParserTest):
     def test_rejected_const_action_hint(self):
         for action in ('store_const', 'append_const'):
             with self.assertRaisesRegex(ParameterDefinitionError, 'Invalid action=.* for Option - use Flag instead'):
-                Option(action=action)
+                Option(action=action)  # noqa
+
+    def test_bad_action_rejected(self):
+        with self.assertRaisesRegex(ParameterDefinitionError, 'Invalid action=.*- valid actions:'):
+            Option(action='foo')  # noqa
 
     # endregion
 

--- a/tests/test_parameters/test_options.py
+++ b/tests/test_parameters/test_options.py
@@ -4,7 +4,7 @@ import re
 from unittest import main
 from unittest.mock import Mock
 
-from cli_command_parser import Command, Flag, Option, ParamGroup
+from cli_command_parser import Command, Flag, Option, ParamGroup, Context
 from cli_command_parser.exceptions import UsageError, ParameterDefinitionError
 from cli_command_parser.exceptions import ParamUsageError, MissingArgument, BadArgument, ParamsMissing, ParamConflict
 from cli_command_parser.nargs import REMAINDER
@@ -91,11 +91,6 @@ class OptionTest(ParserTest):
 
     # endregion
 
-    def test_usage(self):
-        self.assertEqual('--foo', Option('--foo').format_usage())
-        self.assertEqual('[--foo bar]', Option('--foo', metavar='bar', required=False).formatter.format_basic_usage())
-        self.assertEqual('--foo bar', Option('--foo', metavar='bar', required=True).formatter.format_basic_usage())
-
     # region Name Mode
 
     def test_name_both(self):
@@ -162,6 +157,15 @@ class OptionTest(ParserTest):
         self.assert_argv_parse_fails_cases(Foo, fail_cases)
 
     # endregion
+
+    def test_usage(self):
+        self.assertEqual('--foo', Option('--foo').format_usage())
+        self.assertEqual('[--foo bar]', Option('--foo', metavar='bar', required=False).formatter.format_basic_usage())
+        self.assertEqual('--foo bar', Option('--foo', metavar='bar', required=True).formatter.format_basic_usage())
+
+    def test_append_get_maybe_poppable_counts(self):
+        with Context():
+            self.assertEqual([], Option(action='append').action.get_maybe_poppable_counts())
 
 
 class OptionNargsTest(ParserTest):

--- a/tests/test_parameters/test_options.py
+++ b/tests/test_parameters/test_options.py
@@ -70,6 +70,9 @@ class OptionTest(ParserTest):
         with self.assertRaisesRegex(ParameterDefinitionError, 'Invalid action=.*- valid actions:'):
             Option(action='foo')  # noqa
 
+    def test_metavar_is_stored(self):
+        self.assertEqual('foo', Option(metavar='foo').metavar)
+
     # endregion
 
     # region Option Strings

--- a/tests/test_parameters/test_options.py
+++ b/tests/test_parameters/test_options.py
@@ -143,7 +143,7 @@ class OptionTest(ParserTest):
         class Foo(Command, option_name_mode=None):
             bar = Option()
 
-        with self.assertRaisesRegex(ParameterDefinitionError, 'No option strings were registered'):
+        with self.assert_raises_contains_str(ParameterDefinitionError, 'No option strings were registered'):
             Foo().parse([])
 
     def test_name_none(self):
@@ -183,19 +183,19 @@ class OptionNargsTest(ParserTest):
         self.assert_call_fails_cases(Option, fail_cases)
 
     def test_nargs_0_range_tip_step_1(self):
-        with self.assertRaisesRegex(ParameterDefinitionError, r'try using range\(1, 2\) instead'):
+        with self.assert_raises_contains_str(ParameterDefinitionError, 'try using range(1, 2) instead'):
 
             class Foo(Command):
                 bar = Option(nargs=range(2))
 
     def test_nargs_0_range_tip_step_2_matches_stop(self):
-        with self.assertRaisesRegex(ParameterDefinitionError, 'specified without a value'):
+        with self.assert_raises_contains_str(ParameterDefinitionError, 'specified without a value'):
 
             class Foo(Command):
                 bar = Option(nargs=range(0, 2, 2))
 
     def test_nargs_0_range_tip_step_2(self):
-        with self.assertRaisesRegex(ParameterDefinitionError, r'try using range\(2, 3, 2\) instead'):
+        with self.assert_raises_contains_str(ParameterDefinitionError, 'try using range(2, 3, 2) instead'):
 
             class Foo(Command):
                 bar = Option(nargs=range(0, 3, 2))
@@ -211,13 +211,13 @@ class OptionNargsTest(ParserTest):
         self.assertIsNone(Foo.bar.type)  # noqa
 
     def test_type_with_remainder_rejected(self):
-        with self.assertRaisesRegex(ParameterDefinitionError, 'Type casting and choices are not supported'):
+        with self.assert_raises_contains_str(ParameterDefinitionError, 'Type casting and choices are not supported'):
 
             class Foo(Command):
                 bar = Option(nargs=(1, REMAINDER), type=int)  # TODO: Should this be supported?  Why not?
 
     def test_choices_with_remainder_rejected(self):
-        with self.assertRaisesRegex(ParameterDefinitionError, 'Type casting and choices are not supported'):
+        with self.assert_raises_contains_str(ParameterDefinitionError, 'Type casting and choices are not supported'):
 
             class Foo(Command):
                 bar = Option(nargs=(1, REMAINDER), choices=('a', 'b'))
@@ -226,7 +226,7 @@ class OptionNargsTest(ParserTest):
         expected = 'only allow_leading_dash=AllowLeadingDash.ALWAYS'
         for allow_leading_dash in ('numeric', False):
             with self.subTest(allow_leading_dash=allow_leading_dash):
-                with self.assertRaisesRegex(ParameterDefinitionError, expected):
+                with self.assert_raises_contains_str(ParameterDefinitionError, expected):
 
                     class Foo(Command):
                         bar = Option(nargs=(1, REMAINDER), allow_leading_dash=allow_leading_dash)

--- a/tests/test_parameters/test_pass_thru.py
+++ b/tests/test_parameters/test_pass_thru.py
@@ -31,7 +31,7 @@ class PassThruTest(ParserTest):
 
         self.assertTrue(Foo.baz.default is not None)
         foo = Foo()
-        with self.assertRaisesRegex(ParamsMissing, "missing pass thru args separated from others with '--'"):
+        with self.assert_raises_contains_str(ParamsMissing, "missing pass thru args separated from others with '--'"):
             foo.parse([])
         with self.assertRaises(MissingArgument):
             foo.baz  # noqa
@@ -41,7 +41,7 @@ class PassThruTest(ParserTest):
             bar = PassThru()
             baz = PassThru()
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'it cannot follow another PassThru param'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'it cannot follow another PassThru param'):
             Foo.parse([])
 
     def test_double_dash_without_pass_thru_rejected(self):
@@ -68,7 +68,7 @@ class PassThruTest(ParserTest):
         class Bar(Foo):
             pt2 = PassThru()
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'it cannot follow another PassThru param'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'it cannot follow another PassThru param'):
             Bar.parse([])
 
     def test_extra_rejected(self):

--- a/tests/test_parameters/test_pass_thru.py
+++ b/tests/test_parameters/test_pass_thru.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python
+
+from unittest import main
+
+from cli_command_parser import Command, CommandDefinitionError, Context, SubCommand, PassThru, Flag
+from cli_command_parser.core import get_params
+from cli_command_parser.exceptions import NoSuchOption, ParamUsageError, MissingArgument, ParamsMissing
+from cli_command_parser.testing import ParserTest
+
+
+class PassThruTest(ParserTest):
+    def test_pass_thru(self):
+        class Foo(Command):
+            bar = Flag()
+            baz = PassThru()
+
+        success_cases = [
+            (['--bar', '--', 'a', 'b', '--c', '---x'], {'bar': True, 'baz': ['a', 'b', '--c', '---x']}),
+            (['--', '--bar', '--', 'a', '-b', 'c'], {'bar': False, 'baz': ['--bar', '--', 'a', '-b', 'c']}),
+            (['--bar', '--'], {'bar': True, 'baz': []}),
+            (['--', '--bar'], {'bar': False, 'baz': ['--bar']}),
+            (['--'], {'bar': False, 'baz': []}),
+            (['--bar'], {'bar': True, 'baz': None}),
+        ]
+        self.assert_parse_results_cases(Foo, success_cases)
+
+    def test_pass_thru_missing(self):
+        class Foo(Command):
+            bar = Flag()
+            baz = PassThru(required=True)
+
+        self.assertTrue(Foo.baz.default is not None)
+        foo = Foo()
+        with self.assertRaisesRegex(ParamsMissing, "missing pass thru args separated from others with '--'"):
+            foo.parse([])
+        with self.assertRaises(MissingArgument):
+            foo.baz  # noqa
+
+    def test_multiple_rejected(self):
+        class Foo(Command):
+            bar = PassThru()
+            baz = PassThru()
+
+        with self.assertRaisesRegex(CommandDefinitionError, 'it cannot follow another PassThru param'):
+            Foo.parse([])
+
+    def test_double_dash_without_pass_thru_rejected(self):
+        class Foo(Command):
+            bar = Flag()
+
+        with self.assertRaises(NoSuchOption):
+            Foo.parse(['--'])
+
+    def test_parser_has_pass_thru(self):
+        class Foo(Command):
+            pt = PassThru()
+
+        class Bar(Foo):
+            pass
+
+        self.assertTrue(get_params(Bar).pass_thru)
+
+    def test_sub_cmd_multiple_rejected(self):
+        class Foo(Command):
+            sub = SubCommand()
+            pt1 = PassThru()
+
+        class Bar(Foo):
+            pt2 = PassThru()
+
+        with self.assertRaisesRegex(CommandDefinitionError, 'it cannot follow another PassThru param'):
+            Bar.parse([])
+
+    def test_extra_rejected(self):
+        with Context():
+            pt = PassThru()
+            pt.action.add_values(['a'])
+            with self.assertRaises(ParamUsageError):
+                pt.action.add_values(['a'])
+
+    def test_usage(self):
+        self.assertEqual('[-- FOO]', PassThru(name='foo', required=False).formatter.format_basic_usage())
+        self.assertEqual('-- FOO', PassThru(name='foo', required=True).formatter.format_basic_usage())
+
+    # region Unsupported Kwargs
+
+    def test_nargs_not_allowed(self):
+        with self.assertRaises(TypeError):
+            PassThru(nargs='+')
+
+    def test_type_not_allowed(self):
+        with self.assertRaises(TypeError):
+            PassThru(type=int)
+
+    def test_choices_not_allowed(self):
+        with self.assertRaises(TypeError):
+            PassThru(choices=(1, 2))
+
+    def test_allow_leading_dash_not_allowed(self):
+        with self.assertRaises(TypeError):
+            PassThru(allow_leading_dash=True)
+
+    # endregion
+
+
+if __name__ == '__main__':
+    try:
+        main(verbosity=2, exit=False)
+    except KeyboardInterrupt:
+        print()

--- a/tests/test_parameters/test_positionals.py
+++ b/tests/test_parameters/test_positionals.py
@@ -1,12 +1,11 @@
 #!/usr/bin/env python
 
 from unittest import main
-from unittest.mock import Mock
 
 from cli_command_parser import Command, ParamGroup, SubCommand, Positional, Context
 from cli_command_parser.exceptions import ParameterDefinitionError, CommandDefinitionError, UsageError, TooManyArguments
-from cli_command_parser.parameters.base import parameter_action, BasePositional
 from cli_command_parser.testing import ParserTest
+from cli_command_parser.utils import _NotSet
 
 
 class PositionalTest(ParserTest):
@@ -17,13 +16,6 @@ class PositionalTest(ParserTest):
     def test_default_rejected(self):
         with self.assertRaises(ParameterDefinitionError):
             Positional(default=None)
-
-    def test_custom_default_rejected(self):
-        class CustomPositional(BasePositional):
-            foo = parameter_action(Mock())
-
-        with self.assertRaises(ParameterDefinitionError):
-            CustomPositional(default=None, action='foo')
 
     def test_nargs_0_rejected(self):
         with self.assertRaises(ParameterDefinitionError):
@@ -42,16 +34,21 @@ class PositionalTest(ParserTest):
         success_cases = [([], {'bar': []}), (['a'], {'bar': ['a']}), (['a', 'b'], {'bar': ['a', 'b']})]
         self.assert_parse_results_cases(Foo, success_cases)
 
-    def test_unbound_nargs_defaults(self):
-        for nargs in ('*', 'REMAINDER'):
-            for default in ('a', ['a']):
-                with self.subTest(nargs=nargs, default=default):
-
-                    class Foo(Command):
-                        bar = Positional(nargs=nargs, default=default)
-
-                    success_cases = [([], {'bar': ['a']}), (['b'], {'bar': ['b']}), (['a', 'b'], {'bar': ['a', 'b']})]
-                    self.assert_parse_results_cases(Foo, success_cases)
+    # def test_unbound_nargs_defaults(self):
+    #     for nargs in ('*', 'REMAINDER'):
+    #         for default in ('a', ['a']):
+    #             with self.subTest(nargs=nargs, default=default):
+    #
+    #                 class Foo(Command):
+    #                     # TODO: The default for this should be store, not append
+    #                     bar = Positional(nargs=nargs, default=default)
+    #
+    #                 success_cases = [
+    #                     ([], {'bar': ['a']}),
+    #                     (['b'], {'bar': ['b']}),
+    #                     (['a', 'b'], {'bar': ['a', 'b']}),
+    #                 ]
+    #                 self.assert_parse_results_cases(Foo, success_cases)
 
     def test_pos_after_unbound_nargs_rejected(self):
         exp_0 = 'it is a positional that is not required'
@@ -129,18 +126,17 @@ class PositionalTest(ParserTest):
                         bar = Positional(nargs='REMAINDER', allow_leading_dash=allow_leading_dash)
 
     def test_default_get_const(self):
-        self.assertIs(NotImplemented, Positional().get_const())
+        self.assertIs(_NotSet, Positional().get_const())
 
     def test_default_normalize_env_val(self):
-        value = '123456'
-        self.assertIs(value, Positional().normalize_env_var_value(value, ''))
+        self.assertEqual((_NotSet, False), Positional().get_env_const('123456', ''))
 
     def test_too_many_arguments(self):
         with Context():
             param = Positional(nargs=1, action='append')
-            param.append('foo')
-            with self.assertRaisesRegex(TooManyArguments, 'cannot accept any additional args with nargs='):
-                param.append('bar')
+            param.action.add_value('foo')
+            with self.assertRaisesRegex(TooManyArguments, 'cannot accept any additional args'):
+                param.action.add_value('bar')
 
 
 if __name__ == '__main__':

--- a/tests/test_parameters/test_positionals.py
+++ b/tests/test_parameters/test_positionals.py
@@ -60,7 +60,7 @@ class PositionalTest(ParserTest):
                     bar = Positional(nargs=nargs)
                     baz = Positional()
 
-                with self.assertRaisesRegex(CommandDefinitionError, pat):
+                with self.assert_raises_contains_str(CommandDefinitionError, pat):
                     Foo.parse([])
 
     def test_sub_cmd_pos_after_unbound_nargs_rejected(self):
@@ -76,7 +76,7 @@ class PositionalTest(ParserTest):
                 class Bar(Foo):
                     baz = Positional()
 
-                with self.assertRaisesRegex(CommandDefinitionError, pat):
+                with self.assert_raises_contains_str(CommandDefinitionError, pat):
                     Foo.parse(['bar'])
 
     def test_pos_after_non_required_sub_cmd_rejected(self):
@@ -84,7 +84,7 @@ class PositionalTest(ParserTest):
             sub = SubCommand(required=False)
             bar = Positional()
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'it is a positional that is not required'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'it is a positional that is not required'):
             Foo.parse([])
 
     def test_pos_grouped_pos_both_required(self):
@@ -105,13 +105,13 @@ class PositionalTest(ParserTest):
         self.assertIsNone(Foo.bar.type)  # noqa
 
     def test_type_with_remainder_rejected(self):
-        with self.assertRaisesRegex(ParameterDefinitionError, 'Type casting and choices are not supported'):
+        with self.assert_raises_contains_str(ParameterDefinitionError, 'Type casting and choices are not supported'):
 
             class Foo(Command):
                 bar = Positional(nargs='REMAINDER', type=int)
 
     def test_choices_with_remainder_rejected(self):
-        with self.assertRaisesRegex(ParameterDefinitionError, 'Type casting and choices are not supported'):
+        with self.assert_raises_contains_str(ParameterDefinitionError, 'Type casting and choices are not supported'):
 
             class Foo(Command):
                 bar = Positional(nargs='REMAINDER', choices=('a', 'b'))
@@ -120,7 +120,7 @@ class PositionalTest(ParserTest):
         expected = 'only allow_leading_dash=AllowLeadingDash.ALWAYS'
         for allow_leading_dash in ('numeric', False):
             with self.subTest(allow_leading_dash=allow_leading_dash):
-                with self.assertRaisesRegex(ParameterDefinitionError, expected):
+                with self.assert_raises_contains_str(ParameterDefinitionError, expected):
 
                     class Foo(Command):
                         bar = Positional(nargs='REMAINDER', allow_leading_dash=allow_leading_dash)
@@ -135,7 +135,7 @@ class PositionalTest(ParserTest):
         with Context():
             param = Positional(nargs=1, action='append')
             param.action.add_value('foo')
-            with self.assertRaisesRegex(TooManyArguments, 'cannot accept any additional args'):
+            with self.assert_raises_contains_str(TooManyArguments, 'cannot accept any additional args'):
                 param.action.add_value('bar')
 
 

--- a/tests/test_parameters/test_positionals.py
+++ b/tests/test_parameters/test_positionals.py
@@ -3,8 +3,8 @@
 from unittest import main
 from unittest.mock import Mock
 
-from cli_command_parser import Command, ParamGroup, SubCommand, Positional
-from cli_command_parser.exceptions import ParameterDefinitionError, CommandDefinitionError, UsageError
+from cli_command_parser import Command, ParamGroup, SubCommand, Positional, Context
+from cli_command_parser.exceptions import ParameterDefinitionError, CommandDefinitionError, UsageError, TooManyArguments
 from cli_command_parser.parameters.base import parameter_action, BasePositional
 from cli_command_parser.testing import ParserTest
 
@@ -127,6 +127,20 @@ class PositionalTest(ParserTest):
 
                     class Foo(Command):
                         bar = Positional(nargs='REMAINDER', allow_leading_dash=allow_leading_dash)
+
+    def test_default_get_const(self):
+        self.assertIs(NotImplemented, Positional().get_const())
+
+    def test_default_normalize_env_val(self):
+        value = '123456'
+        self.assertIs(value, Positional().normalize_env_var_value(value, ''))
+
+    def test_too_many_arguments(self):
+        with Context():
+            param = Positional(nargs=1, action='append')
+            param.append('foo')
+            with self.assertRaisesRegex(TooManyArguments, 'cannot accept any additional args with nargs='):
+                param.append('bar')
 
 
 if __name__ == '__main__':

--- a/tests/test_parsing/test_parse_flags.py
+++ b/tests/test_parsing/test_parse_flags.py
@@ -274,7 +274,7 @@ class ParseFlagsTest(ParserTest):
         class Foo(Command):
             bar = Flag('-b', env_var='BAR', strict_env=False)
 
-        with self.assertLogs('cli_command_parser.parameters.options', 'WARNING'):
+        with self.assertLogs('cli_command_parser.parser', 'WARNING'):
             self.assert_env_parse_results(Foo, [], {'BAR': 'foo'}, {'bar': False})
 
     def test_non_default_const_stored_from_env_var(self):
@@ -356,13 +356,6 @@ class ParseFlagsTest(ParserTest):
 
 
 class ParseTriFlagsTest(ParserTest):
-    def test_tri_flag_rejects_value(self):
-        class Foo(Command):
-            bar = TriFlag('-b', alt_short='-B')
-
-        with Foo().ctx, self.assertRaises(UsageError):
-            Foo.bar.take_action('foo')
-
     def test_alt_opt_mutual_exclusivity(self):
         class Foo(Command):
             bar = TriFlag('-b', alt_short='-B')

--- a/tests/test_parsing/test_parse_flags.py
+++ b/tests/test_parsing/test_parse_flags.py
@@ -223,6 +223,12 @@ class ParseFlagsTest(ParserTest):
         self.assert_parse_results_cases(Foo, success_cases)
         self.assert_parse_fails(Foo, ['-baz'])
 
+    def test_append_const_value_rejected(self):
+        class Foo(Command):
+            bar = Flag('-b', action='append_const')
+
+        self.assert_parse_fails(Foo, ['-b=123'])
+
     # region Env Var Handling
 
     def test_env_var(self):

--- a/tests/test_parsing/test_parse_flags.py
+++ b/tests/test_parsing/test_parse_flags.py
@@ -39,7 +39,7 @@ class ParseFlagsTest(ParserTest):
             de = Flag('-de')
 
         exp_pat = "part of argument='-abc' may match multiple parameters: --a / -a, --ab / -ab, --b / -b"
-        with self.assertRaisesRegex(AmbiguousCombo, exp_pat):
+        with self.assert_raises_contains_str(AmbiguousCombo, exp_pat):
             Foo.parse(['-abc'])
 
     def test_combined_flags_ambiguous(self):
@@ -101,7 +101,7 @@ class ParseFlagsTest(ParserTest):
             'Ambiguous short form for --abc / -abc - it conflicts with: --a / -a, --b / -b, --c / -c\n'
             'Ambiguous short form for --bc / -bc - it conflicts with: --b / -b, --c / -c'
         )
-        with self.assertRaisesRegex(AmbiguousShortForm, exp_error_pat):
+        with self.assert_raises_contains_str(AmbiguousShortForm, exp_error_pat):
             get_params(Foo)
 
     def test_combined_flags_ambiguous_strict_parsing(self):

--- a/tests/test_parsing/test_parse_flags.py
+++ b/tests/test_parsing/test_parse_flags.py
@@ -352,6 +352,18 @@ class ParseFlagsTest(ParserTest):
                 with self.assertRaisesRegex(BadArgument, 'invalid value=.*? from env_var='):
                     Foo.parse([])
 
+    def test_env_var_append_const(self):
+        class Foo(Command):
+            bar = Flag('-b', env_var='BAR', action='append_const', use_env_value=True)
+
+        cases = [
+            ([], {}, {'bar': []}),
+            (['-b'], {'BAR': '0'}, {'bar': [True]}),  # cli takes precedence
+            ([], {'BAR': '1'}, {'bar': [True]}),
+            ([], {'BAR': '0'}, {'bar': [False]}),
+        ]
+        self.assert_env_parse_results_cases(Foo, cases)
+
     # endregion
 
 

--- a/tests/test_parsing/test_parse_options.py
+++ b/tests/test_parsing/test_parse_options.py
@@ -2,11 +2,11 @@
 
 from unittest import main
 
-from cli_command_parser import Command, Option, Flag, Positional, SubCommand, REMAINDER, BaseOption, ctx
+from cli_command_parser import Command, Option, Flag, Positional, SubCommand, REMAINDER, BaseOption
 from cli_command_parser.core import CommandMeta
 from cli_command_parser.exceptions import UsageError, NoSuchOption, MissingArgument, AmbiguousShortForm, AmbiguousCombo
 from cli_command_parser.nargs import Nargs
-from cli_command_parser.parameters.base import parameter_action
+from cli_command_parser.parameters.actions import Store
 from cli_command_parser.testing import ParserTest
 
 get_config = CommandMeta.config
@@ -151,14 +151,10 @@ class OptionTest(ParserTest):
         self.assert_parse_fails_cases(Foo, fail_cases)
 
     def test_nargs_question(self):
-        class CustomOption(BaseOption):
+        class CustomOption(BaseOption, actions=(Store,)):
             def __init__(self, *args, **kwargs):
                 super().__init__(*args, action='store', **kwargs)
                 self.nargs = Nargs('?')
-
-            @parameter_action
-            def store(self, value):
-                ctx.set_parsed_value(self, value)
 
         class Foo(Command):
             bar = CustomOption('-b')
@@ -216,9 +212,9 @@ class OptionTest(ParserTest):
     def test_defaults_with_nargs_multi(self):
         success_cases = [
             ([], {'bar': [1]}),
-            (['-b', '2'], {'bar': [2]}),
-            (['-b=2'], {'bar': [2]}),
-            (['--bar', '2', '3'], {'bar': [2, 3]}),
+            (['-b', '2'], {'bar': [1, 2]}),
+            (['-b=2'], {'bar': [1, 2]}),
+            (['--bar', '2', '3'], {'bar': [1, 2, 3]}),
         ]
         fail_cases = [
             ['-b=2', '3'],  # argparse also rejects this

--- a/tests/test_parsing/test_parse_options.py
+++ b/tests/test_parsing/test_parse_options.py
@@ -272,6 +272,41 @@ class OptionTest(ParserTest):
         fail_cases = [['-b']]
         self.assert_argv_parse_fails_cases(Foo, fail_cases)
 
+    def test_append_strict_default(self):
+        default = {'xyz': 'abc'}
+
+        class Foo(Command):
+            bar = Option('-b', nargs='+', action='append', default=default)
+            baz = Option('-B', nargs='+', action='append', default=default, strict_default=True)
+
+        success_cases = [
+            ([], {'bar': ['xyz'], 'baz': default}),
+            (['-b', 'a'], {'bar': ['xyz', 'a'], 'baz': default}),
+            (['-b', 'a', '-b', 'b'], {'bar': ['xyz', 'a', 'b'], 'baz': default}),
+            (['-b', 'a', 'b'], {'bar': ['xyz', 'a', 'b'], 'baz': default}),
+        ]
+        self.assert_parse_results_cases(Foo, success_cases)
+        fail_cases = [
+            (['-B'], UsageError),
+            (['-b'], UsageError),
+            (['-B', 'a'], AttributeError, "'dict' object has no attribute 'append'"),
+        ]
+        self.assert_parse_fails_cases(Foo, fail_cases)
+
+    def test_append_fix_str_to_range(self):
+        class Foo(Command):
+            bar = Option('-b', type=range(10), nargs='+', action='append', default='5')
+
+        success_cases = [
+            ([], {'bar': [5]}),
+            (['-b', '1'], {'bar': [5, 1]}),
+            (['-b', '1', '-b', '2'], {'bar': [5, 1, 2]}),
+            (['-b', '1', '2'], {'bar': [5, 1, 2]}),
+        ]
+        self.assert_parse_results_cases(Foo, success_cases)
+        fail_cases = [['-b'], ['-b', 'a']]
+        self.assert_argv_parse_fails_cases(Foo, fail_cases)
+
 
 if __name__ == '__main__':
     # import logging

--- a/tests/test_parsing/test_parse_param_combos.py
+++ b/tests/test_parsing/test_parse_param_combos.py
@@ -237,7 +237,7 @@ class ParseParamsWithSubcommandsTest(ParserTest):
             sub = SubCommand()
             pre = Positional()
 
-        with self.assertRaisesRegex(CommandDefinitionError, 'has no sub Commands'):
+        with self.assert_raises_contains_str(CommandDefinitionError, 'has no sub Commands'):
             Cmd.parse([])
 
     def test_positional_nargs_star_after_local_choices(self):

--- a/tests/test_parsing/test_parse_param_combos.py
+++ b/tests/test_parsing/test_parse_param_combos.py
@@ -30,7 +30,7 @@ class ParamComboTest(ParserTest):
             bar = Option(nargs=2)
             baz = Positional()
 
-        self.assertEqual('append', Foo.bar._action_name)
+        self.assertEqual('append', Foo.bar.action.name)
         success_cases = [
             (['--bar', 'a', 'b', 'c'], {'bar': ['a', 'b'], 'baz': 'c'}),
             (['c', '--bar', 'a', 'b'], {'bar': ['a', 'b'], 'baz': 'c'}),

--- a/tests/test_parsing/test_parse_param_combos.py
+++ b/tests/test_parsing/test_parse_param_combos.py
@@ -30,7 +30,7 @@ class ParamComboTest(ParserTest):
             bar = Option(nargs=2)
             baz = Positional()
 
-        self.assertEqual('append', Foo.bar.action)
+        self.assertEqual('append', Foo.bar._action_name)
         success_cases = [
             (['--bar', 'a', 'b', 'c'], {'bar': ['a', 'b'], 'baz': 'c'}),
             (['c', '--bar', 'a', 'b'], {'bar': ['a', 'b'], 'baz': 'c'}),

--- a/tests/test_parsing/test_parse_pass_thru.py
+++ b/tests/test_parsing/test_parse_pass_thru.py
@@ -27,13 +27,11 @@ class PassThruTest(ParserTest):
         self.assert_parse_fails(Foo, ['bar', 'a', '--', 'x'], NoSuchOption)
 
     def test_required_pass_thru(self):
-        class Foo(Command):
+        class Foo(Command, add_help=False):
             bar = PassThru(required=True)
 
-        success_cases = [
-            (['--', 'a', 'b'], {'bar': ['a', 'b']}),
-            (['--'], {'bar': []}),
-        ]
+        self.assertEqual({'bar': 123}, Foo().ctx.get_parsed(default=123))
+        success_cases = [(['--', 'a', 'b'], {'bar': ['a', 'b']}), (['--'], {'bar': []})]
         self.assert_parse_results_cases(Foo, success_cases)
         self.assert_parse_fails(Foo, [], ParamsMissing)
 

--- a/tests/test_parsing/test_parse_positionals.py
+++ b/tests/test_parsing/test_parse_positionals.py
@@ -33,7 +33,7 @@ class PositionalTest(ParserTest):
             bar = Positional(nargs=2)
             baz = Positional()
 
-        self.assertEqual('append', Foo.bar.action)
+        self.assertEqual('append', Foo.bar._action_name)
         self.assert_parse_results(Foo, ['a', 'b', 'c'], {'bar': ['a', 'b'], 'baz': 'c'})
         fail_cases = [[], ['a', 'b', 'c', 'd'], ['a', 'b']]
         self.assert_parse_fails_cases(Foo, fail_cases, UsageError)

--- a/tests/test_parsing/test_parse_positionals.py
+++ b/tests/test_parsing/test_parse_positionals.py
@@ -33,7 +33,7 @@ class PositionalTest(ParserTest):
             bar = Positional(nargs=2)
             baz = Positional()
 
-        self.assertEqual('append', Foo.bar._action_name)
+        self.assertEqual('append', Foo.bar.action.name)
         self.assert_parse_results(Foo, ['a', 'b', 'c'], {'bar': ['a', 'b'], 'baz': 'c'})
         fail_cases = [[], ['a', 'b', 'c', 'd'], ['a', 'b']]
         self.assert_parse_fails_cases(Foo, fail_cases, UsageError)

--- a/tests/test_parsing/test_parse_positionals.py
+++ b/tests/test_parsing/test_parse_positionals.py
@@ -289,16 +289,15 @@ class NargsParsingTest(ParserTest):
         for n in range(1, 4):
 
             class Foo(Command):
-                foo = Positional(nargs=n)
+                foo = Positional(nargs=n, action='append')
                 bar = Option(nargs='+')
 
             foo = ['a'] * n
-            exp = 'a' if n == 1 else foo
             success_cases = [
-                ([*foo, '--bar', 'w', 'x'], {'foo': exp, 'bar': ['w', 'x']}),
-                ([*foo, '--bar', 'w', 'x', 'y', 'z'], {'foo': exp, 'bar': ['w', 'x', 'y', 'z']}),
-                (['--bar', 'w', 'x', *foo], {'foo': exp, 'bar': ['w', 'x']}),
-                (['--bar', 'w', 'x', 'y', 'z', *foo], {'foo': exp, 'bar': ['w', 'x', 'y', 'z']}),
+                ([*foo, '--bar', 'w', 'x'], {'foo': foo, 'bar': ['w', 'x']}),
+                ([*foo, '--bar', 'w', 'x', 'y', 'z'], {'foo': foo, 'bar': ['w', 'x', 'y', 'z']}),
+                (['--bar', 'w', 'x', *foo], {'foo': foo, 'bar': ['w', 'x']}),
+                (['--bar', 'w', 'x', 'y', 'z', *foo], {'foo': foo, 'bar': ['w', 'x', 'y', 'z']}),
             ]
             self.assert_parse_results_cases(Foo, success_cases)
 

--- a/tests/test_parsing/test_parse_tree.py
+++ b/tests/test_parsing/test_parse_tree.py
@@ -251,7 +251,7 @@ class ParseTreeTestBad(ParserTest):
         class ShowFooBar(Show, choice='foo bar'):
             pass
 
-        with self.assertRaisesRegex(AmbiguousParseTree, 'Conflicting targets'):
+        with self.assert_raises_contains_str(AmbiguousParseTree, 'Conflicting targets'):
             Show.parse([])
 
         get_config(Show).reject_ambiguous_pos_combos = False
@@ -267,7 +267,7 @@ class ParseTreeTestBad(ParserTest):
         class ShowFooBar(Show, choice='foo bar'):
             pass
 
-        with self.assertRaisesRegex(AmbiguousParseTree, 'Conflicting choices'):
+        with self.assert_raises_contains_str(AmbiguousParseTree, 'Conflicting choices'):
             Show.parse([])
 
     def test_overlap_deep_choice_conflict_bad(self):


### PR DESCRIPTION
This change dramatically changes the way that Parameters' actions are handled internally.  Specific Parameter types are no longer as closely coupled with the actions that they can handle / support.  This opens the door for more easily adding `StoreValueOrConst` support to `Option` in the near future, for example.

This change should also make it easier to implement a planned future refactor of how nargs / actions interact to bring the behavior a bit closer to argparse's (specifically related to `store` vs `append`, since using any `nargs` values besides `1` or `'?'` currently results in switching to `append` instead of always using `store` unless otherwise specified).

**Potentially breaking changes**:
- The allowed value(s) for the `action` keyword-only param for some Parameters changed (they were the default, and only supported values, anyways):
    - `Counter`: `'append'` -> `'count'`
    - `SubCommand` and `Action`: `'append'` -> `'concatenate'`
- Some methods / attributes of multiple Parameter classes were removed, renamed, or dramatically changed
- The behavior of some `Context` methods used during parsing (that already had docstrings saying they were not intended to be called by users) was changed

While the above may potentially cause breakage, they are all relatively minor, and are unlikely to be noticed in practice.

Other changes in this PR:
- Some minor documentation fixes / additions
- Some minor performance improvements
    - Most improvements in this area are at a scale that are only really noticeable during testing, where hundreds of Commands and sets of arguments are parsed in a short period of time.  Running all unit tests with coverage completes in < 1 second.
- Improved some error messages related to invalid `action` values to provide hints about what to use instead
