### PR TITLE
Improved nargs=+ metavar and --option=value parsing

### DIFF
--- a/examples/complex/shared_params.py
+++ b/examples/complex/shared_params.py
@@ -26,7 +26,7 @@ class Update(Example):
     item_type = SubCommand(local_choices=('foo', 'bar'), help='The type of item to update')
     dry_run = Flag('-D', help='Print the actions that would be taken instead of taking them')
     with ParamGroup(mutually_exclusive=True):
-        ids = Option('-i', nargs='+', help='The IDs of the item to update')
+        ids = Option('-i', metavar='ID', nargs='+', help='The IDs of the item to update')
         all = Flag('-A', help='Update all items')
     with ParamGroup('Common Fields'):
         name = Option('-n', help='The new name for the specified item(s)')
@@ -79,8 +79,8 @@ class UpdateUser(UpdateUserOrGroup, choice='user'):
 
 
 class UpdateGroup(UpdateUserOrGroup, choice='group'):
-    add = Option('-a', nargs='+', help='Members to add')
-    remove = Option('-r', nargs='+', help='Members to remove')
+    add = Option('-a', metavar='MEMBER', nargs='+', help='Members to add')
+    remove = Option('-r', metavar='MEMBER', nargs='+', help='Members to remove')
 
     def get_updates(self):
         updates = super().get_updates()

--- a/examples/rest_api_wrapper.py
+++ b/examples/rest_api_wrapper.py
@@ -23,7 +23,7 @@ class ApiWrapper(Command):
 
 class Show(ApiWrapper, help='Show an object'):
     type = Positional(choices=('foo', 'bar', 'baz'), help='The type of object to show')
-    ids = Option('-i', nargs='+', help='The IDs of the objects to show')
+    ids = Option('-i', metavar='ID', nargs='+', help='The IDs of the objects to show')
 
     def main(self):
         log.info(f'Would show {self.type} objects: {self.ids}')

--- a/lib/cli_command_parser/command_parameters.py
+++ b/lib/cli_command_parser/command_parameters.py
@@ -355,11 +355,13 @@ class CommandParameters:
 
     # region Option Processing
 
-    def short_option_to_param_value_pairs(self, option: str) -> List[Tuple[str, BaseOption, Optional[str]]]:
+    def short_option_to_param_value_pairs(
+        self, option: str
+    ) -> Tuple[List[Tuple[str, BaseOption, Optional[str]]], bool]:
         option, eq, value = option.partition('=')
         if eq:  # An `=` was present in the string
             # Note: if the option is not in this Command's option_map, the KeyError is handled by CommandParser
-            return [(option, self.option_map[option], value)]
+            return [(option, self.option_map[option], value)], True
         else:
             value = None
 
@@ -370,16 +372,16 @@ class CommandParameters:
             if opt_len < 2 or (opt_len > 2 and self._is_combo_potentially_ambiguous(option)):
                 raise
         else:
-            return [(option, param, value)]
+            return [(option, param, value)], False
 
         key, value = option[1], option[2:]
         # value will never be empty if key is a valid option because by this point, option is not a short option
         param = self.combo_option_map[key]
         if param.action.would_accept(value, combo=True):
-            return [(key, param, value)]
+            return [(key, param, value)], False
         else:
             # Multi-char short options can never be combined with each other, but single-char ones can
-            return [(c, self.combo_option_map[c], None) for c in option[1:]]
+            return [(c, self.combo_option_map[c], None) for c in option[1:]], False
 
     # endregion
 

--- a/lib/cli_command_parser/formatting/commands.py
+++ b/lib/cli_command_parser/formatting/commands.py
@@ -59,6 +59,8 @@ class CommandHelpFormatter:
         self.pos_group.extend(param for param in params if not param.group)
 
     def maybe_add_options(self, params: Iterable[BaseOption]):
+        # TODO: It would be good for required options' default group to indicate they are required, instead of the
+        #  default group saying "Optional"
         self.opt_group.extend(param for param in params if not param.group)
 
     def _iter_params(self) -> Iterator[Union[BasePositional, BaseOption, PassThru]]:

--- a/lib/cli_command_parser/parameters/base.py
+++ b/lib/cli_command_parser/parameters/base.py
@@ -293,11 +293,11 @@ class Parameter(ParamBase, Generic[T_co], ABC):
         except Exception as e:
             raise BadArgument(self, f'unable to cast {value=} to type={type_func!r}') from e
 
-    def validate(self, value: Optional[T_co]):
+    def validate(self, value: Optional[T_co], joined: Bool = False):
         if not isinstance(value, str) or not value or not value[0] == '-':
             return
         elif self.allow_leading_dash == AllowLeadingDash.NUMERIC:
-            if len(value) > 1 and not _is_numeric(value):
+            if not joined and len(value) > 1 and not _is_numeric(value):
                 raise BadArgument(self, f'invalid {value=}')
         elif self.allow_leading_dash == AllowLeadingDash.NEVER:
             raise BadArgument(self, f'invalid {value=}')

--- a/lib/cli_command_parser/parameters/choice_map.py
+++ b/lib/cli_command_parser/parameters/choice_map.py
@@ -150,7 +150,7 @@ class ChoiceMap(BasePositional[str], Generic[T], actions=(Concatenate,)):
 
     # region Argument Handling
 
-    def validate(self, value: str):
+    def validate(self, value: str, joined: Bool = False):
         if not (choices := self.choices):
             self._no_choices_error()
 

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -481,7 +481,7 @@ class Counter(BaseOption[int], actions=(Count,)):
                 return len(value) + 1  # +1 for the -short that preceded this value
             raise BadArgument(self, f'bad counter {value=}') from e
 
-    def validate(self, value: Any):
+    def validate(self, value: Any, joined: Bool = False):
         if value is None or isinstance(value, self.type):
             return
         try:

--- a/tests/data/test_examples_documentation/complex__all.rst
+++ b/tests/data/test_examples_documentation/complex__all.rst
@@ -104,7 +104,7 @@ Subcommand: update
 
 ::
 
-    usage: complex_example.py update {foo|bar|user|group} [--verbose [VERBOSE]] [--help] [--dry-run] [--ids IDS] [--all] [--name NAME] [--description DESCRIPTION]
+    usage: complex_example.py update {foo|bar|user|group} [--verbose [VERBOSE]] [--help] [--dry-run] [--ids ID [ID ...]] [--all] [--name NAME] [--description DESCRIPTION]
 
 
 
@@ -160,11 +160,11 @@ Subcommand: update
 .. table::
     :widths: auto
 
-    +---------------------------+-------------------------------+
-    | ``--ids IDS``, ``-i IDS`` | The IDs of the item to update |
-    +---------------------------+-------------------------------+
-    | ``--all``, ``-A``         | Update all items              |
-    +---------------------------+-------------------------------+
+    +-------------------------------------------+-------------------------------+
+    | ``--ids ID [ID ...]``, ``-i ID [ID ...]`` | The IDs of the item to update |
+    +-------------------------------------------+-------------------------------+
+    | ``--all``, ``-A``                         | Update all items              |
+    +-------------------------------------------+-------------------------------+
 
 
 Subcommand: update foo
@@ -172,7 +172,7 @@ Subcommand: update foo
 
 ::
 
-    usage: complex_example.py update foo {foo|bar|user|group} [--verbose [VERBOSE]] [--help] [--dry-run] [--ids IDS] [--all] [--name NAME] [--description DESCRIPTION]
+    usage: complex_example.py update foo {foo|bar|user|group} [--verbose [VERBOSE]] [--help] [--dry-run] [--ids ID [ID ...]] [--all] [--name NAME] [--description DESCRIPTION]
 
 
 
@@ -228,11 +228,11 @@ Subcommand: update foo
 .. table::
     :widths: auto
 
-    +---------------------------+-------------------------------+
-    | ``--ids IDS``, ``-i IDS`` | The IDs of the item to update |
-    +---------------------------+-------------------------------+
-    | ``--all``, ``-A``         | Update all items              |
-    +---------------------------+-------------------------------+
+    +-------------------------------------------+-------------------------------+
+    | ``--ids ID [ID ...]``, ``-i ID [ID ...]`` | The IDs of the item to update |
+    +-------------------------------------------+-------------------------------+
+    | ``--all``, ``-A``                         | Update all items              |
+    +-------------------------------------------+-------------------------------+
 
 
 Subcommand: update bar
@@ -240,7 +240,7 @@ Subcommand: update bar
 
 ::
 
-    usage: complex_example.py update bar {foo|bar|user|group} [--verbose [VERBOSE]] [--help] [--dry-run] [--ids IDS] [--all] [--name NAME] [--description DESCRIPTION]
+    usage: complex_example.py update bar {foo|bar|user|group} [--verbose [VERBOSE]] [--help] [--dry-run] [--ids ID [ID ...]] [--all] [--name NAME] [--description DESCRIPTION]
 
 
 
@@ -296,11 +296,11 @@ Subcommand: update bar
 .. table::
     :widths: auto
 
-    +---------------------------+-------------------------------+
-    | ``--ids IDS``, ``-i IDS`` | The IDs of the item to update |
-    +---------------------------+-------------------------------+
-    | ``--all``, ``-A``         | Update all items              |
-    +---------------------------+-------------------------------+
+    +-------------------------------------------+-------------------------------+
+    | ``--ids ID [ID ...]``, ``-i ID [ID ...]`` | The IDs of the item to update |
+    +-------------------------------------------+-------------------------------+
+    | ``--all``, ``-A``                         | Update all items              |
+    +-------------------------------------------+-------------------------------+
 
 
 Subcommand: update user
@@ -308,7 +308,7 @@ Subcommand: update user
 
 ::
 
-    usage: complex_example.py update user [--verbose [VERBOSE]] [--help] [--dry-run] [--ids IDS] [--all] [--name NAME] [--description DESCRIPTION] [--location LOCATION] [--role {admin|user}]
+    usage: complex_example.py update user [--verbose [VERBOSE]] [--help] [--dry-run] [--ids ID [ID ...]] [--all] [--name NAME] [--description DESCRIPTION] [--location LOCATION] [--role {admin|user}]
 
 
 
@@ -347,11 +347,11 @@ Subcommand: update user
 .. table::
     :widths: auto
 
-    +---------------------------+-------------------------------+
-    | ``--ids IDS``, ``-i IDS`` | The IDs of the item to update |
-    +---------------------------+-------------------------------+
-    | ``--all``, ``-A``         | Update all items              |
-    +---------------------------+-------------------------------+
+    +-------------------------------------------+-------------------------------+
+    | ``--ids ID [ID ...]``, ``-i ID [ID ...]`` | The IDs of the item to update |
+    +-------------------------------------------+-------------------------------+
+    | ``--all``, ``-A``                         | Update all items              |
+    +-------------------------------------------+-------------------------------+
 
 
 Subcommand: update group
@@ -359,7 +359,7 @@ Subcommand: update group
 
 ::
 
-    usage: complex_example.py update group [--verbose [VERBOSE]] [--help] [--dry-run] [--ids IDS] [--all] [--name NAME] [--description DESCRIPTION] [--location LOCATION] [--add ADD] [--remove REMOVE]
+    usage: complex_example.py update group [--verbose [VERBOSE]] [--help] [--dry-run] [--ids ID [ID ...]] [--all] [--name NAME] [--description DESCRIPTION] [--location LOCATION] [--add MEMBER [MEMBER ...]] [--remove MEMBER [MEMBER ...]]
 
 
 
@@ -368,19 +368,19 @@ Subcommand: update group
 .. table::
     :widths: auto
 
-    +-------------------------------------------+--------------------------------------------------------------------------+
-    | ``--verbose [VERBOSE]``, ``-v [VERBOSE]`` | Increase logging verbosity (can specify multiple times) (default: ``0``) |
-    +-------------------------------------------+--------------------------------------------------------------------------+
-    | ``--help``, ``-h``                        | Show this help message and exit                                          |
-    +-------------------------------------------+--------------------------------------------------------------------------+
-    | ``--dry-run``, ``-D``                     | Print the actions that would be taken instead of taking them             |
-    +-------------------------------------------+--------------------------------------------------------------------------+
-    | ``--location LOCATION``, ``-L LOCATION``  | The new location for the specified item(s)                               |
-    +-------------------------------------------+--------------------------------------------------------------------------+
-    | ``--add ADD``, ``-a ADD``                 | Members to add                                                           |
-    +-------------------------------------------+--------------------------------------------------------------------------+
-    | ``--remove REMOVE``, ``-r REMOVE``        | Members to remove                                                        |
-    +-------------------------------------------+--------------------------------------------------------------------------+
+    +--------------------------------------------------------------+--------------------------------------------------------------------------+
+    | ``--verbose [VERBOSE]``, ``-v [VERBOSE]``                    | Increase logging verbosity (can specify multiple times) (default: ``0``) |
+    +--------------------------------------------------------------+--------------------------------------------------------------------------+
+    | ``--help``, ``-h``                                           | Show this help message and exit                                          |
+    +--------------------------------------------------------------+--------------------------------------------------------------------------+
+    | ``--dry-run``, ``-D``                                        | Print the actions that would be taken instead of taking them             |
+    +--------------------------------------------------------------+--------------------------------------------------------------------------+
+    | ``--location LOCATION``, ``-L LOCATION``                     | The new location for the specified item(s)                               |
+    +--------------------------------------------------------------+--------------------------------------------------------------------------+
+    | ``--add MEMBER [MEMBER ...]``, ``-a MEMBER [MEMBER ...]``    | Members to add                                                           |
+    +--------------------------------------------------------------+--------------------------------------------------------------------------+
+    | ``--remove MEMBER [MEMBER ...]``, ``-r MEMBER [MEMBER ...]`` | Members to remove                                                        |
+    +--------------------------------------------------------------+--------------------------------------------------------------------------+
 
 
 .. rubric:: Common Fields options
@@ -400,8 +400,8 @@ Subcommand: update group
 .. table::
     :widths: auto
 
-    +---------------------------+-------------------------------+
-    | ``--ids IDS``, ``-i IDS`` | The IDs of the item to update |
-    +---------------------------+-------------------------------+
-    | ``--all``, ``-A``         | Update all items              |
-    +---------------------------+-------------------------------+
+    +-------------------------------------------+-------------------------------+
+    | ``--ids ID [ID ...]``, ``-i ID [ID ...]`` | The IDs of the item to update |
+    +-------------------------------------------+-------------------------------+
+    | ``--all``, ``-A``                         | Update all items              |
+    +-------------------------------------------+-------------------------------+

--- a/tests/data/test_examples_documentation/complex__depth_1.rst
+++ b/tests/data/test_examples_documentation/complex__depth_1.rst
@@ -104,7 +104,7 @@ Subcommand: update
 
 ::
 
-    usage: complex_example.py update {foo|bar|user|group} [--verbose [VERBOSE]] [--help] [--dry-run] [--ids IDS] [--all] [--name NAME] [--description DESCRIPTION]
+    usage: complex_example.py update {foo|bar|user|group} [--verbose [VERBOSE]] [--help] [--dry-run] [--ids ID [ID ...]] [--all] [--name NAME] [--description DESCRIPTION]
 
 
 
@@ -160,8 +160,8 @@ Subcommand: update
 .. table::
     :widths: auto
 
-    +---------------------------+-------------------------------+
-    | ``--ids IDS``, ``-i IDS`` | The IDs of the item to update |
-    +---------------------------+-------------------------------+
-    | ``--all``, ``-A``         | Update all items              |
-    +---------------------------+-------------------------------+
+    +-------------------------------------------+-------------------------------+
+    | ``--ids ID [ID ...]``, ``-i ID [ID ...]`` | The IDs of the item to update |
+    +-------------------------------------------+-------------------------------+
+    | ``--all``, ``-A``                         | Update all items              |
+    +-------------------------------------------+-------------------------------+

--- a/tests/data/test_examples_documentation/complex_update_help.txt
+++ b/tests/data/test_examples_documentation/complex_update_help.txt
@@ -1,4 +1,4 @@
-usage: complex_example.py update {foo|bar|user|group} [--verbose [VERBOSE]] [--help] [--dry-run] [--ids IDS] [--all] [--name NAME] [--description DESCRIPTION]
+usage: complex_example.py update {foo|bar|user|group} [--verbose [VERBOSE]] [--help] [--dry-run] [--ids ID [ID ...]] [--all] [--name NAME] [--description DESCRIPTION]
 
 │ Subcommands:
 │ {foo|bar|user|group}
@@ -20,6 +20,7 @@ Common Fields options:
 │                           The new description to use for the specified item(s)
 │
 Mutually exclusive options:
-¦ --ids IDS, -i IDS         The IDs of the item to update
+¦ --ids ID [ID ...], -i ID [ID ...]
+¦                           The IDs of the item to update
 ¦ --all, -A                 Update all items
 ¦

--- a/tests/data/test_examples_documentation/rest_api_wrapper__show.txt
+++ b/tests/data/test_examples_documentation/rest_api_wrapper__show.txt
@@ -1,11 +1,12 @@
-usage: rest_api_wrapper.py show {foo|bar|baz} [--verbose [VERBOSE]] [--env {dev|qa|uat|prod}] [--help] [--ids IDS]
+usage: rest_api_wrapper.py show {foo|bar|baz} [--verbose [VERBOSE]] [--env {dev|qa|uat|prod}] [--help] [--ids ID [ID ...]]
 
 Positional arguments:
   {foo|bar|baz}               The type of object to show
 
 Optional arguments:
   --help, -h                  Show this help message and exit
-  --ids IDS, -i IDS           The IDs of the objects to show
+  --ids ID [ID ...], -i ID [ID ...]
+                              The IDs of the objects to show
 
 Common options:
   --verbose [VERBOSE], -v [VERBOSE]

--- a/tests/test_commands/test_param_registry.py
+++ b/tests/test_commands/test_param_registry.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 from abc import ABC
-from unittest import TestCase, main
+from unittest import main
 from unittest.mock import Mock
 
 from cli_command_parser import Command

--- a/tests/test_documentation/test_help_text.py
+++ b/tests/test_documentation/test_help_text.py
@@ -173,6 +173,18 @@ usage: foo_bar.py [--abcdef ABCDEF] [--ghijkl
     [--yz YZ]"""
         self.assert_strings_equal(expected, get_usage_text(Foo))
 
+    def test_nargs_plus_usage(self):
+        class Foo(Command, prog='foo.py'):
+            bar = Option(nargs='+')
+
+        self.assert_strings_equal('usage: foo.py [--bar BAR [BAR ...]] [--help]', get_usage_text(Foo))
+
+    # def test_nargs_star_usage(self):
+    #     class Foo(Command, prog='foo.py'):
+    #         bar = Option(nargs='*')
+    #
+    #     self.assert_strings_equal('usage: foo.py [--bar [BAR ...]] [--help]', get_usage_text(Foo))
+
 
 class HelpTextTest(ParserTest):
     def test_custom_choice_map(self):

--- a/tests/test_parsing/test_parse_options.py
+++ b/tests/test_parsing/test_parse_options.py
@@ -30,14 +30,13 @@ class OptionTest(ParserTest):
 
     def test_eq_with_eq_in_value(self):
         class Foo(Command):
-            bar = Option('-b', allow_leading_dash=True)
+            bar = Option('-b')
 
         success_cases = [
             (['-b', 'a=b'], {'bar': 'a=b'}),
             (['-b=a=b'], {'bar': 'a=b'}),
             (['--bar', 'a=b'], {'bar': 'a=b'}),
             (['--bar=a=b'], {'bar': 'a=b'}),
-            # TODO: Should allow_leading_dash really be necessary for the following case?
             (['--bar=--baz=abc'], {'bar': '--baz=abc'}),
         ]
         self.assert_parse_results_cases(Foo, success_cases)


### PR DESCRIPTION
- When an Option has `nargs='+'`, now the metavar in usage / help text will indicate that additional values are accepted.
- Parsing is now more permissive about value prefixes when an `--option=value` argument is provided
