### PR TITLE
Removed unnecessary command_parent attribute from CommandParameters

### DIFF
--- a/lib/cli_command_parser/command_parameters.py
+++ b/lib/cli_command_parser/command_parameters.py
@@ -34,7 +34,6 @@ class CommandParameters:
     # fmt: off
     command: CommandCls                                  #: The Command associated with this CommandParameters object
     formatter: CommandHelpFormatter                      #: The formatter used for this Command's help text
-    command_parent: CommandCls | None                    #: The parent Command, if any
     parent: CommandParameters | None                     #: The parent Command's CommandParameters
     action: Action | None = None                         #: An Action Parameter, if specified
     _pass_thru: PassThru | None = None                   #: A PassThru Parameter, if specified
@@ -49,15 +48,8 @@ class CommandParameters:
     option_map: OptionMap                                #: Mapping of {--opt / -opt: Parameter}
     # fmt: on
 
-    def __init__(
-        self,
-        command: CommandCls,
-        command_parent: CommandCls | None,
-        parent_params: CommandParameters | None,
-        config: CommandConfig,
-    ):
+    def __init__(self, command: CommandCls, parent_params: CommandParameters | None, config: CommandConfig):
         self.command = command
-        self.command_parent = command_parent
         self.parent = parent_params
         self.config = config
         self._process_parameters()
@@ -167,7 +159,7 @@ class CommandParameters:
             while param_group := param_group.group:
                 groups.add(param_group)
 
-        if self.config.add_help and self.command_parent is not None and (not self.parent or not self.parent._has_help):
+        if self.config.add_help and self.parent is not None and not self.parent._has_help:
             options.append(help_action)
 
         self._process_positionals(positionals)

--- a/lib/cli_command_parser/core.py
+++ b/lib/cli_command_parser/core.py
@@ -211,7 +211,7 @@ class CommandMeta(ABCMeta, type):
                 cls = cls.__class__
             parent = mcs.parent(cls, True)
             parent_params = mcs.params(parent) if parent is not None else None
-            cls.__params = params = CommandParameters(cls, parent, parent_params, mcs.config(cls, DEFAULT_CONFIG))
+            cls.__params = params = CommandParameters(cls, parent_params, mcs.config(cls, DEFAULT_CONFIG))
         return params
 
     @classmethod

--- a/tests/test_commands/test_command_meta.py
+++ b/tests/test_commands/test_command_meta.py
@@ -4,7 +4,7 @@ from abc import ABC
 from unittest import TestCase, main
 
 from cli_command_parser import Command, CommandConfig
-from cli_command_parser.core import CommandMeta, _choice_items, get_config, get_params, get_parent
+from cli_command_parser.core import CommandMeta, _choice_items, get_config, get_parent
 from cli_command_parser.exceptions import CommandDefinitionError
 
 _get_config = CommandMeta.config
@@ -49,7 +49,7 @@ class TestCommandMeta(TestCase):
         class Bar(Foo):
             pass
 
-        self.assertEqual(get_params(Bar).command_parent, Foo)
+        self.assertEqual(get_parent(Bar), Foo)
 
     def test_choice_items_results(self):
         cases = [


### PR DESCRIPTION
The `command_parent` attribute was not used in any meaningful way, so I removed it.