### PR TITLE
Added get_type_hints cache; documentation updates

### DIFF
--- a/docs/_src/commands.rst
+++ b/docs/_src/commands.rst
@@ -98,7 +98,8 @@ be parsed, a list of strings may also be provided when using either approach::
 
 ----
 
-.. [1] The only other methods that do not have ``__dunder__`` or ``_sunder_`` names.
+.. [1] The listed methods are the only ones other than ``main`` in the Command interface that do not have ``__dunder__``
+       or ``_sunder_`` names.  AsyncCommand (see `Asyncio Applications`_) defines one more.
 .. [2] Almost any.  A :ref:`ctx <advanced:Post-Run & Context>` attribute is defined for convenience, but is 100% safe
        to override.  See :ref:`commands:Overriding Command Methods` for more info about other methods.
 .. [3] The :func:`~.commands.main` function selects the top-level class that is known to extend :class:`.Command`,

--- a/docs/_src/commands.rst
+++ b/docs/_src/commands.rst
@@ -108,6 +108,29 @@ be parsed, a list of strings may also be provided when using either approach::
 ----
 
 
+Asyncio Applications
+====================
+
+Commands in applications that use :doc:`asyncio <python:library/asyncio>` should extend :class:`~.AsyncCommand` instead
+of :class:`~.Command`.  The ``main`` method within Command classes that extend AsyncCommand should generally be defined
+as an ``async`` method / :ref:`coroutine <python:coroutine>`.  For example::
+
+    class MyAsyncCommand(AsyncCommand):
+        async def main(self):
+            ...
+
+
+To run an AsyncCommand, both :func:`~.commands.main` and :meth:`~.AsyncCommand.parse_and_run` can be used as if running
+a synchronous :class:`~.Command` (as described `above <#parse-run>`__).  The asynchronous version of
+:meth:`~.AsyncCommand.parse_and_run` handles calling :func:`python:asyncio.run`.
+
+For applications that need more direct control over how the event loop is run, :meth:`~.AsyncCommand.parse_and_await`
+can be used instead.
+
+All of the `supported _sunder_ methods <#supported-sunder-methods>`__ may be overridden with either synchronous or
+async versions, and :ref:`parameters:Action` methods may similarly be defined either way as well.
+
+
 Advanced
 ========
 

--- a/docs/_src/conf.py
+++ b/docs/_src/conf.py
@@ -66,6 +66,7 @@ autodoc_default_options = {
     'ignore-module-all': True,
 }
 autodoc_typehints_format = 'short'
+autodoc_inherit_docstrings = False
 
 templates_path = [docs_dir.joinpath('_templates').as_posix()]
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']

--- a/lib/cli_command_parser/annotations.py
+++ b/lib/cli_command_parser/annotations.py
@@ -5,8 +5,9 @@ Utilities for extracting types from annotations.
 """
 
 from collections.abc import Collection, Iterable
+from functools import lru_cache
 from inspect import isclass
-from typing import Union, Optional, get_type_hints, get_origin, get_args as _get_args  # pylint: disable=C0412
+from typing import Union, Optional, get_type_hints as _get_type_hints, get_origin, get_args as _get_args
 
 try:
     from types import NoneType
@@ -15,9 +16,10 @@ except ImportError:  # Added in 3.10
 
 __all__ = ['get_descriptor_value_type']
 
+get_type_hints = lru_cache()(_get_type_hints)  # Cache the attr:annotation mapping for each Command class
+
 
 def get_descriptor_value_type(command_cls: type, attr: str) -> Optional[type]:
-    # TODO: Optimize this to cache get_type_hints for a given class?
     try:
         annotation = get_type_hints(command_cls)[attr]
     except (KeyError, NameError):  # KeyError due to attr missing; NameError for forward references

--- a/lib/cli_command_parser/commands.py
+++ b/lib/cli_command_parser/commands.py
@@ -20,7 +20,7 @@ from .utils import maybe_await
 if TYPE_CHECKING:
     from .typing import Bool, CommandObj
 
-__all__ = ['Command', 'main']
+__all__ = ['Command', 'AsyncCommand', 'main']
 log = logging.getLogger(__name__)
 
 Argv = Sequence[str]

--- a/lib/cli_command_parser/exceptions.py
+++ b/lib/cli_command_parser/exceptions.py
@@ -123,7 +123,6 @@ class UsageError(CommandParserException):
     """Base exception for user errors"""
 
     message: str = None
-    # TODO: Document that this is a recommended exception type to use when performing manual input validation
 
 
 class ParamUsageError(UsageError):


### PR DESCRIPTION
- Added `lru_cache` for `get_type_hints` for type annotation detection since `get_type_hints` returns a dict of `{attr_name: annotation}` for all attributes in the given class, and re-builds that dict each time it is called.  Since multiple attributes are examined in each class that extends Command, caching the result improves performance for that step.
- Updated docs to include info about `AsyncCommand`
- Updated docs to suggest using `UsageError` and `BadArgument` when manually validating user input