### PR TITLE
Improved help text for required options & improved get_parsed

### DIFF
--- a/lib/cli_command_parser/commands.py
+++ b/lib/cli_command_parser/commands.py
@@ -166,6 +166,8 @@ class Command(ABC, metaclass=CommandMeta):
         :param args: Positional arguments to pass to the :obj:`~.options.action_flag` methods
         :param kwargs: Keyword arguments to pass to the :obj:`~.options.action_flag` methods
         """
+        # TODO: --help should take precedence over input validation - right now, if a Path input expecting a
+        #  non-existent file receives a file that exists, that error is reported instead of showing help text
         ctx = self.__ctx
         n_flags = ctx.action_flag_count
         if n_flags and not ctx.config.multiple_action_flags and n_flags > 1:

--- a/lib/cli_command_parser/formatting/params.py
+++ b/lib/cli_command_parser/formatting/params.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 from functools import cached_property
 from typing import TYPE_CHECKING, Type, Callable, Iterator, Iterable, Tuple, Dict
 
-from ..config import SubcommandAliasHelpMode
+from ..config import SubcommandAliasHelpMode, CmdAliasMode
 from ..context import ctx
 from ..core import get_config
 from ..parameters.base import BasePositional, BaseOption
@@ -304,9 +304,10 @@ class ChoiceGroup:
         if choice_str := choice.choice:
             self.choice_strs.append(choice_str)
 
-    def format(self, default_mode: SubcommandAliasHelpMode, tw_offset: int = 0, prefix: str = '') -> Iterator[str]:
+    def format(self, default_mode: CmdAliasMode, tw_offset: int = 0, prefix: str = '') -> Iterator[str]:
         """
-        :param default_mode: The default :class:`.SubcommandAliasHelpMode` to use if no mode was explicitly configured.
+        :param default_mode: The default :class:`.SubcommandAliasHelpMode` to use if no mode was explicitly configured,
+          or the format string to use for subcommand aliases.
         :param tw_offset: Terminal width offset for text width calculations.
         :param prefix: Prefix to add to every line (primarily intended for use with nested groups).
         :return: Generator that yields formatted help text entries (strings) for the Choices in this group.
@@ -314,12 +315,13 @@ class ChoiceGroup:
         for choice, usage, description in self.prepare(default_mode):
             yield format_help_entry((usage,), description, lpad=4, tw_offset=tw_offset, prefix=prefix)
 
-    def prepare(self, default_mode: SubcommandAliasHelpMode) -> Iterator[Tuple[Choice, OptStr, OptStr]]:
+    def prepare(self, default_mode: CmdAliasMode) -> Iterator[Tuple[Choice, OptStr, OptStr]]:
         """
         Prepares the choice values and descriptions to use for each Choice in this group based on the configured alias
         mode.
 
-        :param default_mode: The default :class:`.SubcommandAliasHelpMode` to use if no mode was explicitly configured.
+        :param default_mode: The default :class:`.SubcommandAliasHelpMode` to use if no mode was explicitly configured,
+          or the format string to use for subcommand aliases.
         :return: Generator that yields 3-tuples containing the :class:`.Choice` object, the choice string value, and
           the help text / description for that choice / alias.
         """

--- a/tests/test_core/test_context.py
+++ b/tests/test_core/test_context.py
@@ -2,12 +2,11 @@
 
 from unittest import main
 
-from cli_command_parser import Command, CommandConfig
+from cli_command_parser import Command, CommandConfig, Option, Flag, SubCommand, Positional
 from cli_command_parser.core import CommandMeta
 from cli_command_parser.context import Context, ActionPhase, ctx, get_current_context
 from cli_command_parser.context import get_context, get_parsed, get_raw_arg
 from cli_command_parser.error_handling import extended_error_handler
-from cli_command_parser.parameters import Flag, SubCommand, Positional
 from cli_command_parser.testing import ParserTest
 
 
@@ -158,6 +157,19 @@ class ContextTest(ParserTest):
         self.assertDictEqual({'a': True}, get_parsed(foo, bar))
         self.assertDictEqual({'a': True}, get_parsed(foo, baz))
         self.assertDictEqual({'a': True}, get_parsed(foo, zab))
+
+    def test_get_parsed_defaults(self):
+        class Foo(Command):
+            a = Option('-a')
+            b = Option('-b', default=123)
+
+        foo = Foo.parse(['-a', 'bar'])
+        self.assertDictEqual({'a': 'bar', 'b': 123, 'help': False}, get_parsed(foo))
+        self.assertDictEqual({'a': 'bar'}, get_parsed(foo, include_defaults=False))
+
+        bar = Foo.parse([])
+        self.assertDictEqual({'a': None, 'b': 123, 'help': False}, get_parsed(bar))
+        self.assertDictEqual({}, get_parsed(bar, include_defaults=False))
 
     def test_get_raw_arg(self):
         class Foo(Command):

--- a/tests/test_documentation/test_help_text.py
+++ b/tests/test_documentation/test_help_text.py
@@ -835,6 +835,25 @@ class FormatterTest(ParserTest):
 
         self.assertEqual('test 12345', Foo.group.formatter.format_description(description='test 12345'))
 
+    def test_required_default_group(self):
+        class Foo(Command):
+            out_path = Option('-o', required=True, help='Output file path')
+            verbose = Counter('-v', help='Increase logging verbosity (can specify multiple times)')
+            dry_run = Flag('-D', help='Print the actions that would be taken instead of taking them')
+
+        expected = """
+Required arguments:
+  --out-path OUT_PATH, -o OUT_PATH
+                              Output file path
+
+Optional arguments:
+  --verbose [VERBOSE], -v [VERBOSE]
+                              Increase logging verbosity (can specify multiple times) (default: 0)
+  --dry-run, -D               Print the actions that would be taken instead of taking them
+  --help, -h                  Show this help message and exit
+        """.rstrip()
+        self.assert_str_contains(expected, get_help_text(Foo))
+
 
 def _get_output(command: CommandCls, args: Sequence[str]) -> Tuple[str, str]:
     with RedirectStreams() as streams:


### PR DESCRIPTION
- Added a default help text group for required options that were not explicitly included in a group so the description indicates that they are required.
- Added `include_defaults` option to `get_parsed` to be able to obtain only the user-provided args, excluding defaults, if desired.  The default behavior remains the same (it includes default values).