### PR TITLE
fixed docs_url and other metadata keys that could not be provided as Command kwargs

### DIFF
--- a/lib/cli_command_parser/core.py
+++ b/lib/cli_command_parser/core.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 __all__ = ['CommandMeta', 'get_parent', 'get_config', 'get_params', 'get_metadata', 'get_top_level_commands']
 
 _NotSet = object()
-META_KEYS = {'prog', 'usage', 'description', 'epilog', 'doc_name'}
+META_KEYS = {'prog', 'usage', 'description', 'epilog', 'doc_name', 'path', 'url', 'docs_url', 'email', 'version'}
 
 
 class CommandMeta(ABCMeta, type):


### PR DESCRIPTION
Fixed `META_KEYS` in `cli_command_parser.core` to match the kwargs that users should be able to provide for `ProgramMetadata.for_command`, such as docs_url, email, etc, if they do not match the project-level values.