### PR TITLE
improved error message for default values that fail input validation

### DIFF
--- a/lib/cli_command_parser/annotations.py
+++ b/lib/cli_command_parser/annotations.py
@@ -21,7 +21,9 @@ def get_descriptor_value_type(command_cls: type, attr: str) -> Optional[type]:
         annotation = get_type_hints(command_cls)[attr]
     except (KeyError, NameError):  # KeyError due to attr missing; NameError for forward references
         return None
-
+    # Note: `inspect.get_annotations(obj)` returns a dict of where values are the string representations of the
+    # discovered annotations; values in the dict returned by `typing.get_type_hints` are the actual classes / typing
+    # aliases that were used, which are significantly more useful for this analysis.
     return get_annotation_value_type(annotation)
 
 

--- a/lib/cli_command_parser/parameters/base.py
+++ b/lib/cli_command_parser/parameters/base.py
@@ -385,7 +385,12 @@ class Parameter(ParamBase, Generic[T_co], ABC):
                     raise MissingArgument(self)
                 return missing_default
             else:
-                return self.action.get_default(command, missing_default)
+                try:
+                    return self.action.get_default(command, missing_default)
+                except InputValidationError as e:
+                    # At this point, a default value was provided, but it was not an acceptable value
+                    # TODO: Do any of the other cases handled by the `prepare_value` method need to be checked here?
+                    raise BadArgument(self, f'bad default value - {e}') from e
 
         return self.action.finalize_value(value)
 

--- a/tests/test_inputs/test_numeric_inputs.py
+++ b/tests/test_inputs/test_numeric_inputs.py
@@ -3,7 +3,7 @@
 from unittest import main
 
 from cli_command_parser import Command, Option
-from cli_command_parser.exceptions import ParameterDefinitionError
+from cli_command_parser.exceptions import ParameterDefinitionError, BadArgument
 from cli_command_parser.inputs import Range, NumRange, InputValidationError
 from cli_command_parser.testing import ParserTest
 
@@ -161,7 +161,7 @@ class ParseInputTest(ParserTest):
             bar = Option(type=Range(range(10), fix_default=True), default='-10')
             baz = Option(type=Range(range(10), fix_default=False), default='-10')
 
-        with self.assert_raises_contains_str(InputValidationError, 'expected a value in the range'):
+        with self.assert_raises_contains_str(BadArgument, 'bad default value - expected a value in the range'):
             Foo().bar  # noqa
 
         self.assertEqual('-10', Foo().baz)


### PR DESCRIPTION
Default values that fail custom input validation now include more useful information about the originating Parameter and the fact that it was the default value that was bad.