### PR TITLE
Improved subcommand help text, json error messages, and TimeDelta inputs

### DIFF
--- a/lib/cli_command_parser/commands.py
+++ b/lib/cli_command_parser/commands.py
@@ -29,9 +29,6 @@ Argv = Sequence[str]
 class Command(ABC, metaclass=CommandMeta):
     """The main class that other Commands should extend."""
 
-    # TODO: Make the distinction between help/description clearer, or merge them?
-    # TODO: Pull help text from docstring for subcommands if not specified as help=?
-
     #: The parsing Context used for this Command. Provided here for convenience - this reference to it is not used by
     #: any CLI Command Parser internals, so it is safe for subclasses to redefine / overwrite it.
     ctx: Context

--- a/lib/cli_command_parser/core.py
+++ b/lib/cli_command_parser/core.py
@@ -94,11 +94,14 @@ class CommandMeta(ABCMeta, type):
             namespace['_CommandMeta__config'] = config
 
         cls = super().__new__(mcs, name, bases, namespace, **kwargs)
+        if metadata:
+            # If no overrides were provided, then this is skipped, and it will be initialized lazily later
+            # This must be set before calling _maybe_register_sub_cmd so overrides are available during registration
+            cls.__metadata = ProgramMetadata.for_command(cls, parent=mcs._from_parent(mcs.meta, bases), **metadata)
+
         if ABC not in bases:
             mcs._commands.add(cls)
             mcs._maybe_register_sub_cmd(cls, choice, choices, help)
-        if metadata:  # If no overrides were provided, then initialize lazily later
-            cls.__metadata = ProgramMetadata.for_command(cls, parent=mcs._from_parent(mcs.meta, bases), **metadata)
 
         return cls
 

--- a/tests/test_commands/test_command_meta.py
+++ b/tests/test_commands/test_command_meta.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 
+from abc import ABC
 from unittest import TestCase, main
 
 from cli_command_parser import Command, CommandConfig
-from cli_command_parser.core import CommandMeta, get_config, get_parent, get_params, _choice_items
+from cli_command_parser.core import CommandMeta, _choice_items, get_config, get_params, get_parent
 from cli_command_parser.exceptions import CommandDefinitionError
 
 _get_config = CommandMeta.config
@@ -139,7 +140,16 @@ class TestCommandMeta(TestCase):
             pass
 
         self.assertIs(Command, get_parent(Foo))
-        self.assertIs(Command, get_parent(Foo()))
+        self.assertIs(Command, get_parent(Foo()))  # This returns cached results
+
+    def test_get_parent_abc(self):
+        class Foo(Command, ABC):
+            pass
+
+        self.assertIsNone(Foo._CommandMeta__parents)  # noqa
+        self.assertIs(Command, get_parent(Foo()))  # This first ensures coverage for the _mro func
+        self.assertIsNotNone(Foo._CommandMeta__parents)  # noqa
+        self.assertIs(Command, get_parent(Foo))  # This returns cached results
 
     def test_init_subclass_kwargs_allowed(self):
         class Foo(Command):

--- a/tests/test_commands/test_sub_commands.py
+++ b/tests/test_commands/test_sub_commands.py
@@ -4,10 +4,10 @@ from abc import ABC
 from unittest import main
 from unittest.mock import Mock
 
-from cli_command_parser import Command, SubCommand, Counter, Option, Positional, Flag, TriFlag, ParamGroup
+from cli_command_parser import Command, Counter, Flag, Option, ParamGroup, Positional, SubCommand, TriFlag
 from cli_command_parser.exceptions import CommandDefinitionError, MissingArgument, UsageError
 from cli_command_parser.formatting.commands import get_formatter
-from cli_command_parser.testing import RedirectStreams, ParserTest, get_help_text
+from cli_command_parser.testing import ParserTest, RedirectStreams, get_help_text
 
 
 class SubCommandTest(ParserTest):
@@ -88,6 +88,61 @@ class SubCommandTest(ParserTest):
             pass
 
         self.assertEqual({}, Foo.sub.choices)
+
+    def test_help_from_description_kwarg(self):
+        class Foo(Command):
+            """Foo docstring"""
+
+            sub: SubCommand = SubCommand()
+
+        class Bar(Foo, description='Bar description'):
+            pass
+
+        self.assertEqual('Bar description', Foo.sub.choices['bar'].help)
+
+    def test_help_from_description_docstring(self):
+        class Foo(Command):
+            """Foo docstring"""
+
+            sub: SubCommand = SubCommand()
+
+        class Bar(Foo):
+            """Bar docstring"""
+
+        self.assertEqual('Bar docstring', Foo.sub.choices['bar'].help)
+
+    def test_help_from_help_kwarg(self):
+        class Foo(Command):
+            """Foo docstring"""
+
+            sub: SubCommand = SubCommand()
+
+        class Bar(Foo, help='Bar help'):
+            pass
+
+        self.assertEqual('Bar help', Foo.sub.choices['bar'].help)
+
+    def test_help_from_help_not_desc_kwarg(self):
+        class Foo(Command):
+            """Foo docstring"""
+
+            sub: SubCommand = SubCommand()
+
+        class Bar(Foo, description='Bar description', help='Bar help'):
+            pass
+
+        self.assertEqual('Bar help', Foo.sub.choices['bar'].help)
+
+    def test_empty_help_from_help_not_desc_kwarg(self):
+        class Foo(Command):
+            """Foo docstring"""
+
+            sub: SubCommand = SubCommand()
+
+        class Bar(Foo, description='Bar description', help=''):
+            pass
+
+        self.assertEqual('', Foo.sub.choices['bar'].help)
 
     # endregion
 
@@ -213,8 +268,8 @@ class SubCommandTest(ParserTest):
         class D(B):
             y = Positional()
 
-        self.assertEqual('1', A.parse(['b', 'c', '1']).x)
-        self.assertEqual('2', A.parse(['b', 'd', '2']).y)
+        self.assertEqual('1', A.parse(['b', 'c', '1']).x)  # noqa
+        self.assertEqual('2', A.parse(['b', 'd', '2']).y)  # noqa
 
     def test_middle_abc_subcommand(self):
         class Base(Command):

--- a/tests/test_core/test_metadata.py
+++ b/tests/test_core/test_metadata.py
@@ -3,12 +3,21 @@
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest import TestCase, main
-from unittest.mock import patch, Mock, seal
+from unittest.mock import Mock, patch, seal
 
 from cli_command_parser import Command, Context, main as ccp_main
-from cli_command_parser.core import CommandMeta
-from cli_command_parser.metadata import ProgramMetadata, Metadata, DynamicMetadata, ProgFinder, dynamic_metadata
-from cli_command_parser.metadata import _path_and_globals, _description, _prog_finder, EntryPoint
+from cli_command_parser.core import CommandMeta, get_metadata
+from cli_command_parser.metadata import (
+    DynamicMetadata,
+    EntryPoint,
+    Metadata,
+    ProgFinder,
+    ProgramMetadata,
+    _description,
+    _path_and_globals,
+    _prog_finder,
+    dynamic_metadata,
+)
 from cli_command_parser.testing import ParserTest
 
 MODULE = 'cli_command_parser.metadata'
@@ -60,7 +69,7 @@ class MetadataTest(ParserTest):
             Baz
             """
 
-        self.assertEqual('Foo\nBar\nBaz\n', Bar.__class__.meta(Bar).description)
+        self.assertEqual('Foo\nBar\nBaz\n', get_metadata(Bar).description)
 
     def test_empty_doc_ignored(self):
         self.assertIs(None, _description(None, '\n\n'))

--- a/tests/test_documentation/test_rst.py
+++ b/tests/test_documentation/test_rst.py
@@ -6,7 +6,7 @@ from unittest import main
 from unittest.mock import patch
 
 from cli_command_parser import Command, SubCommand
-from cli_command_parser.documentation import load_commands, render_command_rst, RstWriter
+from cli_command_parser.documentation import RstWriter, load_commands, render_command_rst
 from cli_command_parser.testing import ParserTest, TemporaryDir
 
 THIS_FILE = Path(__file__).resolve()
@@ -109,16 +109,17 @@ class CommandRstTest(ParserTest):
 
     def test_unique_description_included(self):
         for show in (True, False):
+            with self.subTest(show=show):
 
-            class Foo(Command, description='foobarbaz', show_inherited_descriptions=show):
-                sub = SubCommand()
+                class Foo(Command, description='foobarbaz', show_inherited_descriptions=show):
+                    sub = SubCommand()
 
-            class Bar(Foo, description='bazbarfoo'):
-                pass
+                class Bar(Foo, description='bazbarfoo'):
+                    pass
 
-            rendered = render_command_rst(Foo)
-            self.assertEqual(1, rendered.count('\nfoobarbaz\n'))
-            self.assertEqual(1, rendered.count('\nbazbarfoo\n'))
+                rendered = render_command_rst(Foo)
+                self.assertEqual(1, rendered.count('\nfoobarbaz\n'))
+                self.assertEqual(2, rendered.count('\nbazbarfoo\n'))
 
     def test_basic_subcommand_no_help(self):
         expected = THIS_DATA_DIR.joinpath('basic_subcommand_no_help.rst').read_text('utf-8')

--- a/tests/test_parameters/test_choice_maps.py
+++ b/tests/test_parameters/test_choice_maps.py
@@ -4,8 +4,8 @@ from unittest import main
 from unittest.mock import Mock
 
 from cli_command_parser import Command, Context
-from cli_command_parser.exceptions import CommandDefinitionError, BadArgument, InvalidChoice, ParameterDefinitionError
-from cli_command_parser.parameters.choice_map import SubCommand, Action, Choice
+from cli_command_parser.exceptions import BadArgument, CommandDefinitionError, InvalidChoice, ParameterDefinitionError
+from cli_command_parser.parameters.choice_map import Action, Choice, SubCommand
 from cli_command_parser.testing import ParserTest
 
 
@@ -104,9 +104,12 @@ class ChoiceMapTest(ParserTest):
         class Foo(Command):
             sub = SubCommand()
 
-        Foo.sub.register(Mock(__name__='bar'))
-        with self.assertRaisesRegex(CommandDefinitionError, 'Invalid choice=.*with parent=None - already assigned to'):
-            Foo.sub.register(Mock(__name__='bar'))
+        class Bar(Command):
+            pass
+
+        Foo.sub.register(Bar)
+        with self.assertRaisesRegex(CommandDefinitionError, 'Invalid choice=.*with parent=.* - already assigned to'):
+            Foo.sub.register(Bar)
 
     def test_redundant_sub_cmd_choice_rejected(self):
         class Foo(Command):


### PR DESCRIPTION
- Added min/max/int validation options for `TimeDelta` inputs, similar to `NumRange` inputs
- Added a wrapper around `json.load` for `Json` inputs to provide a more user-friendly error message
- Updated `SubCommand` so that if no `help='...'` text is provided as a class kwarg when a sub-Command is defined, but a description or docstring is present, then that description/docstring will be used as the `help` text when the subcommand choices are displayed in `--help` text.  To prevent that text from being displayed when a description is provided, it is possible to specify `help=''` with an empty string.