### PR TITLE
Documentation Updates

### DIFF
--- a/docs/_src/conf.py
+++ b/docs/_src/conf.py
@@ -65,6 +65,7 @@ autodoc_default_options = {
     'private-members': '_pre_init_actions_,_init_command_,_before_main_,_after_main_',
     'ignore-module-all': True,
 }
+autodoc_mock_imports = ['ctypes']
 autodoc_typehints_format = 'short'
 autodoc_inherit_docstrings = False
 

--- a/docs/_src/configuration.rst
+++ b/docs/_src/configuration.rst
@@ -77,9 +77,10 @@ Parsing Options
 :allow_backtrack: Whether the parser is allowed to backtrack or not when a Positional parameter follows a
   parameter with variable :class:`.Nargs`, and not enough arguments are available to fulfil that Positional's
   requirements (default: True)
-:option_name_mode: How the default long form that is added for Option/Flag/Counter/etc. Parameters should handle
-  underscores/dashes.  See :class:`.OptionNameMode` for more details.  Defaults to using underscores to match the
-  attribute name.  May be overridden on a per-Parameter basis with :ref:`parameters:Options:name_mode`.
+:option_name_mode: How the default ``--long-form`` option string that is added for Option/Flag/Counter/etc. Parameters
+  should handle underscores/dashes.  See :class:`.OptionNameMode` for more details about the values that can be used.
+  Defaults to replacing underscores in the attribute name with dashes.  May be overridden on a per-Parameter basis
+  with :ref:`parameters:Options:name_mode`.
 :reject_ambiguous_pos_combos: [EXPERIMENTAL] Whether ambiguous combinations of positional choices should result in an
   :class:`.AmbiguousParseTree` error.  Defaults to False.  Some combinations of positional parameter choices may pass
   this check, but still be problematic during parsing.  Since this is still experimental, there may be false positives.

--- a/docs/_src/index.rst
+++ b/docs/_src/index.rst
@@ -26,11 +26,11 @@ CLI Command Parser is a class-based CLI argument parser that defines parameters 
 tools to quickly and easily get started with basic CLIs, and it scales well to support even very large and complex
 CLIs while remaining readable and easy to maintain.
 
-The primary goals of this project:
-  - Make it easy to define subcommands and actions in an clean and organized manner
-  - Allow for inheritance so that common parameters don't need to be repeated
-  - Make it easy to handle common initialization tasks for all actions / subcommands once
-  - Reduce the amount of boilerplate code that is necessary for setting up parsing and handling argument values
+Some of the primary goals and key features of this project:
+  - Minimal boilerplate code is necessary to define CLI parameters and access their parsed values
+  - Easy to use type annotations for CLI parameters
+  - Subcommands can inherit common parameters so they don't need to be repeated
+  - Easy to handle common initialization tasks for all actions / subcommands once
 
 
 Example Program

--- a/docs/_src/intro.rst
+++ b/docs/_src/intro.rst
@@ -1,13 +1,12 @@
 Getting Started
 ***************
 
-Simple scripts usually contain a single Command and implement a ``def main(self):`` method in that Command to be
-called after arguments are parsed.
+Simple scripts usually contain a single class that extends ``Command`` and implements a ``def main(self):`` method
+to be called after arguments are parsed.
 
-Multiple Parameters can be specified as attributes inside the Command to define how CLI arguments will be parsed.
-
-The ``main()`` function that can be imported from ``cli_command_parser`` provides the main entry point for parsing
-arguments and running the Command.
+CLI parameters are defined as attributes within that class that are very similar to properties.  There's no need to
+specify a ``'--long-option-name'`` string for options, flags, and other similar parameters (but you can!) - by default,
+those are automatically generated based on the name assigned to the attribute.
 
 .. _hello_example:
 
@@ -39,18 +38,34 @@ After saving the example above as ``hello_world.py``, we can run it with multipl
     Hello John!
 
 
+That example used the ``main()`` function imported from ``cli_command_parser`` to automatically find the command that
+should be used, to parse the provided CLI arguments, and to invoke the ``main`` method within that command.
+
+
 Parameters
 ==========
 
 Types
 -----
 
-Rather than needing to infer the type of parameter that will result from a combination of arguments when defining it,
-each distinct type has its own :doc:`Parameter<parameters>` class.  Commands may contain any number of Parameters to
-define how they will parse CLI arguments.
+One of the largest changes for users who are familiar with other Python libraries used for parsing CLI arguments is
+that different kinds of parameters all have their own distinct :doc:`Parameter<parameters>` class.  This helps to make
+it clear which settings are supported by each one.  Commands may contain any number of Parameters.
 
-The basic types are :ref:`parameters:Positional`, :ref:`parameters:Option`, and :ref:`parameters:Flag`, but there are
-:doc:`others<parameters>` as well, including :doc:`groups<groups>` that can be mutually exclusive or dependent.
+A short intro for each type:
+  - :ref:`parameters:Positional`: Arguments without a ``--key`` preceding their values, where order matters
+  - :ref:`parameters:Option`: Options that can be provided as ``--key value`` or ``-k value`` pairs
+  - :ref:`parameters:Flag`: Options that usually toggle between ``True`` / ``False``, provided as ``--flag`` or ``-f``
+  - :ref:`parameters:TriFlag`: Similar to ``Flag``, but with support for a third constant and an alternate ``--no-flag``
+  - :ref:`parameters:Counter`: Counts the number of times it was provided as a flag; useful for cases like log verbosity
+  - :ref:`parameters:ActionFlag`: Chainable action methods invoked in a pre-defined order when provided like a ``--flag``
+  - :ref:`parameters:SubCommand`: Positional parameter used to specify where the name of a subcommand should be provided
+  - :ref:`parameters:Action`: Similar to ``SubCommand``, but used with action methods within a command
+  - :ref:`parameters:PassThru`: Arguments that are collected verbatim and provided as ``-- extra args here``
+
+Parameters can also be :doc:`grouped<groups>` for organizational purposes, or to make parameters be mutually exclusive
+or dependent.
+
 
 Names
 -----
@@ -70,6 +85,12 @@ If an explicit long form is provided, then it will be used instead of the defaul
 and/or short forms may be provided::
 
     example = Option('--foo', '-f', '--FOO')
+
+
+By default, multi-part `snake_case` names will be translated such that the underscores become dashes.  I.e.,
+``foo_bar = Option()`` will result in ``--foo-bar``.  This behavior can be adjusted for all options in a given command
+(and its subcommands, if any), and on a per-option basis.  See :ref:`configuration:Parsing Options:option_name_mode`
+for more info about how to configure this.
 
 
 Entry Points

--- a/docs/_src/parameters.rst
+++ b/docs/_src/parameters.rst
@@ -88,7 +88,7 @@ a ``--`` prefix, and short forms have a ``-`` prefix.
 
 The long form is automatically added (if not explicitly specified) based on the name of the Parameter attribute.  That
 is, if a parameter is defined as ``foo = Option('-f')`` or ``foo = Option()``, then ``--foo`` will automatically be
-added as its long form option string.
+added as its long form option string.  See :ref:`intro:Names` for more info.
 
 
 .. _options_init_params:
@@ -133,7 +133,8 @@ Options support two additional initialization parameters:
 Option
 ------
 
-The generic :class:`.Option` parameter that accepts arbitrary values or lists of values.
+The generic :class:`.Option` parameter that accepts arbitrary values or lists of values.  See :ref:`intro:Names` for
+more about how attribute names are used to automatically generate ``--long`` option names by default.
 
 .. _option_init_params:
 

--- a/readme.rst
+++ b/readme.rst
@@ -26,11 +26,11 @@ CLI Command Parser is a class-based CLI argument parser that defines parameters 
 tools to quickly and easily get started with basic CLIs, and it scales well to support even very large and complex
 CLIs while remaining readable and easy to maintain.
 
-The primary goals of this project:
-  - Make it easy to define subcommands and actions in an clean and organized manner
-  - Allow for inheritance so that common parameters don't need to be repeated
-  - Make it easy to handle common initialization tasks for all actions / subcommands once
-  - Reduce the amount of boilerplate code that is necessary for setting up parsing and handling argument values
+Some of the primary goals and key features of this project:
+  - Minimal boilerplate code is necessary to define CLI parameters and access their parsed values
+  - Easy to use type annotations for CLI parameters
+  - Subcommands can inherit common parameters so they don't need to be repeated
+  - Easy to handle common initialization tasks for all actions / subcommands once
 
 
 Example Program


### PR DESCRIPTION
- Revised and expanded upon some intro sections of the docs
- Fixed the config doc section related to `option_name_mode` to match the actual default (it was changed from underscore to dash in #27)