### PR TITLE
Fixed variable Option arguments with default Actions

### DIFF
--- a/lib/cli_command_parser/inputs/choices.py
+++ b/lib/cli_command_parser/inputs/choices.py
@@ -36,7 +36,12 @@ class _ChoicesBase(InputType[T], ABC):
         return True
 
     def _type_str(self) -> str:
-        return f'type={self.type.__name__}, ' if self.type is not None else ''
+        if self.type is not None:
+            try:
+                return f'type={self.type.__name__}, '
+            except AttributeError:  # type is not a class
+                pass
+        return ''
 
     def __repr__(self) -> str:
         cls_name = self.__class__.__name__
@@ -100,7 +105,10 @@ class Choices(_ChoicesBase[T]):
         self.case_sensitive = case_sensitive
 
     def _choices_repr(self, delim: str = ',') -> str:
-        return delim.join(map(repr, sorted(self.choices)))
+        try:
+            return delim.join(map(repr, sorted(self.choices)))
+        except TypeError:  # The choice values are not sortable
+            return delim.join(sorted(map(repr, self.choices)))
 
     def __call__(self, value: str) -> T:
         choices = self.choices

--- a/lib/cli_command_parser/nargs.py
+++ b/lib/cli_command_parser/nargs.py
@@ -6,9 +6,9 @@ Helpers for handling ``nargs=...`` for Parameters.
 
 from __future__ import annotations
 
-from typing import Any, Collection, FrozenSet, Iterable, Optional, Sequence, Set, Tuple, Union
+from typing import Any, Collection, FrozenSet, Optional, Sequence, Set, Tuple, Union
 
-__all__ = ['Nargs', 'NargsValue', 'REMAINDER', 'nargs_min_and_max_sums']
+__all__ = ['Nargs', 'NargsValue', 'REMAINDER']
 
 REMAINDER = type('REMAINDER', (), {})()
 _UNBOUND = (None, REMAINDER)
@@ -177,20 +177,3 @@ class Nargs:
     @property
     def upper_bound(self) -> Union[int, float]:
         return self.max if self._has_upper_bound else float('inf')
-
-
-def nargs_min_and_max_sums(nargs_objects: Iterable[Nargs]) -> tuple[int, Union[int, float]]:
-    min_sum, max_sum = 0, 0
-    iter_nargs = iter(nargs_objects)
-    for obj in iter_nargs:
-        min_sum += obj.min
-        if obj._has_upper_bound:
-            max_sum += obj.max
-        else:
-            max_sum = float('inf')
-            break
-
-    for obj in iter_nargs:  # If any had no upper bound, then this loop will complete the min total
-        min_sum += obj.min  # Otherwise, it will not have anything to iterate over
-
-    return min_sum, max_sum

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -516,7 +516,7 @@ class Counter(BaseOption[int], actions=(Count,)):
         if value is None or isinstance(value, self.type):
             return
         try:
-            value = self.type(value)
+            self.type(value)
         except (ValueError, TypeError) as e:
             raise BadArgument(self, f'invalid {value=} (expected an integer)') from e
         else:

--- a/lib/cli_command_parser/parse_tree.py
+++ b/lib/cli_command_parser/parse_tree.py
@@ -7,7 +7,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Collection, Iterable, Iterator, MutableMapping, Optional, Union
 
 from .exceptions import AmbiguousParseTree
-from .nargs import nargs_min_and_max_sums
 from .utils import _parse_tree_target_repr
 
 if TYPE_CHECKING:
@@ -88,9 +87,6 @@ class PosNode(MutableMapping[Word, 'PosNode']):
         if recursive:
             for node in self.values():
                 yield from node._link_params(_has_upper_bound(node))
-
-    def nargs_min_and_max(self) -> tuple[int, Union[int, float]]:
-        return nargs_min_and_max_sums(p.nargs for p in self.link_params(True))
 
     # region AnyWord Methods
 

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import logging
 from collections import deque
 from os import environ
-from typing import TYPE_CHECKING, Deque, Iterable, Optional
+from typing import TYPE_CHECKING, Deque, Sequence
 
 from .context import ActionPhase, Context
 from .core import get_parent
@@ -22,7 +22,7 @@ from .exceptions import (
     ParamUsageError,
     UsageError,
 )
-from .nargs import REMAINDER, nargs_min_and_max_sums
+from .nargs import REMAINDER
 from .parameters.base import BaseOption, BasePositional, Parameter
 from .parse_tree import PosNode
 
@@ -45,12 +45,12 @@ class CommandParser:
 
     __slots__ = ('_last', 'arg_deque', 'ctx', 'config', 'deferred', 'params', 'positionals')
 
-    arg_deque: Optional[Deque[str]]
+    arg_deque: Deque[str] | None
     config: CommandConfig
-    deferred: Optional[list[str]]
+    deferred: list[str] | None
     params: CommandParameters
     positionals: list[BasePositional]
-    _last: Optional[Parameter]
+    _last: Parameter | None
 
     def __init__(self, ctx: Context, params: CommandParameters, config: CommandConfig):
         self._last = None
@@ -62,7 +62,7 @@ class CommandParser:
             PosNode.build_tree(ctx.command_cls)
 
     @classmethod
-    def parse_args_and_get_next_cmd(cls, ctx: Context) -> Optional[CommandType]:
+    def parse_args_and_get_next_cmd(cls, ctx: Context) -> CommandType | None:
         try:
             return cls(ctx, ctx.params, ctx.config).get_next_cmd(ctx)
         except UsageError:
@@ -70,7 +70,7 @@ class CommandParser:
                 raise
             return None
 
-    def get_next_cmd(self, ctx: Context) -> Optional[CommandType]:
+    def get_next_cmd(self, ctx: Context) -> CommandType | None:
         self._parse_args(ctx)
         self._validate_groups()
         missing = ctx.get_missing()
@@ -273,7 +273,7 @@ class CommandParser:
             if len(self.positionals) == 1 and 0 in self.positionals[0].nargs:
                 raise NextCommand
             else:
-                raise ParamUsageError(param, 'subcommand arguments must be provided after the subcommand')
+                raise ParamUsageError(param, 'subcommand arguments must be provided after the subcommand')  # noqa
 
     # region Backtracking
 
@@ -287,26 +287,61 @@ class CommandParser:
         :param found: The number of values that were consumed by the given Parameter
         :return: The updated found count, if backtracking was possible, otherwise the unmodified found count
         """
-        if self.positionals:
-            can_pop = param.action.get_maybe_poppable_counts()
-            if rollback_count := _to_pop(self.positionals, can_pop, found - 1):
-                self.arg_deque.extendleft(reversed(self.ctx.roll_back_parsed_values(param, rollback_count)))
-                return found - rollback_count
-        return found
+        if not self.positionals:
+            return found
+        elif rollback_count := self._get_backtrack_count(param):
+            self.arg_deque.extendleft(reversed(self.ctx.roll_back_parsed_values(param, rollback_count)))
+            return found - rollback_count
+        else:
+            return found
 
-    def _maybe_backtrack_last(self, param: BasePositional, found: int):
+    def _get_backtrack_count(
+        self, param: Parameter, extras: Sequence[str] = (), positionals: Sequence[BasePositional] = ()
+    ) -> int:
+        if poppable_groups := param.action.get_maybe_poppable_values():
+            return next((len(g) for g in poppable_groups if self._should_backtrack(g, extras, positionals)), 0)
+        return 0
+
+    def _should_backtrack(
+        self, group: list[str], extras: Sequence[str] = (), positionals: Sequence[BasePositional] = ()
+    ) -> bool:
+        args = [*group, *extras, *self.arg_deque]
+        for pos_param in positionals or self.positionals:
+            n = pos_param.nargs.min
+            if not n and 1 in pos_param.nargs:
+                n = 1
+
+            param_args = args[:n]
+            if len(param_args) != n or not pos_param.action.would_accept_all(param_args):
+                return False
+
+            args = args[n:]
+
+        return True
+
+    def _maybe_backtrack_last_positional(self, param: BasePositional, found: int):
         """
         Similar to :meth:`._maybe_backtrack`, but allows backtracking even after starting to process a Positional.
+
+        By the time this method is called, it has already been discovered that `found` does not satisfy `param`'s
+        nargs requirements.
+
+        This method does not check whether the popped parameters would be accepted by the positional(s) before popping
+        them, while :meth:`_maybe_backtrack` does perform that check.
         """
         if not self.config.allow_backtrack:
-            # This method is called relatively rarely & it's cleaner to have this check here than in _finalize_consume
+            # This method is called extremely rarely & it's cleaner to have this check here than in _finalize_consume
             return
 
-        can_pop = self._last.action.get_maybe_poppable_counts()
-        # It is extremely unlikely for this point to be reached without this resulting in triggering a backtrack
-        if rollback_count := _to_pop((param, *self.positionals), can_pop, max(can_pop, default=0) + found, found):
+        parsed = self.ctx.get_parsed_value(param, ())
+        # It is extremely unlikely for this point to be reached without this resulting in triggering backtrack
+        if num := self._get_backtrack_count(self._last, parsed, (param, *self.positionals)):
+            # log.debug(f'Rolling back {num} parsed values from {self._last=} / {param=} and triggering Backtrack')
+            # Reset all of this param's parsed args because the previous param's roll back args need to be injected
+            # before them so they can be processed by this parameter.
             self.arg_deque.extendleft(reversed(self.ctx.pop_parsed_value(param)))
-            self.arg_deque.extendleft(reversed(self.ctx.roll_back_parsed_values(self._last, rollback_count)))
+            # Roll back a subset of the previous param's parsed args
+            self.arg_deque.extendleft(reversed(self.ctx.roll_back_parsed_values(self._last, num)))
             raise Backtrack
 
     # endregion
@@ -353,15 +388,13 @@ class CommandParser:
                 # log.debug(f'{value=} was rejected by {param=}', exc_info=True)
                 return self._finalize_consume(param, value, found, e)
 
-        # TODO: Positional(nargs='?') with no values will steal values intended for an Option(nargs='+')
-        #  (likely occurs with nargs='*' for the Positional as well)
-
         # log.debug(f'Ran out of values in deque while processing {param=}')
         if found >= 2 and self.config.allow_backtrack:
             found = self._maybe_backtrack(param, found)
         return self._finalize_consume(param, None, found)
 
-    def _finalize_consume(self, param: Parameter, value: OptStr, found: int, exc: Optional[Exception] = None) -> int:
+    def _finalize_consume(self, param: Parameter, value: OptStr, found: int, exc: Exception | None = None) -> int:
+        # log.debug(f'Finalizing arg consumption for {param=}, {value=}, {found=}, {exc=}')
         nargs = param.nargs
         if nargs.satisfied(found):
             # Even if an exception was passed to this method, if the found number of values is acceptable, then it
@@ -373,29 +406,13 @@ class CommandParser:
         elif exc:
             raise exc
         elif self._last and isinstance(param, BasePositional) and param.action.can_reset():
-            self._maybe_backtrack_last(param, found)
+            self._maybe_backtrack_last_positional(param, found)
 
         s = '' if nargs.min == 1 else 's'
         raise MissingArgument(param, f'expected {nargs.min} value{s}, but only found {found}')
 
 
 parse_args_and_get_next_cmd = CommandParser.parse_args_and_get_next_cmd
-
-
-def _to_pop(positionals: Iterable[BasePositional], can_pop: list[int], available: int, req_mod: int = 0) -> int:
-    if not can_pop:
-        return 0
-
-    required, acceptable = nargs_min_and_max_sums(p.nargs for p in positionals)
-    if available < required:
-        return 0
-
-    required -= req_mod
-    for n in can_pop:
-        if required <= n <= acceptable:
-            return n
-
-    return 0
 
 
 def get_opt_prefix(text: str) -> OptStr:

--- a/lib/cli_command_parser/parser.py
+++ b/lib/cli_command_parser/parser.py
@@ -319,15 +319,12 @@ class CommandParser:
 
         return True
 
-    def _maybe_backtrack_last_positional(self, param: BasePositional, found: int):
+    def _maybe_backtrack_last_positional(self, param: BasePositional):
         """
         Similar to :meth:`._maybe_backtrack`, but allows backtracking even after starting to process a Positional.
 
         By the time this method is called, it has already been discovered that `found` does not satisfy `param`'s
         nargs requirements.
-
-        This method does not check whether the popped parameters would be accepted by the positional(s) before popping
-        them, while :meth:`_maybe_backtrack` does perform that check.
         """
         if not self.config.allow_backtrack:
             # This method is called extremely rarely & it's cleaner to have this check here than in _finalize_consume
@@ -406,7 +403,7 @@ class CommandParser:
         elif exc:
             raise exc
         elif self._last and isinstance(param, BasePositional) and param.action.can_reset():
-            self._maybe_backtrack_last_positional(param, found)
+            self._maybe_backtrack_last_positional(param)
 
         s = '' if nargs.min == 1 else 's'
         raise MissingArgument(param, f'expected {nargs.min} value{s}, but only found {found}')

--- a/tests/test_core/test_nargs.py
+++ b/tests/test_core/test_nargs.py
@@ -2,7 +2,7 @@
 
 from unittest import TestCase, main
 
-from cli_command_parser.nargs import REMAINDER, Nargs, nargs_min_and_max_sums
+from cli_command_parser.nargs import REMAINDER, Nargs
 
 
 class NargsTest(TestCase):
@@ -336,9 +336,6 @@ class NargsTest(TestCase):
         self.assertNotEqual(b, c)
         self.assertNotEqual(c, a)
         self.assertNotEqual(c, b)
-
-    def test_min_max_unbound_mid(self):
-        self.assertEqual((3, float('inf')), nargs_min_and_max_sums([Nargs(1), Nargs('+'), Nargs(1)]))
 
     # endregion
 

--- a/tests/test_parameters/test_actions.py
+++ b/tests/test_parameters/test_actions.py
@@ -197,6 +197,34 @@ class ActionTest(ParserTest):
         self.assertIs(None, Foo.action.choices['foo'].help)
         self.assertIs(None, Foo.bar.help)
 
+    def test_default_action_has_no_explicit_choice(self):
+        class Foo(Command):
+            action = Action()
+
+            @action(default=True)
+            def bar(self):
+                pass
+
+        self.assert_parse_results(Foo, [], {'action': None})
+        self.assert_parse_fails(Foo, ['bar'])
+
+    def test_default_action_with_explicit_choice(self):
+        class Foo(Command):
+            action_called = None
+            action = Action()
+
+            @action(default=True, choice='bar')
+            def bar(self):
+                self.action_called = 'bar'
+
+            @action()
+            def baz(self):
+                self.action_called = 'baz'
+
+        self.assertEqual('bar', Foo.parse_and_run([]).action_called)
+        self.assertEqual('bar', Foo.parse_and_run(['bar']).action_called)
+        self.assertEqual('baz', Foo.parse_and_run(['baz']).action_called)
+
 
 def make_build_docs_command(explicit_build: bool = False):
     build_mock, clean_mock = sealed_mock(__name__='sphinx_build'), sealed_mock()

--- a/tests/test_parameters/test_flags.py
+++ b/tests/test_parameters/test_flags.py
@@ -182,6 +182,12 @@ class FlagTest(ParserTest):
         expected = '<TriFlagOptionStrings[name_mode=OptionNameMode.DASH][--a-c, --no-a-c]>'
         self.assertEqual(expected, repr(Foo.a_c.option_strs))
 
+    def test_flag_would_not_accept_all(self):
+        class Foo(Command):
+            bar = Flag()
+
+        self.assertFalse(Foo.bar.action.would_accept_all([]))
+
 
 class TriFlagTest(ParserTest):
     def test_trinary(self):

--- a/tests/test_parameters/test_misc.py
+++ b/tests/test_parameters/test_misc.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+from enum import Enum
 from unittest import main
 
 from cli_command_parser import Command, CommandDefinitionError, Context, ParameterDefinitionError
@@ -129,6 +130,14 @@ class MiscParameterTest(ParserTest):
 
     def test_leading_dash_property(self):
         self.assertIsInstance(Option.allow_leading_dash, AllowLeadingDashProperty)
+
+    def test_param_repr_with_enum_choices(self):
+        Test = Enum('Test', ('A', 'B', 'C'))  # noqa
+
+        class Foo(Command):
+            bar = Option(type=Test, choices=(Test.A, Test.B))
+
+        self.assertIn('type=<Choices[case_sensitive=True, choices=(<Test.A: 1>,<Test.B: 2>)]>', repr(Foo.bar))
 
 
 class UnlikelyToBeReachedParameterTest(ParserTest):

--- a/tests/test_parameters/test_misc.py
+++ b/tests/test_parameters/test_misc.py
@@ -193,7 +193,7 @@ class UnlikelyToBeReachedParameterTest(ParserTest):
 
     def test_flag_backtrack(self):
         flag_act = Flag().action
-        self.assertEqual([], flag_act.get_maybe_poppable_counts())
+        self.assertEqual([], flag_act.get_maybe_poppable_values())
         self.assertFalse(flag_act.can_reset())
 
     def test_store_add_const(self):

--- a/tests/test_parameters/test_options.py
+++ b/tests/test_parameters/test_options.py
@@ -194,7 +194,7 @@ class OptionTest(ParserTest):
 
     def test_append_get_maybe_poppable_counts(self):
         with Context():
-            self.assertEqual([], Option(action='append').action.get_maybe_poppable_counts())
+            self.assertEqual([], Option(action='append').action.get_maybe_poppable_values())
 
 
 class OptionNargsTest(ParserTest):

--- a/tests/test_parsing/test_parse_positionals.py
+++ b/tests/test_parsing/test_parse_positionals.py
@@ -158,7 +158,12 @@ class NargsParsingTest(ParserTest):
             # The following works if backtracking is removed
             # (['--bar', 'a', 'b', '1', '2', '3'], {'foo': [1, 2, 3], 'bar': ['a', 'b']}),
         ]
-        fail_cases = [[], ['--bar', 'a', 'b', '1', '2', '3', 'c'], ['--bar', 'a', 'b', '1', '2', '3', 'c', 'd']]
+        fail_cases = [
+            [],
+            ['--bar', 'a', 'b', '1', '2', '3'],  # This should work without backtracking
+            ['--bar', 'a', 'b', '1', '2', '3', 'c'],
+            ['--bar', 'a', 'b', '1', '2', '3', 'c', 'd'],
+        ]
         self.assert_parse_results_cases(Foo, success_cases)
         self.assert_parse_fails_cases(Foo, fail_cases, UsageError)
 

--- a/tests/test_parsing/test_parse_tree.py
+++ b/tests/test_parsing/test_parse_tree.py
@@ -22,40 +22,6 @@ class TestPosNode(ParserTest):
         self.assertEqual({Foo.foo}, node.link_params())
         self.assertEqual({Foo.foo, Foo.bar}, node.link_params(True))
 
-    # region Nargs Tests
-
-    def test_nargs_min_max_unbound(self):
-        class Foo(Command):
-            foo = Positional(nargs=2)
-            bar = Positional(nargs='+')
-
-        self.assertEqual((3, float('inf')), PosNode.build_tree(Foo).nargs_min_and_max())
-
-    def test_nargs_variable_then_fixed(self):
-        # Note: Positionals accepting any value with variable nargs can't be followed by ones with a fixed # of args
-        class Foo(Command):
-            foo = Positional(nargs=range(1, 5), choices=('a', 'b'))
-            bar = Positional()
-
-        self.assertEqual((2, 5), PosNode.build_tree(Foo).nargs_min_and_max())
-
-    @skip('This case needs to be handled')
-    def test_nargs_pair_extreme(self):
-        class Foo(Command):
-            foo = Positional(nargs=sys.maxsize)
-            bar = Positional(nargs='+')
-
-        self.assertEqual((sys.maxsize, float('inf')), PosNode.build_tree(Foo).nargs_min_and_max())
-
-    def test_nargs_min_max_bound(self):
-        class Foo(Command):
-            foo = Positional(choices=('a', 'b'))
-            bar = Positional()
-
-        self.assertEqual((2, 2), PosNode.build_tree(Foo).nargs_min_and_max())
-
-    # endregion
-
     def test_repr(self):
         class Foo(Command):
             sub_cmd = SubCommand()


### PR DESCRIPTION
The parser backtracking logic was slightly improved, so it now takes into account whether the positional parameters that it would feed by backtracking would actually accept the arguments that would be removed from the preceding parameter.

This fixes the problem where an `Action` parameter with a method registered as the default would steal argument values from an `Option` with `nargs='+'`, even if the values it stole were not valid for that Action.  Any other similar cases with "optional" positional arguments like that should also be fixed by this change.