### PR TITLE
Final batch of typing related fixes

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -32,8 +32,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip setuptools
-          python -m pip install ruff pytest pytest-cov
-          pip install -e .[wcwidth]
+          pip install -e .[wcwidth,dev]
       - name: Lint with ruff
         run: ruff check
       - name: Generate coverage report

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Generate coverage report
         run: pytest --cov-branch --cov=./lib/ --cov-report=xml
       - name: Upload coverage report to Codecov
-        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           directory: ./coverage/reports/

--- a/bin/build_docs.py
+++ b/bin/build_docs.py
@@ -32,7 +32,7 @@ class BuildDocs(Command, description='Build documentation using Sphinx'):
     verbose = Counter('-v', help='Increase logging verbosity (can specify multiple times)')
     dry_run = Flag('-D', help='Print the actions that would be taken instead of taking them')
 
-    def _init_command_(self):
+    def _init_command_(self) -> None:
         self.title = __description__
         self.package = __title__
         self.package_path = PROJECT_ROOT.joinpath('lib', self.package)

--- a/docs/_src/commands.rst
+++ b/docs/_src/commands.rst
@@ -4,7 +4,7 @@ Commands
 Commands provide a way to organize CLI applications in an intuitively object-oriented way.
 
 Having parameters defined as attributes in the class results in a better developer experience when writing code that
-references those attributes in an IDE.  You can take advantage of type annotations and variable name completion.
+references those attributes in an IDE.  You can take advantage of type detection and variable name completion.
 Changing the name of a parameter can take advantage of builtin renaming tools, instead of needing to hunt for
 references to ``args.foo`` to be updated, for example.  Further, there's no need to keep function signatures up to date
 with parameters defined in decorators.
@@ -24,11 +24,9 @@ while other :ref:`configuration:Configuration Options` exist to control error ha
 
 :gh_examples:`Example command <hello_world.py>` that uses some of those options::
 
-    class HelloWorld(
-        Command,
-        description='Simple greeting example',
-        epilog='Contact <example@fake.org> with any issues'
-    ):
+    class HelloWorld(Command, epilog='Contact <example@fake.org> with any issues'):
+        """Simple greeting example"""
+
         name = Option('-n', default='World', help='The person to say hello to')
 
         def main(self):

--- a/docs/_src/configuration.rst
+++ b/docs/_src/configuration.rst
@@ -57,6 +57,30 @@ Parameter Options
   ``type`` argument takes precedence.  When disabled, type annotations will not be inspected.  If no ``type`` is
   specified, then the default type (usually ``str``) for that Parameter will be used.
 
+.. warning:: Type inference from annotations is deprecated
+
+    In a future (TBD) version, this setting will change so that it defaults to False and/or a DeprecationWarning will
+    be raised.  In a later version, support for inferring the type from annotations will be removed completely.
+
+    Using an annotation like the following is not actually valid::
+
+        count: int = Option('-c', default=1, help='Number of times to repeat the message')  # INVALID
+
+    Some type checkers will allow it, but it is not technically accurate, and it is not supported by mypy.  The more
+    accurate way to annotate the above example would be::
+
+        count: Option[int] = Option('-c', default=1, help='Number of times to repeat the message')  # INVALID
+
+    But that still would not be accurate without also passing ``type=int`` to Option.
+
+    The recommended approach is now the following::
+
+        count = Option('-c', type=int, default=1, help='Number of times to repeat the message')  # CORRECT
+
+    Changes were made to all Parameter subclasses so that they are now annotated in a way that type checkers can
+    correctly understand the value type when parameter attributes are accessed, without needing an explicit annotation
+    for the parameter attribute itself.
+
 
 ActionFlag Options
 ------------------

--- a/docs/_src/groups.rst
+++ b/docs/_src/groups.rst
@@ -70,7 +70,7 @@ raised.  The ``tasks`` and ``verbose`` parameters are not in the group::
         tasks = Positional(nargs='+', help='The tasks to run')
 
         with ParamGroup('Wait Options', mutually_exclusive=True):
-            wait: int = Option('-w', default=1, help='Seconds to wait (0 or below to wait indefinitely)')
+            wait = Option('-w', type=int, default=1, help='Seconds to wait (0 or below to wait indefinitely)')
             no_wait = Flag('-W', help='Do not wait')
 
         verbose = Counter('-v', help='Increase logging verbosity (can specify multiple times)')
@@ -87,7 +87,7 @@ following :gh_examples:`example <rest_api_wrapper.py>` snippet::
     class FindBaz(Find, choices=('baz', 'bazs'), help='Find baz objects'):
         with ParamGroup(description='Filter Choices', mutually_exclusive=True, required=True):
             foo = Option('-f', metavar='NAME', help='Find baz objects related to the foo object with the specified name')
-            bar: int = Option('-b', metavar='ID', help='Find baz objects related to the bar object with the specified ID')
+            bar = Option('-b', type=int, metavar='ID', help='Find baz objects related to the bar object with the specified ID')
 
         def find_objects(self):
             if self.foo:

--- a/docs/_src/index.rst
+++ b/docs/_src/index.rst
@@ -28,7 +28,7 @@ CLIs while remaining readable and easy to maintain.
 
 Some of the primary goals and key features of this project:
   - Minimal boilerplate code is necessary to define CLI parameters and access their parsed values
-  - Easy to use type annotations for CLI parameters
+  - Typing support for CLI parameters that can be validated via type checkers
   - Subcommands can inherit common parameters so they don't need to be repeated
   - Easy to handle common initialization tasks for all actions / subcommands once
 

--- a/docs/_src/index.rst
+++ b/docs/_src/index.rst
@@ -40,9 +40,11 @@ Example Program
 
     from cli_command_parser import Command, Option, main
 
-    class Hello(Command, description='Simple greeting example'):
+    class Hello(Command):
+        """Simple greeting example"""
+
         name = Option('-n', default='World', help='The person to say hello to')
-        count: int = Option('-c', default=1, help='Number of times to repeat the message')
+        count = Option('-c', type=int, default=1, help='Number of times to repeat the message')
 
         def main(self):
             for _ in range(self.count):

--- a/docs/_src/inputs.rst
+++ b/docs/_src/inputs.rst
@@ -80,7 +80,7 @@ Using another snippet from the above :gh_examples:`example <custom_inputs.py>`::
 
     class InputsExample(Command):
         in_file = Option('-f', type=File(allow_dash=True, lazy=False), help='The path to a file to read')
-        out_file: FileWrapper = Option('-o', type=File(allow_dash=True, mode='w'), help='The path to a file to write')
+        out_file = Option('-o', type=File(allow_dash=True, mode='w'), help='The path to a file to write')
 
         def main(self):
             if self.in_file:
@@ -118,7 +118,7 @@ In addition to plain text or binary files, custom input handlers also exist for 
 and a generic handler (:class:`.Serialized`) exists for any other serialization format.  They all extend
 :ref:`inputs:File`, so the same options are accepted.
 
-.. version-changed:: 2026-04-TBD
+.. version-changed:: 2026-06-27
 
     A breaking change was made to the generic :class:`.Serialized` class to remove support for a single ``converter``
     callable that handled either serialization xor deserialization.  Instead, it now requires a ``serializer`` that
@@ -145,7 +145,7 @@ and a generic handler (:class:`.Serialized`) exists for any other serialization 
 Adding another snippet to the above :gh_examples:`example <custom_inputs.py>`::
 
     class InputsExample(Command):
-        json: FileWrapper = Option('-j', type=Json(allow_dash=True), help='The path to a file containing json')
+        json = Option('-j', type=Json(allow_dash=True), help='The path to a file containing json')
 
         def main(self):
             if self.json:

--- a/docs/_src/intro.rst
+++ b/docs/_src/intro.rst
@@ -10,13 +10,17 @@ those are automatically generated based on the name assigned to the attribute.
 
 .. _hello_example:
 
-Here's a basic example of a program that uses CLI Command Parser::
+Here's a basic example of a program that uses CLI Command Parser:
+
+.. code-block:: python
 
     from cli_command_parser import Command, Option, main
 
-    class Hello(Command, description='Simple greeting example'):
+    class Hello(Command):
+        """Simple greeting example"""
+
         name = Option('-n', default='World', help='The person to say hello to')
-        count: int = Option('-c', default=1, help='Number of times to repeat the message')
+        count = Option('-c', type=int, default=1, help='Number of times to repeat the message')
 
         def main(self):
             for _ in range(self.count):
@@ -26,7 +30,9 @@ Here's a basic example of a program that uses CLI Command Parser::
         main()
 
 
-After saving the example above as ``hello_world.py``, we can run it with multiple variations of arguments::
+After saving the example above as ``hello_world.py``, we can run it with multiple variations of arguments:
+
+.. code-block:: shell-session
 
     $ hello_world.py
     Hello World!
@@ -107,15 +113,18 @@ More advanced programs may contain multiple Commands, and more complex entry poi
 Help Text
 =========
 
-Using the Hello World example again, we can see the automatically generated help text::
+Using the Hello World example again, we can see the automatically generated help text:
+
+.. code-block:: shell-session
 
     $ hello_world.py -h
-    usage: hello_world.py [--name NAME] [--help]
+    usage: hello_world.py [--name NAME] [--count COUNT] [--help]
 
     Simple greeting example
 
     Optional arguments:
       --name NAME, -n NAME        The person to say hello to (default: 'World')
+      --count COUNT, -c COUNT     Number of times to repeat the message (default: 1)
       --help, -h                  Show this help message and exit
 
 

--- a/docs/_src/parameters.rst
+++ b/docs/_src/parameters.rst
@@ -7,8 +7,9 @@ but there are `Others`_ as well.  The base class for all Parameters is extensibl
 :class:`~cli_command_parser.parameters.Parameter` types are technically possible as well.
 
 Many parameters support a ``type`` argument, which will result in the user-provided value being cast to that type before
-being stored.  For the parameters that support a type, if not explicitly specified when initializing the parameter, the
-type will be inferred automatically from any type annotations (see :pep:`484`) that are present.
+being stored.  The default type is string (i.e., no type cast occurs).  Most type checkers (mypy, your IDE, etc.) should
+understand the value type to match the specified ``type`` in code that accesses a given parameter without needing to
+explicitly annotate it.
 
 
 .. _common_init_params:
@@ -71,9 +72,14 @@ Common parameters that are supported when initializing most Parameters:
 :type: A callable (function, class, etc.) that accepts a single string argument to be used to transform parsed
   argument values.  It will be used before evaluating whether the value is in ``choices``, if specified.  If ``nargs``
   accepts multiple values, then this will be called on each value individually before appending it to the list of
-  values.  By default, no transformation is performed, and values will be strings.  If not specified, but a type
-  annotation is detected, then that annotation will be used as if it was provided here.  When both are present, this
-  argument takes precedence.
+  values.  By default, no transformation is performed, and values will be strings.
+
+  .. warning:: Type inference from annotations is deprecated
+
+        In the past, the use of invalid type annotations for parameters was fully supported as an alternative to passing
+        an explicit ``type=...`` argument.  This is now deprecated, and it will be removed in a future (TBD) version.
+        See :ref:`configuration:Parameter Options:allow_annotation_type` for more info.
+
 :strict_default: Whether default values should be processed as if provided via CLI (this happens when
   ``strict_default=False``, the default), or used as-is (``strict_default=True``).  Only applies to :doc:`inputs`
   that have a :meth:`~.InputType.fix_default` method.
@@ -592,9 +598,9 @@ are provided to simplify this distinction: :func:`.before_main` and :func:`.afte
 Example command::
 
     class Build(Command):
-        build_dir: Path = Option(required=True, help='The target build directory')
-        install_dir: Path = Option(required=True, help='The target install directory')
-        backup_dir: Path = Option(required=True, help='Directory in which backups should be stored')
+        build_dir = Option(required=True, help='The target build directory')
+        install_dir = Option(required=True, help='The target install directory')
+        backup_dir = Option(required=True, help='Directory in which backups should be stored')
 
         @before_main('-b', help='Backup the install directory before building')
         def backup(self):

--- a/docs/_src/subcommands.rst
+++ b/docs/_src/subcommands.rst
@@ -107,7 +107,7 @@ we can see an example of two levels of subcommands, and another way that we can 
 
     class Find(ApiWrapper, help='Find objects'):
         sub_cmd = SubCommand(help='What to find')
-        limit: int = Option('-L', default=10, help='The number of results to show')
+        limit = Option('-L', type=int, default=10, help='The number of results to show')
 
         def main(self):
             for obj in self.find_objects():

--- a/examples/complex/__main__.py
+++ b/examples/complex/__main__.py
@@ -1,4 +1,0 @@
-from examples.complex import main
-
-if __name__ == '__main__':
-    main()

--- a/examples/custom_inputs.py
+++ b/examples/custom_inputs.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python
 
 from cli_command_parser import Command, Option, ParamGroup, main
-from cli_command_parser.inputs import File, FileWrapper, Json, NumRange, Path, Range
+from cli_command_parser.inputs import File, Json, NumRange, Path, Range
 
 
 class InputsExample(Command):
     path = Option('-p', type=Path(exists=True, type='file'), help='The path to a file')
     in_file = Option('-f', type=File(allow_dash=True, lazy=False), help='The path to a file to read')
-    out_file: FileWrapper = Option('-o', type=File(allow_dash=True, mode='w'), help='The path to a file to write')
-    json: FileWrapper = Option('-j', type=Json(allow_dash=True), help='The path to a file containing json')
+    out_file = Option('-o', type=File(allow_dash=True, mode='w'), help='The path to a file to write')
+    json = Option('-j', type=Json(allow_dash=True), help='The path to a file containing json')
 
     with ParamGroup(mutually_exclusive=True):
         simple_range = Option('-r', type=Range(50), help='Choose a number in the specified range')
-        skip_range = Option('-k', type=range(1, 30, 2), help='Choose a number in the specified range')
+        skip_range = Option('-k', choices=range(1, 30, 2), help='Choose a number in the specified range')
         float_range = Option('-F', type=NumRange(float, min=0, max=1), help='Choose a number in the specified range')
         choice_range = Option('-c', choices=range(20), help='Choose a number in the specified range')
 

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -6,9 +6,11 @@ Example ``Hello World`` implementation using CLI Command Parser.
 from cli_command_parser import Command, Option, main
 
 
-class HelloWorld(Command, description='Simple greeting example', epilog='Contact <example@fake.org> with any issues'):
+class HelloWorld(Command, epilog='Contact <example@fake.org> with any issues'):
+    """Simple greeting example"""
+
     name = Option('-n', default='World', help='The person to say hello to')
-    count: int = Option('-c', default=1, help='Number of times to repeat the message')
+    count = Option('-c', type=int, default=1, help='Number of times to repeat the message')
 
     def main(self):
         for _ in range(self.count):

--- a/examples/rest_api_wrapper.py
+++ b/examples/rest_api_wrapper.py
@@ -51,7 +51,7 @@ class Sync(ApiWrapper, help='Sync group members'):
 
 class Find(ApiWrapper, help='Find objects'):
     sub_cmd = SubCommand(help='What to find')
-    limit: int = Option('-L', default=10, help='The number of results to show')
+    limit = Option('-L', type=int, default=10, help='The number of results to show')
 
     def main(self):
         for obj in self.find_objects():
@@ -85,7 +85,9 @@ class FindBar(Find, choice='bar', help='Find bar objects'):
 class FindBaz(Find, choices=('baz', 'bazs'), help='Find baz objects'):
     with ParamGroup(description='Filter Choices', mutually_exclusive=True, required=True):
         foo = Option('-f', metavar='NAME', help='Find baz objects related to the foo object with the specified name')
-        bar: int = Option('-b', metavar='ID', help='Find baz objects related to the bar object with the specified ID')
+        bar = Option(
+            '-b', type=int, metavar='ID', help='Find baz objects related to the bar object with the specified ID'
+        )
 
     def find_objects(self):
         if self.foo:

--- a/lib/cli_command_parser/context.py
+++ b/lib/cli_command_parser/context.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from .commands import Command
     from .core import CommandMeta
     from .parameters import ActionFlag, BaseOption, Parameter
-    from .typing import Bool, OptStr, ParamOrGroup, PathLike, StrSeq
+    from .typing import AnyParam, Bool, OptStr, ParamOrGroup, PathLike, StrSeq
 
     Argv = StrSeq | None
     AnyConfig = CommandConfig | dict[str, Any] | None
@@ -157,7 +157,7 @@ class Context(AbstractContextManager):  # Extending AbstractContextManager to ma
         self,
         command: Command | None = None,
         *,
-        exclude: Collection[Parameter[Any, Any]] = (),
+        exclude: Collection[AnyParam] = (),
         recursive: Bool = True,
         default: Any = None,
         include_defaults: Bool = True,
@@ -217,23 +217,23 @@ class Context(AbstractContextManager):  # Extending AbstractContextManager to ma
 
     # region Parsing Methods - Generally not intended to be called by users
 
-    def has_parsed_value(self, param: Parameter) -> bool:
+    def has_parsed_value(self, param: AnyParam) -> bool:
         return param in self._parsed
 
-    def get_parsed_value(self, param: Parameter, default=_NotSet):
+    def get_parsed_value(self, param: AnyParam, default=_NotSet):
         """Not intended to be called by users.  Used by Parameters to access their parsed values."""
         return self._parsed.get(param, default)
 
-    def set_parsed_value(self, param: Parameter, value: Any):
+    def set_parsed_value(self, param: AnyParam, value: Any):
         """Not intended to be called by users.  Used by Parameters during parsing to store parsed values."""
         self._parsed[param] = value
 
-    def pop_parsed_value(self, param: Parameter):
+    def pop_parsed_value(self, param: AnyParam):
         """Not intended to be called by users.  Used by Parameters during parsing if backtracking is necessary."""
         self._provided[param] = 0
         return self._parsed.pop(param)
 
-    def roll_back_parsed_values(self, param: Parameter, count: int):
+    def roll_back_parsed_values(self, param: AnyParam, count: int):
         """Not intended to be called by users.  Used during parsing as part of backtracking."""
         values = self._parsed[param]
         self._parsed[param] = values[:-count]
@@ -392,13 +392,13 @@ class ContextProxy:
 
     # region Proxied Parsing Methods
 
-    def has_parsed_value(self, param: Parameter) -> bool:
+    def has_parsed_value(self, param: AnyParam) -> bool:
         return get_current_context().has_parsed_value(param)
 
-    def get_parsed_value(self, param: Parameter):
+    def get_parsed_value(self, param: AnyParam):
         return get_current_context().get_parsed_value(param)
 
-    def set_parsed_value(self, param: Parameter, value: Any):
+    def set_parsed_value(self, param: AnyParam, value: Any):
         get_current_context().set_parsed_value(param, value)
 
     def record_action(self, param: ParamOrGroup, val_count: int = 1):
@@ -525,7 +525,7 @@ def get_parsed(
     return parsed
 
 
-def get_raw_arg(command: Command, parameter: Parameter) -> Any:
+def get_raw_arg(command: Command, parameter: AnyParam) -> Any:
     """Retrieve the raw parsed argument value(s) provided for the given Parameter"""
     return get_context(command).get_parsed_value(parameter)
 

--- a/lib/cli_command_parser/conversion/cli.py
+++ b/lib/cli_command_parser/conversion/cli.py
@@ -38,7 +38,7 @@ class ParserConverter(Command):
 class Convert(ParserConverter):
     """Print the cli-command-parser Commands that are equivalent to the discovered argparse ArgumentParsers"""
 
-    input = Positional(type=IPath(type='file', exists=True), help=f'A file containing an {arg_parser}')
+    input: Param[Path] = Positional(type=IPath(type='file', exists=True), help=f'A file containing an {arg_parser}')
     add_methods = Flag('--no-methods', '-M', default=True, help='Do not include boilerplate methods in Commands')
 
     def main(self):
@@ -50,7 +50,7 @@ class Convert(ParserConverter):
 class Pprint(ParserConverter):
     """Print a tiered internal representation of the discovered argparse ArgumentParsers and their groups/arguments"""
 
-    input = Positional(type=IPath(type='file', exists=True), help=f'A file containing an {arg_parser}')
+    input: Param[Path] = Positional(type=IPath(type='file', exists=True), help=f'A file containing an {arg_parser}')
 
     def main(self):
         for parser in self.script.parsers:

--- a/lib/cli_command_parser/conversion/visitor.py
+++ b/lib/cli_command_parser/conversion/visitor.py
@@ -278,7 +278,7 @@ class ScriptVisitor(NodeVisitor):
     def visit_withitem(self, item: withitem):
         """
         Visit a single ``withitem`` / context expression within a ``with ...:`` statement that may include one or more
-        ``withitem``s / content expressions.
+        ``withitem`` entries / content expressions.
         """
         if func := self.resolve_ref(item.context_expr, True):
             # Found a `with foo(...):` statement where `foo` is being tracked or a `with bar:` where `bar = foo(...)`

--- a/lib/cli_command_parser/exceptions.py
+++ b/lib/cli_command_parser/exceptions.py
@@ -12,9 +12,9 @@ from typing import TYPE_CHECKING, Any, Collection, Mapping
 from .utils import _parse_tree_target_repr
 
 if TYPE_CHECKING:
-    from .parameters import BaseOption, Parameter
+    from .parameters import BaseOption
     from .parse_tree import PosNode, Target, Word
-    from .typing import ParamOrGroup
+    from .typing import AnyParam, OptStr, ParamOrGroup
 
 __all__ = [
     'CommandParserException',
@@ -56,7 +56,7 @@ class CommandParserException(Exception):
 class ParserExit(CommandParserException):
     """Exception used to exit with the given message and status code"""
 
-    def __init__(self, message: str | None = None, code: int = 0):
+    def __init__(self, message: OptStr = None, code: int = 0):
         self.code = code
         self.message = message
 
@@ -121,13 +121,13 @@ class AmbiguousParseTree(CommandDefinitionError):
 class UsageError(CommandParserException):
     """Base exception for user errors"""
 
-    message: str | None = None
+    message: OptStr = None
 
 
 class ParamUsageError(UsageError):
     """Error raised when a Parameter was not used correctly"""
 
-    def __init__(self, param: ParamOrGroup | None, message: str | None = None):
+    def __init__(self, param: ParamOrGroup | None, message: OptStr = None):
         self.param = param
         self.usage_str = param.format_usage(full=True, delim=' / ') if param else ''
         if message:
@@ -144,7 +144,7 @@ class ParamUsageError(UsageError):
 class MultiParamUsageError(UsageError):
     """Error raised when a combination of Parameters was not used correctly"""
 
-    def __init__(self, params: Collection[ParamOrGroup], message: str | None = None):
+    def __init__(self, params: Collection[ParamOrGroup], message: OptStr = None):
         self.params = params
         self.usage_str = ', '.join(sorted(param.format_usage(full=True, delim=' / ') for param in params))
         if message:
@@ -162,7 +162,7 @@ class MultiParamUsageError(UsageError):
 class AmbiguousCombo(MultiParamUsageError):
     """Error raised when an ambiguous combination of short options were provided"""
 
-    def __init__(self, params: Collection[ParamOrGroup], combo: str, message: str | None = None):
+    def __init__(self, params: Collection[ParamOrGroup], combo: str, message: OptStr = None):
         super().__init__(params, message)
         self.combo = combo
 
@@ -183,7 +183,7 @@ class ParamConflict(MultiParamUsageError):
 class ParamsMissing(UsageError):
     """Error raised when one or more required Parameters were not provided"""
 
-    def __init__(self, params: Collection[ParamOrGroup], message: str | None = None, partial: bool = False):
+    def __init__(self, params: Collection[ParamOrGroup], message: OptStr = None, partial: bool = False):
         self.params = params
         self.usage_str = ', '.join(param.format_usage(full=True, delim=' / ') for param in params)
         self.partial = partial
@@ -210,7 +210,7 @@ class BadArgument(ParamUsageError):
 class InvalidChoice(BadArgument):
     """Error raised when a value that does not match one of the pre-defined choices was provided for a Parameter"""
 
-    def __init__(self, param: Parameter | None, invalid: Any, choices: Collection[Any], env_var: str | None = None):
+    def __init__(self, param: AnyParam | None, invalid: Any, choices: Collection[Any], env_var: OptStr = None):
         src = f' from env var={env_var!r}' if env_var else ''
         if isinstance(invalid, Collection) and not isinstance(invalid, str):
             bad_str = f'choices{src}: {", ".join(map(repr, invalid))}'
@@ -228,7 +228,7 @@ class MissingArgument(BadArgument):
 class TooManyArguments(BadArgument):
     """Error raised when too many values were provided for a Parameter"""
 
-    def __init__(self, param: Parameter, message: str | None = None):
+    def __init__(self, param: AnyParam, message: OptStr = None):
         msg = f'expected {param.nargs} args - cannot accept any additional args'
         super().__init__(param, f'{msg} - {message}' if message else msg)
 

--- a/lib/cli_command_parser/formatting/params.py
+++ b/lib/cli_command_parser/formatting/params.py
@@ -123,7 +123,7 @@ class ParameterHelpFormatter(ParamHelpFormatter[ParamP], param_cls=Parameter):
         config = ctx.config
         if (t := param.type) is not None:
             try:
-                metavar = t.format_metavar(  # type: ignore[union-attr]
+                metavar = t.format_metavar(  # type: ignore[attr-defined]
                     config.choice_delim, config.sort_choices
                 )
             except Exception:  # noqa  # pylint: disable=W0703

--- a/lib/cli_command_parser/inputs/__init__.py
+++ b/lib/cli_command_parser/inputs/__init__.py
@@ -21,9 +21,7 @@ from .time import Date, DateTime, Day, DTFormatMode, Month, Time, TimeDelta
 from .utils import FileWrapper, StatMode
 
 if _t.TYPE_CHECKING:
-    from ..typing import ChoicesType, InputTypeFunc, NormalizedType, T, TypeFunc
-
-    TypeT: _t.TypeAlias = _t.Union[_t.Type[T], TypeFunc[T], InputType[T]]
+    from ..typing import ChoicesType, T, TypeFunc
 
 # fmt: off
 __all__ = [
@@ -46,50 +44,48 @@ if _t.TYPE_CHECKING:
     def normalize_input_type(type_func: None, param_choices: None) -> None: ...
 
     @_t.overload
-    def normalize_input_type(type_func: InputType[T], param_choices: None) -> InputType[T]: ...
-
-    @_t.overload
     def normalize_input_type(type_func: TypeFunc[T], param_choices: None) -> TypeFunc[T]: ...
 
     @_t.overload
-    def normalize_input_type(type_func: _t.Type[T], param_choices: None) -> _t.Type[T]: ...
+    def normalize_input_type(type_func: TypeFunc[T] | None, param_choices: range) -> Range[T]: ...
 
     @_t.overload
-    def normalize_input_type(type_func: TypeT[T] | None, param_choices: _t.Collection[T]) -> Choices[T]: ...
+    def normalize_input_type(type_func: TypeFunc[T] | None, param_choices: _t.Collection[T]) -> Choices[T]: ...
 
     @_t.overload
-    def normalize_input_type(type_func: range, param_choices: _t.Any) -> Range[int]: ...
+    def normalize_input_type(type_func: range, param_choices: None) -> Range[int]: ...
 
     @_t.overload
-    def normalize_input_type(type_func: _Pattern, param_choices: _t.Any) -> Regex[str]: ...
+    def normalize_input_type(type_func: _Pattern, param_choices: None) -> Regex[str]: ...
 
 
-def normalize_input_type(type_func: InputTypeFunc[T], param_choices: ChoicesType[T]) -> NormalizedType[T]:
+def normalize_input_type(
+    type_func: TypeFunc[T] | range | _Pattern | None, param_choices: range | ChoicesType[T] | None
+) -> TypeFunc[T] | Range[T] | Range[int] | Choices[T] | Regex[str] | None:
     if param_choices is not None:
         if not param_choices:
             raise _ParamDefinitionError(f'Invalid choices={param_choices!r} - when specified, choices cannot be empty')
-        elif isinstance(param_choices, range):
-            return Range(param_choices, type_func)
-        elif isinstance(param_choices, _INVALID_CHOICES_TYPES):
+        if isinstance(param_choices, _INVALID_CHOICES_TYPES):
             raise _ParamDefinitionError(f'Invalid choices={param_choices!r} - use type={param_choices!r} instead')
-        elif isinstance(type_func, _INVALID_TYPES_WITH_CHOICES):
+        if isinstance(type_func, _INVALID_TYPES_WITH_CHOICES):
             raise _ParamDefinitionError(f'Cannot combine type={type_func!r} with choices={param_choices!r}')
 
     match type_func:
         case None:
-            if param_choices is None:
-                return type_func
-            return Choices(param_choices)
+            pass
+        case _EnumMeta():
+            type_func: EnumChoices = EnumChoices(type_func)  # type: ignore[no-redef]
         case range():
             return Range(type_func)
         case _Pattern():
             return Regex(type_func)
-        case _EnumMeta():
-            enum_choices: EnumChoices = EnumChoices(type_func)
-            if param_choices is None:
-                return enum_choices
-            return Choices(param_choices, enum_choices)
+        case _ if not callable(type_func):
+            raise _ParamDefinitionError(f'Invalid type={type_func!r} - expected a callable')
 
-    if param_choices is None:
-        return type_func
-    return Choices(param_choices, type_func)
+    match param_choices:
+        case None:
+            return type_func
+        case range():
+            return Range(param_choices, type=type_func)
+        case _:
+            return Choices(param_choices, type_func)

--- a/lib/cli_command_parser/inputs/files.py
+++ b/lib/cli_command_parser/inputs/files.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 import os
 from abc import ABC
 from pathlib import Path as _Path
-from typing import TYPE_CHECKING, Any, AnyStr, Literal, TypeVar, overload
+from typing import TYPE_CHECKING, Any, AnyStr, Literal, overload
 
 from ..typing import T
 from .base import InputType
@@ -29,8 +29,6 @@ if TYPE_CHECKING:
     from ._typing import AnySerializer, OpenAnyMode, OpenBinaryMode, OpenTextMode
 
 __all__ = ['Path', 'File', 'Serialized', 'Json', 'Pickle']
-
-T_co = TypeVar('T_co', covariant=True)
 
 
 class FileInput(InputType[T], ABC):
@@ -143,7 +141,7 @@ class Path(FileInput[_Path]):
         return self.validated_path(value)
 
 
-class File(FileInput[T_co]):
+class File(FileInput[T]):
     """
     :param mode: The mode in which the file should be opened.  For more info, see :func:`python:open`.
     :param encoding: The encoding to use when reading the file in text mode.  Ignored if the parsed path is ``-``.
@@ -288,14 +286,14 @@ class File(FileInput[T_co]):
     def _prep_file_wrapper(self, path: _Path) -> FileWrapper:
         return FileWrapper(path, self.mode, encoding=self.encoding, errors=self.errors, parents=self.parents)
 
-    def __call__(self, value: PathLike) -> T_co:
+    def __call__(self, value: PathLike) -> T:
         wrapper = self._prep_file_wrapper(self.validated_path(value))
         if self.lazy:
             return wrapper  # type: ignore[return-value]
         return wrapper.read()
 
 
-class Serialized(File[T_co]):
+class Serialized(File[T]):
     """
     :param serializer: Class or module that provides ``load``/``dump`` and/or ``loads``/``dumps`` methods/functions for
       deserialization and serialization, respectively.  Expects them to follow the same interface as the *json* or
@@ -390,7 +388,7 @@ class Serialized(File[T_co]):
         )
 
 
-class Json(Serialized[T_co]):
+class Json(Serialized[T]):
     """
     :param kwargs: Additional keyword arguments to pass to :class:`.File`
     """
@@ -464,7 +462,7 @@ class Json(Serialized[T_co]):
         super().__init__(JsonSerializer(wrap_errors), mode=mode, **kwargs)
 
 
-class Pickle(Serialized[T_co]):
+class Pickle(Serialized[T]):
     """
     :param kwargs: Additional keyword arguments to pass to :class:`.File`
     """

--- a/lib/cli_command_parser/inputs/numeric.py
+++ b/lib/cli_command_parser/inputs/numeric.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import re
 from abc import ABC, abstractmethod
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, overload
 
 from ._typing import N, Number, NumType, RngType
 from .base import _FixedInputType
@@ -71,11 +71,31 @@ class Range(_RangeInput[N]):
     range: _range
     snap: bool
 
+    if TYPE_CHECKING:
+
+        @overload
+        def __init__(
+            self: Range[int],
+            range: RngType,  # noqa
+            snap: Bool = ...,
+            type: None = None,  # noqa
+            fix_default: Bool = ...,
+        ): ...
+
+        @overload
+        def __init__(
+            self: Range[N],
+            range: RngType,  # noqa
+            snap: Bool = ...,
+            type: NumType[N] = ...,  # noqa
+            fix_default: Bool = ...,
+        ): ...
+
     def __init__(
         self,
         range: RngType,  # noqa
         snap: Bool = False,
-        type: NumType | None = None,  # noqa
+        type: NumType[N] | None = None,  # noqa
         fix_default: Bool = True,
     ):
         super().__init__(fix_default)
@@ -132,20 +152,49 @@ class NumRange(RangeMixin, _RangeInput[N]):
     __slots__ = ('type', 'snap', 'min', 'max', 'include_min', 'include_max')
     snap: bool
 
+    if TYPE_CHECKING:
+
+        @overload
+        def __init__(
+            self: NumRange[N],
+            type: None = None,  # noqa
+            snap: Bool = ...,
+            *,
+            min: N | None = ...,  # noqa
+            max: N | None = ...,  # noqa
+            include_min: Bool = ...,
+            include_max: Bool = ...,
+            fix_default: Bool = ...,
+        ): ...
+
+        @overload
+        def __init__(
+            self: NumRange[N],
+            type: NumType[N],  # noqa
+            snap: Bool = ...,
+            *,
+            # int is included below to indicate that int min/max with type=float will still produce float
+            min: N | int | None = ...,  # noqa
+            max: N | int | None = ...,  # noqa
+            include_min: Bool = ...,
+            include_max: Bool = ...,
+            fix_default: Bool = ...,
+        ): ...
+
     def __init__(
         self,
-        type: NumType | None = None,  # noqa
+        type: NumType[N] | None = None,  # noqa
         snap: Bool = False,
         *,
-        min: Number = None,  # noqa
-        max: Number = None,  # noqa
+        min: N | int | None = None,  # noqa
+        max: N | int | None = None,  # noqa
         include_min: Bool = True,
         include_max: Bool = False,
         fix_default: Bool = True,
     ):
         if min is None and max is None:
             raise ValueError('NumRange inputs must be initialized with at least one of min and/or max values')
-        elif min is not None and max is not None and min >= max:
+        elif min is not None and max is not None and min >= max:  # type: ignore[operator]
             raise ValueError(f'Invalid {min=} >= {max=} - min must be less than max')
 
         super().__init__(fix_default)
@@ -159,17 +208,18 @@ class NumRange(RangeMixin, _RangeInput[N]):
                 raise TypeError('Unable to snap to extrema with type=float')
 
             if min is not None and max is not None:
-                real_min = min if include_min else min + 1
-                real_max = max if include_max else max - 1
-                if real_min >= real_max:
+                real_min = min if include_min else min + 1  # type: ignore[operator]
+                real_max = max if include_max else max - 1  # type: ignore[operator]
+                if real_min >= real_max:  # type: ignore[operator]
                     raise ValueError(
                         f'Invalid {min=} >= {max=} with snap=True, {include_min=},'
                         f' {include_max=} - snap would produce invalid values'
                     )
 
         self.snap = snap
-        self.min = self.type(min) if min is not None else min  # for floats especially, such as a range like 0~1, this
-        self.max = self.type(max) if max is not None else max  # helps to highlight the type in reprs
+        # for floats especially, such as a range like 0~1, this helps to highlight the type in reprs
+        self.min = self.type(min) if min is not None else min  # type: ignore[arg-type]
+        self.max = self.type(max) if max is not None else max  # type: ignore[arg-type]
         self.include_min = include_min
         self.include_max = include_max
 
@@ -205,7 +255,7 @@ class NumRange(RangeMixin, _RangeInput[N]):
             return num_val
 
 
-class Bytes(NumericInput[int | float]):
+class Bytes(NumericInput[N]):
     """
     A byte count/size.
 
@@ -229,6 +279,30 @@ class Bytes(NumericInput[int | float]):
     __slots__ = ('base', 'short', 'fractions', 'negative')
     _pattern = re.compile(r'^(-?\d+(?:\.\d+)?)\s*([KMGTPEZYRQ]?i?B?)$', re.IGNORECASE)
     _PREFIXES = 'KMGTPEZYRQ'
+
+    if TYPE_CHECKING:
+
+        @overload
+        def __init__(
+            self: Bytes[float],
+            base: Literal[2, 10] = 10,
+            *,
+            short: Bool = True,
+            fractions: Literal[True],
+            negative: Bool = False,
+            fix_default: Bool = True,
+        ): ...
+
+        @overload
+        def __init__(
+            self: Bytes[int],
+            base: Literal[2, 10] = 10,
+            *,
+            short: Bool = True,
+            fractions: Bool = False,
+            negative: Bool = False,
+            fix_default: Bool = True,
+        ): ...
 
     def __init__(
         self,
@@ -282,7 +356,7 @@ class Bytes(NumericInput[int | float]):
         parts.append('byte count/size')
         return ' '.join(parts)
 
-    def __call__(self, value: str) -> int | float:
+    def __call__(self, value: str) -> N:
         try:
             num, unit = self._pattern.match(value.strip()).groups()  # type: ignore[union-attr]
         except (TypeError, AttributeError):
@@ -296,7 +370,7 @@ class Bytes(NumericInput[int | float]):
         if not self.negative and num < 0:
             raise InputValidationError(f'expected {self._type_desc()}, but found {num!r}')
 
-        return num * self._get_multiplier(unit)
+        return num * self._get_multiplier(unit)  # type: ignore[return-value]
 
     def _get_multiplier(self, unit: str | None) -> int:
         if not unit:

--- a/lib/cli_command_parser/inputs/patterns.py
+++ b/lib/cli_command_parser/inputs/patterns.py
@@ -22,7 +22,7 @@ __all__ = ['Regex', 'RegexMode', 'Glob']
 _Pat = str | Pattern
 GroupsResult = tuple[str, ...]
 DictResult = dict[str, str]
-RegexResult = TypeVar('RegexResult', str, Match, GroupsResult, DictResult)
+RegexResult = TypeVar('RegexResult', str, Match[str], GroupsResult, DictResult)
 
 
 class PatternInput(InputType[T], ABC):
@@ -105,46 +105,23 @@ class Regex(PatternInput[RegexResult]):
         def __init__(
             self: Regex[str],
             *patterns: _Pat,
-            group: str | int,
-            groups: Collection[str | int] | None = None,
-            mode: Literal['group', RegexMode.GROUP] | None = None,
+            group: str | int | None = None,
+            mode: Literal['group', RegexMode.GROUP, 'string', RegexMode.STRING] | None = None,
         ): ...
 
         @overload
         def __init__(
             self: Regex[GroupsResult],
             *patterns: _Pat,
-            group: None = None,
-            groups: Collection[str | int],
+            groups: Collection[str | int] | None = None,
             mode: Literal['groups', RegexMode.GROUPS] | None = None,
         ): ...
 
         @overload
-        def __init__(
-            self: Regex[str],
-            *patterns: _Pat,
-            group: None = None,
-            groups: None = None,
-            mode: Literal['string', RegexMode.STRING] | None = None,
-        ): ...
+        def __init__(self: Regex[Match[str]], *patterns: _Pat, mode: Literal['match', RegexMode.MATCH]): ...
 
         @overload
-        def __init__(
-            self: Regex[Match],
-            *patterns: _Pat,
-            group: None = None,
-            groups: None = None,
-            mode: Literal['match', RegexMode.MATCH],
-        ): ...
-
-        @overload
-        def __init__(
-            self: Regex[DictResult],
-            *patterns: _Pat,
-            group: None = None,
-            groups: None = None,
-            mode: Literal['dict', RegexMode.DICT],
-        ): ...
+        def __init__(self: Regex[DictResult], *patterns: _Pat, mode: Literal['dict', RegexMode.DICT]): ...
 
     # endregion
 

--- a/lib/cli_command_parser/inputs/time.py
+++ b/lib/cli_command_parser/inputs/time.py
@@ -22,7 +22,7 @@ from datetime import date, datetime, time, timedelta
 from enum import Enum
 from locale import LC_ALL, setlocale
 from threading import RLock
-from typing import TYPE_CHECKING, ClassVar, Collection, Iterator, Literal, NoReturn, Sequence, Type, TypeVar, overload
+from typing import TYPE_CHECKING, ClassVar, Collection, Iterator, Literal, Sequence, Type, TypeVar, overload
 
 from ..typing import T
 from ..utils import MissingMixin
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
 __all__ = ['DTFormatMode', 'Day', 'Month', 'TimeDelta', 'DateTime', 'Date', 'Time']
 
 DT = TypeVar('DT', datetime, date, time)
+SI = TypeVar('SI', str, int)
 TimeUnit = Literal['microseconds', 'milliseconds', 'seconds', 'minutes', 'hours', 'days', 'weeks']
 _TIMEDELTA_UNITS = {'microseconds', 'milliseconds', 'seconds', 'minutes', 'hours', 'days', 'weeks'}
 DEFAULT_DATE_FMT = '%Y-%m-%d'
@@ -111,7 +112,10 @@ class DTFormatMode(MissingMixin, Enum):
     # fmt: on
 
 
-class CalendarUnitInput(DTInput[str | int], ABC):
+_StrDTFormatMode = Literal['full', 'abbreviation', DTFormatMode.FULL, DTFormatMode.ABBREVIATION]
+
+
+class CalendarUnitInput(DTInput[SI], ABC):
     """
     Input type representing a date/time unit.
 
@@ -125,6 +129,7 @@ class CalendarUnitInput(DTInput[str | int], ABC):
     """
 
     __slots__ = ('full', 'abbreviation', 'numeric', 'out_format', 'out_locale')
+    out_format: DTFormatMode
     _formats: dict[DTFormatMode, Sequence[str | int]]
     _min_index: int = 0
 
@@ -211,20 +216,20 @@ class CalendarUnitInput(DTInput[str | int], ABC):
 
         raise InvalidChoiceError(value, self.choices(), self.dt_type)
 
-    def __call__(self, value: str) -> str | int:
+    def __call__(self, value: str) -> SI:
         normalized = self.parse(value)
         if normalized < self._min_index:
             raise InvalidChoiceError(value, self.choices(), self.dt_type)
         elif self.out_format in (DTFormatMode.NUMERIC, DTFormatMode.NUMERIC_ISO):
-            return self._formats[self.out_format][normalized]
+            return self._formats[self.out_format][normalized]  # type: ignore[return-value]
         elif (names_or_abbreviations := self._formats.get(self.out_format)) is not None:
             with different_locale(self.out_locale):
-                return names_or_abbreviations[normalized]
+                return names_or_abbreviations[normalized]  # type: ignore[return-value]
 
         raise ValueError(f'Unexpected output format={self.out_format!r} for {self.dt_type}={normalized}')
 
 
-class Day(CalendarUnitInput, dt_type='day of the week'):
+class Day(CalendarUnitInput[SI], dt_type='day of the week'):
     """
     Input type representing a day of the week.
 
@@ -247,22 +252,49 @@ class Day(CalendarUnitInput, dt_type='day of the week'):
         DTFormatMode.NUMERIC_ISO: range(1, 8),  # 1 = Monday; 7 = Sunday
     }
 
-    @overload
-    def __init__(
-        self,
-        *,
-        full: Bool = True,
-        abbreviation: Bool = True,
-        numeric: Bool = False,
-        iso: Bool = False,
-        locale: Locale | None = None,
-        out_format: str | DTFormatMode = DTFormatMode.FULL,
-        out_locale: Locale | None = None,
-        fix_default: Bool = True,
-    ): ...
+    if TYPE_CHECKING:
 
-    @overload
-    def __init__(self: NoReturn) -> NoReturn: ...  # type: ignore[misc]  # Workaround for single overload def error
+        @overload
+        def __init__(
+            self: Day[str],
+            *,
+            full: Bool = True,
+            abbreviation: Bool = True,
+            numeric: Bool = False,
+            iso: Bool = False,
+            locale: Locale | None = None,
+            out_format: _StrDTFormatMode = DTFormatMode.FULL,
+            out_locale: Locale | None = None,
+            fix_default: Bool = True,
+        ): ...
+
+        @overload
+        def __init__(
+            self: Day[int],
+            *,
+            full: Bool = True,
+            abbreviation: Bool = True,
+            numeric: Bool = False,
+            iso: Bool = False,
+            locale: Locale | None = None,
+            out_format: Literal['numeric', 'numeric_iso', DTFormatMode.NUMERIC, DTFormatMode.NUMERIC_ISO],
+            out_locale: Locale | None = None,
+            fix_default: Bool = True,
+        ): ...
+
+        @overload
+        def __init__(
+            self,
+            *,
+            full: Bool = True,
+            abbreviation: Bool = True,
+            numeric: Bool = False,
+            iso: Bool = False,
+            locale: Locale | None = None,
+            out_format: str | DTFormatMode = DTFormatMode.FULL,
+            out_locale: Locale | None = None,
+            fix_default: Bool = True,
+        ): ...
 
     def __init__(self, *, iso: Bool = False, **kwargs):
         super().__init__(**kwargs)
@@ -286,7 +318,7 @@ class Day(CalendarUnitInput, dt_type='day of the week'):
             )
 
 
-class Month(CalendarUnitInput, dt_type='month', min_index=1):
+class Month(CalendarUnitInput[SI], dt_type='month', min_index=1):
     """
     Input type representing a month.
 
@@ -306,21 +338,49 @@ class Month(CalendarUnitInput, dt_type='month', min_index=1):
         DTFormatMode.NUMERIC: range(13),
     }
 
-    @overload
-    def __init__(
-        self,
-        *,
-        full: Bool = True,
-        abbreviation: Bool = True,
-        numeric: Bool = True,
-        locale: Locale | None = None,
-        out_format: str | DTFormatMode = DTFormatMode.FULL,
-        out_locale: Locale | None = None,
-        fix_default: Bool = True,
-    ): ...
+    if TYPE_CHECKING:
 
-    @overload
-    def __init__(self: NoReturn) -> NoReturn: ...  # type: ignore[misc]  # Workaround for single overload def error
+        @overload
+        def __init__(
+            self: Month[str],
+            *,
+            full: Bool = True,
+            abbreviation: Bool = True,
+            numeric: Bool = True,
+            iso: Bool = False,
+            locale: Locale | None = None,
+            out_format: _StrDTFormatMode = DTFormatMode.FULL,
+            out_locale: Locale | None = None,
+            fix_default: Bool = True,
+        ): ...
+
+        @overload
+        def __init__(
+            self: Month[int],
+            *,
+            full: Bool = True,
+            abbreviation: Bool = True,
+            numeric: Bool = True,
+            iso: Bool = False,
+            locale: Locale | None = None,
+            out_format: Literal['numeric', DTFormatMode.NUMERIC],
+            out_locale: Locale | None = None,
+            fix_default: Bool = True,
+        ): ...
+
+        @overload
+        def __init__(
+            self,
+            *,
+            full: Bool = True,
+            abbreviation: Bool = True,
+            numeric: Bool = True,
+            iso: Bool = False,
+            locale: Locale | None = None,
+            out_format: str | DTFormatMode = DTFormatMode.FULL,
+            out_locale: Locale | None = None,
+            fix_default: Bool = True,
+        ): ...
 
     def __init__(self, *, numeric: Bool = True, **kwargs):
         super().__init__(numeric=numeric, **kwargs)

--- a/lib/cli_command_parser/metadata.py
+++ b/lib/cli_command_parser/metadata.py
@@ -82,6 +82,7 @@ class MetadataBase(Generic[_T]):
 
     @classmethod
     def _get_parent(cls, instance: ProgramMetadata) -> ProgramMetadata | None:
+        # TODO: Maybe this strict package check is why epilog isn't inherited, if the parent is in a different sub-pkg?
         # if (parent := instance.parent) and parent.distribution == instance.distribution:
         if (parent := instance.parent) and parent.package == instance.package:
             return parent
@@ -125,7 +126,7 @@ def dynamic_metadata(func=None, *, inheritable: bool = True):
 
 
 class ProgramMetadata:
-    _fields = {'parent'}
+    _fields = {'parent'}  # This is updated by `MetadataBase.__set_name__`
     parent: ProgramMetadata | None = None
     distribution: Metadata[Distribution | None] = Metadata(None, inheritable=False)
     path: Metadata[Path | None] = Metadata(None, inheritable=False)
@@ -135,7 +136,7 @@ class ProgramMetadata:
     command: Metadata[str | None] = Metadata(None, inheritable=False)
     usage: Metadata[str | None] = Metadata(None)
     description: Metadata[str | None] = Metadata(None)
-    epilog: Metadata[str | None] = Metadata(None)
+    epilog: Metadata[str | None] = Metadata(None)  # TODO: This is not inherited by subclasses of an ABC, but should be
     doc_str: Metadata[str | str] = Metadata('')
     # pkg_doc_str is set by :func:`~.documentation.load_commands` to capture package docstrings
     pkg_doc_str: Metadata[str | str] = Metadata('')

--- a/lib/cli_command_parser/nargs.py
+++ b/lib/cli_command_parser/nargs.py
@@ -29,10 +29,12 @@ NARGS_STR_RANGES = {'?': (0, 1), '*': (0, None), '+': (1, None), 'REMAINDER': (0
 SET_ERROR_FMT = 'Invalid nargs={!r} set - expected non-empty set where all values are integers >= 0'
 SEQ_ERROR_FMT = 'Invalid nargs={!r} sequence - expected 2 ints where 0 <= a <= b or b is None'
 
+_NargsOrig: TypeAlias = int | tuple[int, _Max] | Sequence[int] | FrozenSet[int] | range | _Remainder
+_NargsValue: TypeAlias = _NargsOrig | set[int]
 NargsStr = Literal['?', '*', '+', 'REMAINDER']
-NargsValue: TypeAlias = (
-    NargsStr | int | tuple[int, _Max] | Sequence[int] | set[int] | FrozenSet[int] | range | _Remainder
-)
+NargsValue: TypeAlias = NargsStr | _NargsValue
+NargsSingle = Literal['?', 1, None]  # nargs values that result in param type=T
+NargsMultiple = Literal['*', '+', 'REMAINDER'] | _NargsValue  # nargs values that result in param type=list[T]
 
 
 class Nargs:
@@ -48,7 +50,7 @@ class Nargs:
     # None or REMAINDER without explicit type verification via isinstance/similar.
 
     __slots__ = ('_orig', 'range', 'min', 'max', 'allowed', 'variable', '_has_upper_bound')
-    _orig: NargsValue
+    _orig: _NargsOrig
     range: range | None
     min: int
     max: _Max
@@ -56,13 +58,14 @@ class Nargs:
     variable: bool
 
     def __init__(self, nargs: NargsValue):
-        self._orig = nargs
+        self._orig = nargs  # type: ignore[assignment]  # set is replaced with frozenset below
         self.range = None
 
         match nargs:
             case int():
                 if nargs < 0:
                     raise ValueError(f'Invalid {nargs=} integer - must be >= 0')
+                # Note: 0 is supported specifically for Flag
                 self.min = self.max = nargs
                 self.allowed = (nargs,)
             case str():
@@ -91,7 +94,7 @@ class Nargs:
                 self.max = max(nargs)
             case Sequence():
                 try:
-                    self.min, self.max = self.allowed = a, b = nargs  # type: ignore[misc,assignment]
+                    self.min, self.max = self.allowed = a, b = nargs  # type: ignore[str-unpack,assignment]
                 except (ValueError, TypeError) as e:
                     raise e.__class__(SEQ_ERROR_FMT.format(nargs)) from e
 
@@ -163,7 +166,7 @@ class Nargs:
             try_all = other.min in allowed and other.max in allowed
             return try_all and all(v in allowed for v in other.range)  # less mem than large set(other.range)
         else:
-            return self.allowed == set(other.allowed)
+            return self.allowed == set(other.allowed)  # noqa
 
     def __hash__(self) -> int:
         return hash(self.__class__) ^ hash(self._orig)

--- a/lib/cli_command_parser/parameters/base.py
+++ b/lib/cli_command_parser/parameters/base.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
     from ..commands import Command
     from ..context import Context
     from ..formatting.params import ParamHelpFormatter
-    from ..typing import Bool, NormalizedType, OptStr, OptStrs, Self, Strings
+    from ..typing import AnyParam, Bool, NormalizedType, OptStr, OptStrs, Self, Strings
     from ._typing import CommandMethod, DefaultFunc, LeadingDash
     from .actions import ParamAction
     from .groups import ParamGroup
@@ -59,12 +59,12 @@ class Param(Generic[T]):
         def __get__(self, command: Literal[None], owner: Any = None) -> Self: ...
 
         @overload
-        def __get__(self, command: Command, owner: Any = None) -> T | None: ...
+        def __get__(self, command: Command, owner: Any = None) -> T: ...
 
         @overload
         def __get__(self, command: object, owner: Any = None) -> Self: ...
 
-        def __get__(self, command: Command | object | None, owner: Any = None) -> Self | T | None: ...
+        def __get__(self, command: Command | object | None, owner: Any = None) -> Self | T: ...
 
 
 class ParamBase(ABC):
@@ -245,7 +245,7 @@ class Parameter(ParamBase, Param[T | D], ABC):
     metavar: OptStr = None
     allow_leading_dash: AllowLeadingDash = AllowLeadingDash.NUMERIC     # Set in some subclasses
     nargs: Nargs                                                        # Expected to be set in subclasses
-
+    action: ParamAction
     type: NormalizedType[T] = None
 
     # Expected to be set in subclasses
@@ -514,7 +514,7 @@ class Parameter(ParamBase, Param[T | D], ABC):
         if self.required:
             if missing_default is _NotSet:
                 raise MissingArgument(self)
-            return missing_default
+            return missing_default  # type: ignore[return-value]  # mypy bug (doesn't recognize it can't be _NotSetType)
 
         try:
             return self.action.get_default(command, missing_default)
@@ -745,14 +745,14 @@ class AllowLeadingDashProperty:
     def __get__(self, instance: None, owner: Any) -> AllowLeadingDashProperty: ...
 
     @overload
-    def __get__(self, instance: Parameter, owner: Any) -> AllowLeadingDash: ...
+    def __get__(self, instance: AnyParam, owner: Any) -> AllowLeadingDash: ...
 
-    def __get__(self, instance: Parameter | None, owner: Any) -> AllowLeadingDash | AllowLeadingDashProperty:
+    def __get__(self, instance: AnyParam | None, owner: Any) -> AllowLeadingDash | AllowLeadingDashProperty:
         if instance is None:
             return self
         return instance.__dict__.get(self.name, self.default)
 
-    def __set__(self, instance: Parameter, value: LeadingDash | None):
+    def __set__(self, instance: AnyParam, value: LeadingDash | None):
         if value is not None:
             value = AllowLeadingDash(value)
 

--- a/lib/cli_command_parser/parameters/options.py
+++ b/lib/cli_command_parser/parameters/options.py
@@ -10,9 +10,14 @@ import logging
 from functools import partial, update_wrapper
 from typing import TYPE_CHECKING, Any, Callable, Literal, NoReturn, Type, overload
 
+try:
+    from typing import Never
+except ImportError:  # Added in 3.11
+    Never = NoReturn
+
 from ..exceptions import BadArgument, CommandDefinitionError, ParameterDefinitionError, ParamUsageError, ParserExit
 from ..inputs import normalize_input_type
-from ..nargs import Nargs, NargsValue
+from ..nargs import Nargs
 from ..typing import B, D, T
 from ..utils import _NotSet, _NotSetType, str_to_bool
 from .actions import Append, AppendConst, Count, Store, StoreConst
@@ -22,6 +27,7 @@ from .option_strings import TriFlagOptionStrings
 if TYPE_CHECKING:
     from ..commands import Command
     from ..config import OptionNameMode
+    from ..nargs import NargsMultiple, NargsSingle, NargsValue
     from ..typing import Bool, ChoicesType, InputTypeFunc, OptStr, OptStrs, TypeFunc
     from ._typing import CommandMethod, DefaultFunc, LeadingDash
 
@@ -81,33 +87,111 @@ class Option(BaseOption[T, D], actions=(Store, Append)):
 
         @overload
         def __init__(
-            self: Option[T, _NotSetType],
+            self: Option[T, Never],
             *option_strs: str,
             required: Literal[True],
             type: InputTypeFunc[T] = None,  # noqa
             choices: ChoicesType[T] = None,
             default: _NotSetType = _NotSet,
             default_cb: None = None,
-            nargs: NargsValue | None = None,
-            action: OptAct = None,
-            help: OptStr = None,  # noqa
-            hide: Bool = False,
-            metavar: OptStr = None,
-            name: OptStr = None,
-            name_mode: OptionNameMode | OptStr | _NotSetType = _NotSet,
-            allow_leading_dash: LeadingDash | None = None,
-            cb_with_cmd: Bool = False,
-            show_default: Bool = None,
-            strict_default: Bool = False,
-            env_var: OptStrs = None,
-            strict_env: bool = True,
-            use_env_value: Bool = None,
-            show_env_var: Bool = None,
+            nargs: NargsSingle = None,
+            **kwargs,
+        ): ...
+
+        @overload
+        def __init__(
+            self: Option[list[T], Never],
+            *option_strs: str,
+            required: Literal[True],
+            type: InputTypeFunc[T] = None,  # noqa
+            choices: ChoicesType[T] = None,
+            default: _NotSetType = _NotSet,
+            default_cb: None = None,
+            nargs: NargsMultiple,
+            **kwargs,
+        ): ...
+
+        @overload
+        def __init__(
+            self: Option[T, None],
+            *option_strs: str,
+            required: Literal[False] = False,
+            type: InputTypeFunc[T] = None,  # noqa
+            choices: ChoicesType[T] = None,
+            default: _NotSetType = _NotSet,
+            default_cb: DefaultFunc[D] | None = None,
+            nargs: NargsSingle = None,
+            **kwargs,
         ): ...
 
         @overload
         def __init__(
             self: Option[T, D],
+            *option_strs: str,
+            required: Literal[False] = False,
+            type: InputTypeFunc[T] = None,  # noqa
+            choices: ChoicesType[T] = None,
+            default: D,
+            default_cb: DefaultFunc[D] | None = None,
+            nargs: NargsSingle = None,
+            **kwargs,
+        ): ...
+
+        @overload
+        def __init__(
+            self: Option[T, D],
+            *option_strs: str,
+            required: Literal[False] = False,
+            type: InputTypeFunc[T] = None,  # noqa
+            choices: ChoicesType[T] = None,
+            default: _NotSetType = _NotSet,
+            default_cb: DefaultFunc[D],
+            nargs: NargsSingle = None,
+            **kwargs,
+        ): ...
+
+        @overload
+        def __init__(
+            self: Option[list[T], list[T]],
+            *option_strs: str,
+            required: Literal[False] = False,
+            type: InputTypeFunc[T] = None,  # noqa
+            choices: ChoicesType[T] = None,
+            default: _NotSetType = _NotSet,
+            default_cb: DefaultFunc[D] | None = None,
+            nargs: NargsMultiple,
+            **kwargs,
+        ): ...
+
+        @overload
+        def __init__(
+            self: Option[list[T], D],
+            *option_strs: str,
+            required: Literal[False] = False,
+            type: InputTypeFunc[T] = None,  # noqa
+            choices: ChoicesType[T] = None,
+            default: D,
+            default_cb: DefaultFunc[D] | None = None,
+            nargs: NargsMultiple,
+            **kwargs,
+        ): ...
+
+        @overload
+        def __init__(
+            self: Option[list[T], D],
+            *option_strs: str,
+            required: Literal[False] = False,
+            type: InputTypeFunc[T] = None,  # noqa
+            choices: ChoicesType[T] = None,
+            default: _NotSetType = _NotSet,
+            default_cb: DefaultFunc[D],
+            nargs: NargsMultiple,
+            **kwargs,
+        ): ...
+
+        @overload
+        def __init__(
+            self,
             *option_strs: str,
             required: Bool = False,
             type: InputTypeFunc[T] = None,  # noqa
@@ -212,7 +296,7 @@ class Flag(BaseFlag[B, B], actions=(StoreConst, AppendConst)):
 
     nargs = Nargs(0)
     # Without staticmethod, this would be interpreted as a normal method
-    type: TypeFunc[B] = staticmethod(str_to_bool)  # type: ignore[arg-type]
+    type: TypeFunc[B] = staticmethod(str_to_bool)  # type: ignore[assignment]
     use_env_value: bool = False
     __default_const_map = {True: False, False: True, _NotSet: True}
     default: B
@@ -374,7 +458,7 @@ class TriFlag(BaseFlag[B, D], actions=(StoreConst, AppendConst)):
 
     nargs = Nargs(0)
     # Without staticmethod, this would be interpreted as a normal method
-    type: TypeFunc[B] = staticmethod(str_to_bool)  # type: ignore[arg-type]
+    type: TypeFunc[B] = staticmethod(str_to_bool)  # type: ignore[assignment]
     use_env_value: bool = False
     _default_cb_ok = True
     _opt_str_cls = TriFlagOptionStrings

--- a/lib/cli_command_parser/parameters/positionals.py
+++ b/lib/cli_command_parser/parameters/positionals.py
@@ -6,18 +6,24 @@ Positional Parameters
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING, Literal, NoReturn, overload
+
+try:
+    from typing import Never
+except ImportError:  # Added in 3.11
+    Never = NoReturn
 
 from ..exceptions import ParameterDefinitionError
 from ..inputs import normalize_input_type
-from ..nargs import Nargs, NargsValue
+from ..nargs import Nargs
 from ..typing import D, T
 from ..utils import _NotSet, _NotSetType
 from .actions import Append, Store
 from .base import AllowLeadingDashProperty, BasePositional
 
 if TYPE_CHECKING:
-    from ..typing import ChoicesType, InputTypeFunc
+    from ..nargs import NargsMultiple, NargsValue
+    from ..typing import Bool, ChoicesType, InputTypeFunc, OptStr
     from ._typing import DefaultFunc, LeadingDash
 
 __all__ = ['Positional']
@@ -53,6 +59,74 @@ class Positional(BasePositional[T, D], default_ok=True, actions=(Store, Append))
     """
 
     allow_leading_dash = AllowLeadingDashProperty()
+
+    if TYPE_CHECKING:
+
+        @overload
+        def __init__(
+            self: Positional[T, Never],
+            nargs: Literal[1, None] = None,
+            action: Literal['store', 'append'] | None = None,
+            type: InputTypeFunc[T] = None,  # noqa
+            *,
+            choices: ChoicesType[T] = None,
+            allow_leading_dash: LeadingDash | None = None,
+            help: OptStr = None,  # noqa
+            hide: Bool = False,
+            metavar: OptStr = None,
+            name: OptStr = None,
+        ): ...
+
+        @overload
+        def __init__(
+            self: Positional[T, D],
+            nargs: Literal['?'],
+            action: Literal['store', 'append'] | None = None,
+            type: InputTypeFunc[T] = None,  # noqa
+            default: D | _NotSetType = _NotSet,
+            *,
+            default_cb: DefaultFunc[D] | None = None,
+            choices: ChoicesType[T] = None,
+            allow_leading_dash: LeadingDash | None = None,
+            help: OptStr = None,  # noqa
+            hide: Bool = False,
+            metavar: OptStr = None,
+            name: OptStr = None,
+        ): ...
+
+        @overload
+        def __init__(
+            self: Positional[list[T], list[D]],
+            nargs: NargsMultiple,
+            action: Literal['store', 'append'] | None = None,
+            type: InputTypeFunc[T] = None,  # noqa
+            default: D | _NotSetType = _NotSet,
+            *,
+            default_cb: DefaultFunc[D] | None = None,
+            choices: ChoicesType[T] = None,
+            allow_leading_dash: LeadingDash | None = None,
+            help: OptStr = None,  # noqa
+            hide: Bool = False,
+            metavar: OptStr = None,
+            name: OptStr = None,
+        ): ...
+
+        @overload
+        def __init__(
+            self,
+            nargs: NargsValue | None = None,
+            action: Literal['store', 'append'] | None = None,
+            type: InputTypeFunc[T] = None,  # noqa
+            default: D | _NotSetType = _NotSet,
+            *,
+            default_cb: DefaultFunc[D] | None = None,
+            choices: ChoicesType[T] = None,
+            allow_leading_dash: LeadingDash | None = None,
+            help: OptStr = None,  # noqa
+            hide: Bool = False,
+            metavar: OptStr = None,
+            name: OptStr = None,
+        ): ...
 
     def __init__(
         self,

--- a/lib/cli_command_parser/typing.py
+++ b/lib/cli_command_parser/typing.py
@@ -8,18 +8,7 @@ from __future__ import annotations
 
 import sys
 from collections.abc import Collection
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Iterable,
-    Pattern,
-    Protocol,
-    Sequence,
-    Type,
-    TypeAlias,
-    TypeVar,
-    Union,
-)
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Sequence, Type, TypeAlias, TypeVar, Union
 
 try:
     from typing import Self
@@ -27,10 +16,11 @@ except ImportError:  # added in 3.11
     Self = TypeVar('Self')  # type: ignore[misc,assignment]
 
 if TYPE_CHECKING:
+    from enum import Enum
     from pathlib import Path
 
     from .commands import Command
-    from .inputs import InputType, Regex
+    from .inputs import Choices, Range
     from .parameters import Parameter, ParamGroup
     from .parameters.base import ParamBase
 
@@ -49,24 +39,22 @@ CommandObj = TypeVar('CommandObj', bound='Command')
 CommandCls: TypeAlias = Type[CommandObj]
 CommandAny: TypeAlias = CommandCls | CommandObj
 
+AnyParam: TypeAlias = 'Parameter[Any, Any]'
 ParamOrGroup: TypeAlias = Union['Parameter', 'ParamGroup', 'ParamBase']
 
 
 if sys.version_info >= (3, 13):
-    T = TypeVar('T', default=str, covariant=True, bound=Any)
-    D = TypeVar('D', default=None, covariant=True, bound=Any)
-    B = TypeVar('B', default=bool, covariant=True, bound=Any)
+    T = TypeVar('T', default=str, bound=Any)
+    D = TypeVar('D', default=None, bound=Any)
+    B = TypeVar('B', default=bool, bound=Any)
 else:
-    T = TypeVar('T', covariant=True, bound=Any)
-    D = TypeVar('D', covariant=True, bound=Any)
-    B = TypeVar('B', covariant=True, bound=Any)
+    T = TypeVar('T', bound=Any)
+    D = TypeVar('D', bound=Any)
+    B = TypeVar('B', bound=Any)
 
+E = TypeVar('E', bound='Enum')
 
-class TypeFunc(Protocol[T]):
-    def __call__(self, value: str, /) -> T:
-        pass
-
-
+TypeFunc: TypeAlias = Callable[[str], T]
 ChoicesType: TypeAlias = Collection[T] | None
-InputTypeFunc: TypeAlias = Union[Type[T], TypeFunc[T], 'InputType[T]', range, Pattern, None]
-NormalizedType: TypeAlias = Union[Type[T], TypeFunc[T], 'InputType[T]', 'Regex[str]', None]
+InputTypeFunc: TypeAlias = Union[TypeFunc[T], None]
+NormalizedType: TypeAlias = Union[TypeFunc[T], 'Choices[T]', 'Range[T]', None]

--- a/lib/cli_command_parser/utils.py
+++ b/lib/cli_command_parser/utils.py
@@ -20,7 +20,7 @@ except ImportError:  # added in 3.11
 try:
     from wcwidth import wcwidth  # type: ignore[import-untyped]
 except ImportError:
-    wcwidth = len
+    wcwidth = len  # type: ignore[assignment]
 
 if TYPE_CHECKING:
     from .typing import Self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ Issues = 'https://github.com/dskrypa/cli_command_parser/issues'
 
 [project.optional-dependencies]
 wcwidth = ['wcwidth']
+dev = ['ruff', 'pytest', 'pytest-cov', 'coverage', 'mypy >= 2.1.0']
 
 [project.scripts]
 'argparse_to_command.py' = 'cli_command_parser.conversion.cli:main'

--- a/readme.rst
+++ b/readme.rst
@@ -28,7 +28,7 @@ CLIs while remaining readable and easy to maintain.
 
 Some of the primary goals and key features of this project:
   - Minimal boilerplate code is necessary to define CLI parameters and access their parsed values
-  - Easy to use type annotations for CLI parameters
+  - Typing support for CLI parameters that can be validated via type checkers
   - Subcommands can inherit common parameters so they don't need to be repeated
   - Easy to handle common initialization tasks for all actions / subcommands once
 

--- a/readme.rst
+++ b/readme.rst
@@ -40,9 +40,11 @@ Example Program
 
     from cli_command_parser import Command, Option, main
 
-    class Hello(Command, description='Simple greeting example'):
+    class Hello(Command):
+        """Simple greeting example"""
+
         name = Option('-n', default='World', help='The person to say hello to')
-        count: int = Option('-c', default=1, help='Number of times to repeat the message')
+        count = Option('-c', type=int, default=1, help='Number of times to repeat the message')
 
         def main(self):
             for _ in range(self.count):

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,16 +1,12 @@
--e .[wcwidth]
+-e .[wcwidth,dev]
 -r docs/requirements.txt
 pre-commit
-ruff
 
 # QoL
 ipython>=9.6.0
 rich
 
 # Testing
-coverage
-pytest
-pytest-cov
 # Note: testtools is only used for faster local testing when using unittest (with or without coverage); it isn't used
 # when running tests via pytest or in CI test jobs.
 testtools

--- a/tests/test_documentation/test_help_text.py
+++ b/tests/test_documentation/test_help_text.py
@@ -150,6 +150,9 @@ class UsageTextTest(ParserTest):
             def __name__(self):
                 raise AttributeError
 
+            def __call__(self, *args, **kwargs):
+                pass
+
         class Foo(Command, use_type_metavar=True):
             bar = Option(type=NoName())  # noqa
             baz = Option(type=int)

--- a/tests/test_inputs/test_numeric_inputs.py
+++ b/tests/test_inputs/test_numeric_inputs.py
@@ -11,11 +11,12 @@ from cli_command_parser.testing import ParserTest
 class NumericInputTest(ParserTest):
     def test_range_replaced(self):
         class Foo(Command):
-            bar: int = Option(type=range(10))
-            baz: int = Option(choices=range(10))
+            bar = Option(type=range(10))
+            baz = Option(choices=range(10))
 
-        self.assertIsInstance(Foo.bar.type, Range)  # noqa
-        self.assertIsInstance(Foo.baz.type, Range)  # noqa
+        self.assertIsInstance(Foo.bar.type, Range)
+        self.assertIsInstance(Foo.baz.type, Range)
+        self.assert_parse_results(Foo, ['--bar=1', '--baz', '2'], {'bar': 1, 'baz': 2})
 
     def test_range_with_choices_rejected(self):
         with self.assertRaisesRegex(ParameterDefinitionError, 'Cannot combine type=.* with choices='):

--- a/tests/test_parsing/test_parse_positionals.py
+++ b/tests/test_parsing/test_parse_positionals.py
@@ -167,6 +167,38 @@ class NargsParsingTest(ParserTest):
         self.assert_parse_results_cases(Foo, success_cases)
         self.assert_parse_fails_cases(Foo, fail_cases, UsageError)
 
+    def test_positional_nargs_question_default(self):
+        class Foo(Command):
+            foo = Positional(nargs='?', default='bar')
+
+        cases = [([], {'foo': 'bar'}), (['baz'], {'foo': 'baz'})]
+        self.assert_parse_results_cases(Foo, cases)
+
+    def test_positional_nargs_question_no_default(self):
+        class Foo(Command):
+            foo = Positional(nargs='?')
+
+        cases = [([], {'foo': None}), (['baz'], {'foo': 'baz'})]
+        self.assert_parse_results_cases(Foo, cases)
+
+    def test_positional_nargs_star_default(self):
+        class Foo(Command):
+            foo = Positional(nargs='*', default='bar')
+
+        cases = [
+            ([], {'foo': ['bar']}),
+            # (['baz'], {'foo': ['baz']}),  # TODO: This is what it probably *should* be
+            (['baz'], {'foo': ['bar', 'baz']}),
+        ]
+        self.assert_parse_results_cases(Foo, cases)
+
+    def test_positional_nargs_star_no_default(self):
+        class Foo(Command):
+            foo = Positional(nargs='*')
+
+        cases = [([], {'foo': []}), (['baz'], {'foo': ['baz']}), (['bar', 'baz'], {'foo': ['bar', 'baz']})]
+        self.assert_parse_results_cases(Foo, cases)
+
 
 class NargsParsingBacktrackTest(ParserTest):
     """

--- a/tests/test_typing/modules/inputs.py
+++ b/tests/test_typing/modules/inputs.py
@@ -1,0 +1,142 @@
+from enum import Enum
+from typing import reveal_type
+
+from cli_command_parser import Command, Flag, Option, ParamGroup, Positional, TriFlag
+from cli_command_parser.inputs import ChoiceMap, Choices, File, Glob, Json, Path, Pickle, Regex, RegexMode
+from cli_command_parser.inputs.numeric import Bytes, NumRange, Range
+from cli_command_parser.inputs.time import Date, DateTime, Day, DTFormatMode, Month, Time, TimeDelta
+
+
+class ExampleEnum(Enum):
+    FOO = 'foo'
+    BAR = 'bar'
+    BAZ = 'baz'
+
+
+class InputsExample(Command):
+    positional = Positional()
+    positional_int = Positional(type=int)
+    optional_positional = Positional(nargs='?')
+    required = Option(required=True)
+    required_int = Option(required=True, type=int)
+
+    with ParamGroup('Files / Serialization'):
+        path = Option(type=Path(exists=True, type='file'))
+        in_file = Option(type=File(allow_dash=True, lazy=False))
+        out_file = Option(type=File(allow_dash=True, mode='w'))
+        json = Option(type=Json(allow_dash=True))
+        eager_json = Option(type=Json(allow_dash=True, lazy=False))
+        pickle_lazy = Option(type=Pickle())
+        pickle_eager = Option(type=Pickle(lazy=False))
+
+    with ParamGroup('Numeric'):
+        enum = Option(type=ExampleEnum)
+        integer = Option(type=int)
+        integers = Option(nargs='+', type=int)
+        ints_with_choices = Option(nargs='+', type=int, choices=(1, 2, 3))
+        bytes = Option(type=Bytes())
+        bytes_float = Option(type=Bytes(fractions=True))
+
+    with ParamGroup('Ranges'):
+        range_input = Option(type=Range(50))
+        float_range = Option(type=Range(10, type=float))
+        float_num_range = Option(type=NumRange(float, min=0, max=1))
+        implied_float_num_range = Option(type=NumRange(min=0.0))
+        range_choices = Option(choices=range(20))
+        # The next one doesn't work, but it probably never should have been implemented to work
+        # range_type = Option(type=range(1, 30, 2))
+
+    with ParamGroup('Date / Time'):
+        day_str = Option(type=Day())
+        day_abbr = Option(type=Day(out_format='abbreviation'))
+        day_int = Option(type=Day(out_format=DTFormatMode.NUMERIC))
+        month_str = Option(type=Month())
+        month_int = Option(type=Month(out_format='numeric'))
+        time_delta = Option(type=TimeDelta('seconds'))
+        date_time = Option(type=DateTime())
+        date_time_req = Option(type=DateTime(), required=True)
+        date_times = Option(nargs='+', type=DateTime())
+        date = Option(type=Date())
+        time = Option(type=Time())
+
+    with ParamGroup('Flags'):
+        flag = Flag()
+        flag_str = Flag(default='A', const='B')
+        tri_flag = TriFlag()
+
+    with ParamGroup('Choices'):
+        choices_str = Option(type=Choices(['a', 'b']))
+        choices_int = Option(type=Choices([1, 2], type=int))
+        choice_map_str_str = Option(type=ChoiceMap({'a': 'b'}))
+        choice_map_str_int = Option(type=ChoiceMap({'a': 1}))
+        choice_map_int_str = Option(type=ChoiceMap({1: 'a'}, type=int))
+        choice_map_int_int = Option(type=ChoiceMap({1: 2}, type=int))
+
+    with ParamGroup('Patterns'):
+        glob = Option(type=Glob('*.yml'))
+        regex = Option(type=Regex('foo.*bar'))
+        regex_group = Option(type=Regex('foo.*bar', mode='group'))
+        regex_groups = Option(type=Regex('foo.*bar', mode='groups'))
+        regex_match = Option(type=Regex('foo.*bar', mode=RegexMode.MATCH))
+        regex_dict = Option(type=Regex('foo.*bar', mode=RegexMode.DICT))
+        # The next one doesn't work, but it probably never should have been implemented to work
+        # regex_converted = Option(type=re.compile('foo.*bar'))
+
+    def main(self) -> None:
+        reveal_type(self.positional)  # str
+        reveal_type(self.positional_int)  # int
+        reveal_type(self.required)  # str
+        reveal_type(self.required_int)  # int
+
+        reveal_type(self.path)  # pathlib.Path | None
+        reveal_type(self.in_file)  # str | None
+        reveal_type(self.out_file)  # cli_command_parser.inputs.utils.FileWrapper[str] | None
+        reveal_type(self.json)  # cli_command_parser.inputs.utils.SerializedFileWrapper[str] | None
+        reveal_type(self.eager_json)  # Any | None
+        reveal_type(self.pickle_lazy)  # cli_command_parser.inputs.utils.SerializedFileWrapper[bytes] | None
+        reveal_type(self.pickle_eager)  # Any | None
+
+        reveal_type(self.enum)  # tests.test_typing.modules.inputs.ExampleEnum | None
+        reveal_type(self.integer)  # int | None
+        reveal_type(self.integers)  # list[int]
+        reveal_type(self.ints_with_choices)  # list[int]
+        reveal_type(self.bytes)  # int | None
+        reveal_type(self.bytes_float)  # float | None
+
+        reveal_type(self.range_input)  # int | None
+        reveal_type(self.float_range)  # float | None
+        reveal_type(self.float_num_range)  # float | None
+        reveal_type(self.implied_float_num_range)  # float | None
+        reveal_type(self.range_choices)  # int | None
+        # reveal_type(self.range_type)  # int | None
+
+        reveal_type(self.day_str)  # str | None
+        reveal_type(self.day_abbr)  # str | None
+        reveal_type(self.day_int)  # int | None
+        reveal_type(self.month_str)  # str | None
+        reveal_type(self.month_int)  # int | None
+        reveal_type(self.time_delta)  # datetime.timedelta | None
+        reveal_type(self.date_time)  # datetime.datetime | None
+        reveal_type(self.date_time_req)  # datetime.datetime
+        reveal_type(self.date_times)  # list[datetime.datetime]
+        reveal_type(self.date)  # datetime.date | None
+        reveal_type(self.time)  # datetime.time | None
+
+        reveal_type(self.flag)  # bool
+        reveal_type(self.flag_str)  # str
+        reveal_type(self.tri_flag)  # bool | None
+
+        reveal_type(self.choices_str)  # str | None
+        reveal_type(self.choices_int)  # int | None
+        reveal_type(self.choice_map_str_str)  # str | None
+        reveal_type(self.choice_map_str_int)  # int | None
+        reveal_type(self.choice_map_int_str)  # str | None
+        reveal_type(self.choice_map_int_int)  # int | None
+
+        reveal_type(self.glob)  # str | None
+        reveal_type(self.regex)  # str | None
+        reveal_type(self.regex_group)  # str | None
+        reveal_type(self.regex_groups)  # tuple[str, ...] | None
+        reveal_type(self.regex_match)  # re.Match[str] | None
+        reveal_type(self.regex_dict)  # dict[str, str] | None
+        # reveal_type(self.regex_converted)  # str | None

--- a/tests/test_typing/test_inputs_typing.py
+++ b/tests/test_typing/test_inputs_typing.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python
+
+from __future__ import annotations
+
+import re
+import sys
+from dataclasses import dataclass
+from io import StringIO
+from pathlib import Path
+from typing import Iterator
+from unittest import TestCase, main, skipIf
+
+from mypy.build import build
+from mypy.fscache import FileSystemCache
+from mypy.main import process_options
+
+TEST_MODULES_DIR = Path(__file__).resolve().parent.joinpath('modules')
+
+
+class TestInputsTyping(TestCase):
+    def assert_revealed_types_are_correct(self, name: str):
+        for result in RevealedTypeChecker(name):
+            with self.subTest(line=result.line):
+                if reason := result.failure_reason():
+                    self.fail(reason)
+
+    @skipIf(sys.version_info < (3, 13), 'Most of these pass on 3.12, but not ')
+    def test_inputs(self):
+        self.assert_revealed_types_are_correct('inputs.py')
+
+    def test_all_input_types_covered(self):
+        # fmt: off
+        all_input_types = {
+            # Directly tested types
+            'ChoiceMap', 'Choices', 'File', 'Json', 'Path', 'Pickle', 'Bytes', 'NumRange', 'Range',
+            'Glob', 'Regex', 'Date', 'DateTime', 'Day', 'Month', 'Time', 'TimeDelta',
+            # Indirectly tested types
+            'ExampleEnum',  # => EnumChoices
+        }
+        # fmt: on
+        type_search = re.compile(r'\btype=([a-zA-Z][^\s(]+)[()]').search
+        tested = set()
+        for line in TEST_MODULES_DIR.joinpath('inputs.py').read_text('utf-8').splitlines():
+            if m := type_search(line):
+                tested.add(m.group(1))
+
+        covered = all_input_types.intersection(tested)
+        if missing := all_input_types - tested:
+            total = len(all_input_types)
+            self.fail(
+                f'Input type coverage: {len(covered)}/{total} ({len(covered) / total:.2%})'
+                f' - missing: {", ".join(sorted(missing))}'
+            )
+
+
+class RevealedTypeChecker:
+    __slots__ = ('mod_path', 'rel_path')
+
+    revealed_type_pat = re.compile(r'^(.+?):(\d+): note: Revealed type is "(.+)"$')
+    code_pat = re.compile(r'^\s*reveal_type\(\s*(\S+)\s*\)\s{2}# (.+)$')
+
+    def __init__(self, name: str):
+        self.mod_path = TEST_MODULES_DIR.joinpath(name)
+        try:
+            self.rel_path = self.mod_path.relative_to(Path.cwd()).as_posix()
+        except ValueError:
+            self.rel_path = self.mod_path.as_posix()
+
+    def iter_type_check_results(self) -> Iterator[TypeCheckResult]:
+        revealed_types = self._get_revealed_types()
+        expected_types = self._get_expected_types()
+        all_line_nums = sorted(set(revealed_types) | set(expected_types))
+        for line_num in all_line_nums:
+            try:
+                name, expected = expected_types[line_num]
+            except (KeyError, TypeError):
+                name = expected = None
+
+            yield TypeCheckResult(self.rel_path, line_num, name, expected, revealed_types.get(line_num))
+
+    __iter__ = iter_type_check_results
+
+    def _get_mypy_messages(self) -> list[str]:
+        messages = []
+
+        def flush_errors(filename: str | None, new_messages: list[str], _serious: bool):
+            if new_messages and filename == self.rel_path:
+                messages.extend(new_messages)
+
+        stdout, stderr = StringIO(), StringIO()
+        fscache = FileSystemCache()
+        sources, options = process_options([self.mod_path.as_posix()], stdout=stdout, stderr=stderr, fscache=fscache)
+        # Replaces: res, messages, blockers = run_build(sources, options, fscache, time.time(), stdout, stderr)
+        build(sources, options, None, flush_errors, fscache, stdout, stderr)
+        return messages
+
+    def _get_revealed_types(self) -> dict[int, str]:
+        line_revealed_type_map = {}
+        for line in self._get_mypy_messages():
+            if m := self.revealed_type_pat.match(line):
+                rel_path, line_num, revealed_type = m.groups()
+                line_revealed_type_map[int(line_num)] = revealed_type
+
+        return line_revealed_type_map
+
+    def _get_expected_types(self) -> dict[int, tuple[str, str]]:
+        line_expected_type_map = {}
+        lines = self.mod_path.read_text('utf-8').splitlines()
+        for n, line in enumerate(lines, 1):
+            if m := self.code_pat.match(line):
+                line_expected_type_map[n] = m.group(1), m.group(2)
+
+        return line_expected_type_map
+
+
+@dataclass(slots=True)
+class TypeCheckResult:
+    source: str
+    line: int
+    name: str | None
+    expected: str | None
+    revealed: str | None
+
+    def _item(self) -> str:
+        return f'{self.name!r} @ {self.source}:{self.line}'
+
+    def failure_reason(self) -> str | None:
+        """If the type check passed, then None is returned, otherwise, a string describing why it failed is returned."""
+        if self.expected is None:
+            return f'Unexpected revealed type found at {self.source}:{self.line}'
+        elif self.revealed is None:
+            return f'No type was found for {self._item()}'
+        elif self.expected != self.revealed:
+            return f'Type mismatch for {self._item()}: expected={self.expected!r}, revealed={self.revealed!r}'
+
+        return None
+
+
+if __name__ == '__main__':
+    try:
+        main(verbosity=2, exit=False)
+    except KeyboardInterrupt:
+        print()


### PR DESCRIPTION
This PR includes the final batch of typing related fixes for #151 to be fully compliant with mypy.

The use of type inference from invalid type annotations is now soft deprecated, and a future change will more actively warn or disable it by default, before finally removing it at some point even later.